### PR TITLE
fix(ci): リリースジョブの失敗を修正し、リリースフローをreleaseブランチに限定

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,6 @@ run-name: CD ${{ github.event.head_commit.message }}
 on:
   push:
     branches:
-      - main
       - release
 
 permissions:
@@ -50,10 +49,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: main
           fetch-depth: 0
       - name: Pull latest changes
-        run: git pull origin main
+        run: git pull origin ${{ github.ref_name }}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -84,10 +82,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: main
           fetch-depth: 0
       - name: Pull latest changes
-        run: git pull origin main
+        run: git pull origin ${{ github.ref_name }}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -1,6 +1,5 @@
 module.exports = {
-  branches: ["main", "release"],
-  repositoryUrl: "https://github.com/bamiyanapp/karuta",
+  branches: ["release"],
   plugins: [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,12 @@
         "@commitlint/cli": "^20.3.0",
         "@commitlint/config-conventional": "^20.3.0",
         "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/commit-analyzer": "^13.0.0",
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
+        "@semantic-release/github": "^11.0.1",
+        "@semantic-release/npm": "^12.0.1",
+        "@semantic-release/release-notes-generator": "^14.0.1",
         "semantic-release": "^24.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -9,8 +9,12 @@
     "@commitlint/cli": "^20.3.0",
     "@commitlint/config-conventional": "^20.3.0",
     "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/commit-analyzer": "^13.0.0",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
+    "@semantic-release/github": "^11.0.1",
+    "@semantic-release/npm": "^12.0.1",
+    "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^24.2.0"
   },
   "version": "1.12.1"


### PR DESCRIPTION
設計:
- 選定内容:
  - CDトリガーを release ブランチのみに限定し、main ブランチでの権限エラーを回避。
  - cd.yml 内のハードコードされた main を ${{ github.ref_name }} に変更。
  - .releaserc.cjs から冗長な repositoryUrl を削除し、プラグインを package.json に明示的に追加。
- 却下内容: main ブランチでのリリース継続（保護されたブランチへのプッシュ権限問題が解決困難なため）。
- 理由: ユーザーが release ブランチへのプッシュを意図しており、かつ main ブランチの保護による EGITNOPERMISSION を根本的に解決するため。

影響:
- 影響モジュール: CI/CD パイプライン
- 振る舞いの変更: リリースおよびデプロイは release ブランチへのプッシュ時にのみ実行されるようになる。

テスト:
- 追加済み: N/A (CI設定変更)
- 未追加: N/A