### PR TITLE
fix(ci): use github.ref for reliable branch detection in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,7 @@ jobs:
 
   release:
     needs: [frontend-test, backend-test]
-    if: github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release')
     name: Release
     runs-on: ubuntu-latest
     steps:
@@ -107,7 +107,7 @@ jobs:
         run: npx semantic-release
 
   build-and-deploy-frontend:
-    if: github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release')
     needs: release
     runs-on: ubuntu-latest
     environment:
@@ -145,7 +145,7 @@ jobs:
           echo "Pages URL: ${{ steps.deployment.outputs.page_url }}"
 
   deploy-backend:
-    if: github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release')
     needs: release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
設計:
- 選定内容: deploy.yml の if 条件を github.ref_name から github.ref (refs/heads/...) に戻した。
- 却下内容: github.ref_name のまま修正すること。
- 理由: github.ref_name が環境によって期待通りに動作しない（あるいはスキップの原因となっている）可能性があるため、より標準的で明示的な github.ref を使用して判定の信頼性を高めた。

影響:
- 影響モジュール: CI/CD パイプライン
- 振る舞いの変更: main または release ブランチへのプッシュ時に Release/Deploy ジョブが正しく実行されるようになる。

テスト:
- 追加済み: N/A (CI設定変更)
- 未追加: N/A