### PR TITLE
fix(ci): CDパイプラインの実行条件とチェックアウト処理を改善

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,5 @@
 name: CD
-run-name: CD ${{ github.event.head_commit.message }}
+run-name: CD ${{ github.event.workflow_run.head_commit.message }}
 
 on:
   workflow_run:
@@ -20,11 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.workflow_run.conclusion == 'success' &&
-      (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.head_branch == 'release')
+      (github.event.workflow_run.head_branch == 'main' || 
+       github.event.workflow_run.head_branch == 'release' || 
+       github.event.workflow_run.event == 'pull_request')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0].base.ref || github.event.workflow_run.head_branch }}
           token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
       - name: Setup Node.js
@@ -53,9 +56,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0].base.ref || github.event.workflow_run.head_branch }}
           fetch-depth: 0
-      - name: Pull latest changes
-        run: git pull origin ${{ github.ref_name }}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -86,9 +88,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0].base.ref || github.event.workflow_run.head_branch }}
           fetch-depth: 0
-      - name: Pull latest changes
-        run: git pull origin ${{ github.ref_name }}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
設計:
- 選定内容:
  1. CDワークフローの `if` 条件に `github.event.workflow_run.event == 'pull_request'` を追加。これにより、PAT (Personal Access Token) によるマージ後の push イベントがなくても、PRのCI完了をトリガーにCDが起動するようにした。
  2. チェックアウト時の `ref` を動的に切り替えるように変更。PRの場合はマージ先ブラインチ (base.ref) を、それ以外の場合は実行ブランチ (head_branch) を指定。
- 却下内容: 権限不足によりエラーとなった `BOT_TOKEN` を使用したマージ案。
- 理由: 既存の `GITHUB_TOKEN` によるマージを維持しつつ、トリガーの問題をワークフロー側の条件緩和で解決するため。

影響:
- 影響モジュール: CD パイプライン (.github/workflows/cd.yml)
- 振る舞いの変更: PRのマージ完了（CIワークフローの成功）をトリガーに、正しくデプロイが実行されるようになる。

テスト:
- 追加済み: N/A (ワークフロー定義の修正)
- 未追加: N/A