### PR TITLE
fix(ci): fix permission issue in auto-merge and ignore coverage in lint

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,6 +3,10 @@ on:
     workflows: ["Deploy (with Tests)"]
     types: [completed]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   merge:
     if: github.event.workflow_run.conclusion == 'success'
@@ -10,7 +14,7 @@ jobs:
     steps:
       - uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.BOT_TOKEN }}
+          github-token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const prs = context.payload.workflow_run.pull_requests
             if (!prs.length) return

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'coverage']),
   {
     files: ['**/*.{js,jsx}'],
     extends: [


### PR DESCRIPTION
Design:
- Chosen: Added permissions block to auto-merge.yml and used GITHUB_TOKEN as fallback for BOT_TOKEN. Added coverage to eslint ignores.
- Rejected: N/A
- Reason: workflow_run requires explicit permissions to merge. Lint was failing on coverage files.

Impact:
- Affected modules: .github/workflows/auto-merge.yml, frontend/eslint.config.js
- Behavior change: Auto-merge job will now have sufficient permissions.

Test:
- Added: N/A
- Not added: N/A