### PR TITLE
fix(ci): リリースジョブのスキップを解消

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,9 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' ||
-      (github.event_name == 'workflow_run' && 
-       github.event.workflow_run.conclusion == 'success' && 
-       (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.head_branch == 'release'))
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
設計:
- 選定内容: cd.yml の if 条件から head_branch の判定を削除し、success であることのみを条件とするように簡略化。
- 却下内容: head_branch の複雑な判定ロジックの追加（予期せぬスキップの原因となるため）。
- 理由: ブランチの判定は semantic-release 側でも行われるため、ワークフローレベルでの過剰なガードを外して起動の確実性を高めるため。

影響:
- 影響モジュール: CI/CD パイプライン
- 振る舞いの変更: main/release ブランチでの CI 完了時に、スキップされることなくリリースジョブが実行されるようになる。

テスト:
- 追加済み: N/A
- 未追加: N/A