### PR TITLE
fix(ci): CDパイプラインが実行されない問題を修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,5 @@
 name: CD
-run-name: CD ${{ github.event.head_commit.message }}
+run-name: CD ${{ github.event.workflow_run.head_commit.message }}
 
 on:
   workflow_run:
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
       - name: Setup Node.js
@@ -53,9 +54,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
-      - name: Pull latest changes
-        run: git pull origin ${{ github.ref_name }}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -86,9 +86,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
-      - name: Pull latest changes
-        run: git pull origin ${{ github.ref_name }}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const prNumber = context.payload.pull_request.number;
             const branchName = context.payload.pull_request.head.ref;


### PR DESCRIPTION
設計:
- 選定内容:
  1. CIワークフローの自動マージジョブで BOT_TOKEN (PAT) を使用するように変更。これにより、マージ後の push イベントが新たなCI実行をトリガーするようになる。
  2. CDワークフローのトリガー条件およびチェックアウト処理を修正。head_sha を明示的に指定することで、正しいコミットをデプロイするように改善。
- 却下内容: CDワークフローを on: push に戻す案。
- 理由: ユーザーが以前の変更で workflow_run に統合しようとした意図（CI成功を待ってからCDを実行する）を尊重しつつ、トリガーが欠落していた問題を解決するため。

影響:
- 影響モジュール: CI/CD パイプライン (.github/workflows/ci.yml, .github/workflows/cd.yml)
- 振る舞いの変更: PRのマージ後に正しくCIが走り、その完了を待ってCDが実行されるようになる。

テスト:
- 追加済み: N/A (ワークフロー定義の修正)
- 未追加: N/A