### PR TITLE
fix(release): セマンティックリリースブランチ参照を修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,14 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.workflow_run.conclusion == 'success' &&
-      (github.event.workflow_run.head_branch == 'main' || 
-       github.event.workflow_run.head_branch == 'release' || 
-       github.event.workflow_run.event == 'pull_request')
+      github.event.workflow_run.head_branch == 'release'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.event == 'pull_request' && (github.event.workflow_run.pull_requests[0] && github.event.workflow_run.pull_requests[0].base.ref || 'main') || github.event.workflow_run.head_branch }}
+          ref: release # Always checkout the release branch for semantic release
           token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
       - name: Setup Node.js
@@ -56,7 +54,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.event == 'pull_request' && (github.event.workflow_run.pull_requests[0] && github.event.workflow_run.pull_requests[0].base.ref || 'main') || github.event.workflow_run.head_branch }}
+          ref: release # Checkout the release branch for deployment
           fetch-depth: 0
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -88,7 +86,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.event == 'pull_request' && (github.event.workflow_run.pull_requests[0] && github.event.workflow_run.pull_requests[0].base.ref || 'main') || github.event.workflow_run.head_branch }}
+          ref: release # Checkout the release branch for deployment
           fetch-depth: 0
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
設計:
- 選定内容: GitHub Actionsのcd.ymlにおいて、semantic-releaseジョブがreleaseブランチの完全な履歴を正しく参照できるように、checkoutステップのrefを'release'に固定し、if条件もreleaseブランチでの成功時に限定した。
- 却下内容: 既存の複雑なref条件式を維持すること。
- 理由: 既存のref条件式では、pull_requestイベントやhead_branchがfeatureブランチの場合にreleaseブランチの正確な履歴を参照できない可能性があり、semantic-releaseが正しく機能しないため。

影響:
- 影響モジュール: .github/workflows/cd.yml
- 振る舞いの変更: CDパイプラインのreleaseジョブが、releaseブランチへのマージ時のみ実行され、その際にreleaseブランチの最新の履歴を正しくチェックアウトするようになる。これによりCHANGELOG.mdが期待通りに更新される見込み。

テスト:
- 追加済み: N/A (ワークフローファイルの変更のため)
- 未追加: N/A