### PR TITLE
docs(readme): 技術スタックをREADMEに追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 ## 目的
 かるたの読み上げをアプリで行うことで、全員がかるたに参加すること。
 
+## Tech Stack
+
+| カテゴリ | 技術 |
+| :--- | :--- |
+| **Frontend** | React (v19), Vite, React Markdown, ESLint |
+| **Backend** | AWS Lambda, Node.js, Serverless Framework, Amazon SDK v3 |
+| **Database** | DynamoDB |
+| **Speech Synthesis** | Amazon Polly |
+| **Infrastructure** | GitHub Pages (Frontend Hosting), AWS (Backend) |
+| **CI/CD** | GitHub Actions, Semantic Release, Commitlint |
+| **Testing** | Vitest, React Testing Library, jsdom |
+
 ## Features
 
 - **フレーズ読み上げ**:


### PR DESCRIPTION
設計:
- 選定内容: README.md に技術スタックの表を追加
- 理由: プロジェクトで使用されている主要な技術を一目で把握できるようにするため

影響:
- 影響モジュール: README.md
- 振る舞いの変更: README.md に技術スタックのセクションが追加された

テスト:
- 追加済み: N/A (ドキュメント更新のため)
- 未追加: N/A