### PR TITLE
chore(clinerules): コミットメッセージのBody構造を日本語に翻訳

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -32,7 +32,6 @@
 
 例: feat/add-user-auth, fix/resolve-memory-leak
 
-【3. 実装ルール】
 コミットは必ず切り出したブランチに対して行い、直接 main にコミットしてはならない。
 リモートへのプッシュが完了した後は、必ず main ブランチにチェックアウトして戻ること。
 
@@ -81,27 +80,27 @@
 ## subject
 - Conventional Commits 形式を厳守する
 - 内容は日本語で記述する
-  例: feat(auth): refresh token automatically
+  例: feat(auth): 認証機能の追加
 
 ## body
 - 以下の構造を必ず含め、省略してはならない
 - 該当しない場合は "N/A" と記載する
 - 言語は日本語で記述する
 
-Design:
-- Chosen:
-- Rejected:
-- Reason:
+設計:
+- 選定内容:
+- 却下内容:
+- 理由:
 
-Impact:
-- Affected modules:
-- Behavior change:
+影響:
+- 影響モジュール:
+- 振る舞いの変更:
 
-Test:
-- Added:
-- Not added:
+テスト:
+- 追加済み:
+- 未追加:
 
-レビューで得られた知見は必ず Design または Impact に反映せよ。
+レビューで得られた知見は必ず 設計 または 影響 に反映せよ。
 
 ================================
 【7. 完了条件（ゲート）】


### PR DESCRIPTION
設計:
- 選定内容: コミットメッセージのBodyに含まれる全ての項目（設計/影響/テストとその子項目）を日本語に翻訳。
- 却下内容: 一部のラベルのみを翻訳すること。
- 理由: ユーザーからBody内の例文・構造も日本語にするよう要望があったため。

影響:
- 影響モジュール: .clinerules
- 振る舞いの変更: 今後のコミットメッセージ作成時に、構造全体が日本語で出力される。

テスト:
- 追加済み: N/A
- 未追加: N/A