### PR TITLE
fix: 全札一覧のページタイトル修正とAgentパイプラインの復旧

### DIFF
--- a/.agent/agent.py
+++ b/.agent/agent.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-import google.generativeai as genai
+from google import genai
 from github import Github
 from pathlib import Path
 
@@ -97,10 +97,11 @@ diff --git a/src/file.js b/src/file.js
 # ==============================
 # Gemini
 # ==============================
-genai.configure(api_key=os.environ["GEMINI_API_KEY"])
-model = genai.GenerativeModel("gemini-1.5-flash")
-
-response = model.generate_content(prompt)
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+response = client.models.generate_content(
+    model="gemini-1.5-flash",
+    contents=prompt
+)
 output = response.text.strip()
 
 if "---DIFF_START---" not in output:

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install deps
-        run: pip install google-generativeai pygithub
+        run: pip install google-genai pygithub
 
       - name: Run agent
         env:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -507,6 +507,8 @@ function App() {
       document.title = "指摘一覧 | カルタ読み上げアプリ";
     } else if (view === "changelog") {
       document.title = "更新履歴 | カルタ読み上げアプリ";
+    } else if (view === "all-phrases") {
+      document.title = "全札一覧";
     } else if (detailPhraseId && detailPhrase) {
       document.title = `${detailPhrase.phrase} | ${selectedCategory}`;
     } else if (selectedCategory) {

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -141,4 +141,37 @@ describe('App', () => {
     expect(localStorage.getItem('speechRate')).toBe('100%');
   });
 
+  it('updates document title when viewing all-phrases', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ categories: [] }),
+    });
+    await act(async () => {
+      render(<App />);
+    });
+    
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        return {
+          ok: true,
+          json: async () => ({ categories: [] }),
+        };
+      }
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({ phrases: [] }),
+        };
+      }
+      return { ok: false };
+    });
+
+    const allPhrasesLink = screen.getByText(/全札一覧を見る/i);
+    fireEvent.click(allPhrasesLink);
+
+    await waitFor(() => {
+      expect(document.title).toBe('全札一覧');
+    });
+  });
+
 });


### PR DESCRIPTION
設計:
- 選定内容: frontend/src/App.jsx において、view が "all-phrases" の場合に document.title を "全札一覧" に更新するように変更。また、.agent/agent.py で使用している Gemini SDK を非推奨の google-generativeai から最新の google-genai に移行し、.github/workflows/agent.yml の依存関係も更新。
- 却下内容: google-generativeai のままでモデル名のみを変更する対応。
- 理由: SDK自体が非推奨となっており、今後の安定性のために最新の SDK へ移行することが適切と判断したため。

影響:
- 影響モジュール: frontend (App.jsx), .agent (agent.py), .github/workflows (agent.yml)
- 振る舞いの変更: 「全札一覧」画面表示時にブラウザのタブ名が「全札一覧」と表示されるようになる。GitHub Issue に対する Agent パイプラインが正常に動作するようになる。

テスト:
- 追加済み: frontend/src/App.test.jsx にページタイトルの遷移を確認するテストケースを追加。
- 未追加: Agent パイプライン自体の自動テスト（CI上での動作確認が必要なため）。