### PR TITLE
fix(ci): CDワークフローの重複実行と不適切なタイミングでの実行を解消

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,10 +2,6 @@ name: CD
 run-name: CD ${{ github.event.head_commit.message }}
 
 on:
-  push:
-    branches:
-      - main
-      - release
   workflow_run:
     workflows: ["CI"]
     types:
@@ -23,8 +19,8 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.head_branch == 'release')
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
設計:
- 選定内容: 1. on.push トリガーを削除し、workflow_run (CI完了) のみに統合。2. head_branch の判定を追加し、main または release ブランチのCIが成功した時のみ実行されるように制限。
- 却下内容: なし。
- 理由: マージ前のPR作成時などに不適切にCD（Release/Deploy）が起動するのを防ぎ、またマージ後の重複実行を解消するため。

影響:
- 影響モジュール: CI/CD パイプライン
- 振る舞いの変更: PR作成時に不必要なデプロイジョブが起動しなくなり、マージ後のデプロイも1回に集約される。

テスト:
- 追加済み: N/A
- 未追加: N/A