### PR TITLE
fix(ci): リリース対象をreleaseブランチに限定し権限エラーを回避

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
           token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
       - name: Setup Node.js
@@ -57,9 +58,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
           fetch-depth: 0
       - name: Pull latest changes
-        run: git pull origin ${{ github.ref_name }}
+        run: git pull origin ${{ github.event.workflow_run.head_branch || github.ref_name }}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -90,9 +92,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
           fetch-depth: 0
       - name: Pull latest changes
-        run: git pull origin ${{ github.ref_name }}
+        run: git pull origin ${{ github.event.workflow_run.head_branch || github.ref_name }}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-  branches: ["main", "release"],
+  branches: ["release"],
   repositoryUrl: "https://github.com/bamiyanapp/karuta.git",
   plugins: [
     "@semantic-release/commit-analyzer",
@@ -21,7 +21,7 @@ module.exports = {
       "@semantic-release/github",
       {
         "successComment": false,
-        "failComment": false,
+        "failCommentCondition": false,
         "releasedLabels": false
       }
     ],


### PR DESCRIPTION
設計:
- 選定内容:
  - .releaserc.cjs の branches を release のみに変更し、main での権限エラーを回避。
  - cd.yml の各ステップで head_branch を考慮するように修正（workflow_run トリガー対応）。
  - @semantic-release/github の非推奨警告（failComment -> failCommentCondition）を修正。
- 却下内容: なし。
- 理由: main ブランチが保護されているため、release ブランチをリリースのトリガーとする運用にシフトするため。

影響:
- 影響モジュール: CI/CD パイプライン
- 振る舞いの変更: main へのマージではリリースは走らず、release ブランチへの更新（マージ等）時にリリースが実行されるようになる。

テスト:
- 追加済み: N/A
- 未追加: N/A