### PR TITLE
feat(backup): DynamoDB PITRの有効化と運用仕様の追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ Amazon Polly で生成した音声データのキャッシュ。
 
 詳細な CI/CD パイプラインの仕様については、[CI/CD Pipeline Specification](docs/cicd-pipeline-specification.md) を参照してください。
 
+## 運用
+
+### バックアップと復旧
+
+本システムでは、データの保護と可用性向上のため、以下のバックアップ体制をとっています。
+
+- **DynamoDB Point-in-Time Recovery (PITR)**:
+  - すべてのテーブル（`karuta-phrases`, `karuta-comments`, `karuta-polly-cache`）において PITR を有効化しています。
+  - 過去 35 日間の任意の時点にデータを復旧することが可能です。
+  - 意図しないデータ削除や更新ミスが発生した際の保険として機能します。
+
 ## かるた情報の追加・更新
 
 かるたの情報（フレーズや難易度など）は、以下の手順で追加・更新できます。

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -100,6 +100,8 @@ resources:
           - AttributeName: id
             KeyType: RANGE
         BillingMode: PAY_PER_REQUEST
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
     CommentsTable:
       Type: AWS::DynamoDB::Table
       Properties:
@@ -111,6 +113,8 @@ resources:
           - AttributeName: id
             KeyType: HASH
         BillingMode: PAY_PER_REQUEST
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
     PollyCacheTable: # 追加
       Type: AWS::DynamoDB::Table
       Properties:
@@ -122,3 +126,5 @@ resources:
           - AttributeName: id
             KeyType: HASH
         BillingMode: PAY_PER_REQUEST
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true


### PR DESCRIPTION
設計:
- 選定内容: DynamoDBの PointInTimeRecoverySpecification を有効化。
- 却下内容: オンデマンドバックアップの手動設定（PITRの方が継続的かつ容易なため）。
- 理由: 過去35日間の任意の時点への復旧が可能になり、データ保護レベルが向上するため。

影響:
- 影響モジュール: backend (DynamoDBリソース定義), README.md
- 振る舞いの変更: データベース側で継続的なバックアップが実行されるようになる。

テスト:
- 追加済み: N/A (インフラ設定のため、既存のユニットテストでデグレがないことを確認済み)
- 未追加: N/A