### PR TITLE
feat: IT技術かるた7テーマを追加(HTTP/Linux/Git/SQL/AWS/Java/コードレビュー)

### DIFF
--- a/backend/phrases.csv
+++ b/backend/phrases.csv
@@ -1,374 +1,575 @@
-id,category,level,kana,phrase,phrase_en
-1,テスト用,5,あ,アメンボ赤いな　あいうえお,"A red water strider — A, I, U, E, O."
-2,テスト用,100,い,犬も歩けば　棒に当たる,"If you go out, you may run into trouble."
-3,大ピンチずかん,77,え,エスカレーターが　ぎゃくだった,The escalator was going the opposite way.
-4,大ピンチずかん,20,あ,アイスが　とけてきた,The ice cream started melting.
-5,大ピンチずかん,4,へ,へんな　ひやけを　した,Made a strange face.
-6,大ピンチずかん,30,た,たんじょうびケーキが　たおれて　イチゴが　ころがった,The birthday cake fell over and the strawberries rolled away.
-7,大ピンチずかん,23,ご,ごはんつぶを　ふんだ,Stepped on a grain of rice.
-8,大ピンチずかん,21,お,おふろの　ごみが　すくえない,Can't scoop the debris out of the bathtub.
-9,大ピンチずかん,18,ふ,ふたが　ない,There is no lid.
-10,大ピンチずかん,6,て,テープの　はしが　みつからない,Can't find the end of the tape.
-11,大ピンチずかん,28,え,えだまめが　とんだ,The edamame flew away.
-12,大ピンチずかん,24,か,カップめんの　おゆが　たりない,Not enough hot water for the cup noodles.
-13,大ピンチずかん,68,う,うんてんちゅうの　くるまの　なかに　おおきな　クモが　いる,There is a big spider in the car while driving.
-14,大ピンチずかん,35,ゆ,ゆでたまごが　ボロボロ,The boiled egg is falling apart.
-15,大ピンチずかん,5,す,ストローが　とれない,Can't take out the straw.
-16,大ピンチずかん,27,う,「う」の　もじが　はんたいだった,The letter 'u' was backwards.
-17,大ピンチずかん,19,け,おちたけしゴムがみつからない,Can't find the dropped eraser.
-18,大ピンチずかん,17,し,しょうゆをいれすぎた,Poured too much soy sauce.
-19,大ピンチずかん,34,しゃ,シャワーがみつからない,Can't find the shower.
-20,大ピンチずかん,3,こ,こおりがしたにくっついた,The ice stuck to my tongue.
-21,大ピンチずかん,26,た,たんじょうびケーキがたおれそう,The birthday cake is about to fall.
-22,大ピンチずかん,22,じ,じゅうでんができていなかった,It wasn't charged.
-23,大ピンチずかん,14,し,シャボンえきをすった,Accidentally inhaled the bubble solution.
-24,大ピンチずかん,33,け,ケチャップがとんだ,Ketchup splattered.
-25,大ピンチずかん,31,ぽ,ポケットからすながたくさんでてきた,A lot of sand came out of the pocket.
-26,大ピンチずかん,25,せ,せんたくきのうしろにくつしたがおちた,A sock fell behind the washing machine.
-27,大ピンチずかん,90,ふ,フンをふんだ,Stepped on poop.
-28,大ピンチずかん,55,い,いおうとしていたことをわすれた,Forgot what I was about to say.
-29,大ピンチずかん,46,に,にくがきれない,Can't cut the meat.
-30,大ピンチずかん,39,た,たんじょうびケーキのろうそくがきえない,The birthday cake candles won't go out.
-31,大ピンチずかん,52,む,むかしのおにぎりがでてきた,An old rice ball appeared.
-32,大ピンチずかん,54,れ,れいとうこがあかない,The freezer won't open.
-33,大ピンチずかん,48,ふ,ふくのピラピラがきになる,The loose thread on my clothes is bothering me.
-34,大ピンチずかん,43,し,しゅくだいノートと　じゆうちょうをまちがえた,Confused the homework notebook with the sketchbook.
-35,大ピンチずかん,38,ふ,ふたがしまらない,The lid won't close.
-36,大ピンチずかん,32,め,めんつゆがすごくあまった,A lot of noodle dipping sauce was left over.
-37,大ピンチずかん,53,な,ながしのみずがスプーンではねた,The water in the sink splashed off the spoon.
-38,大ピンチずかん,49,べ,べんざをあけたまますわった,Sat down with the toilet seat up.
-39,大ピンチずかん,37,あ,アメリカンドッグがまわる,The corn dog is spinning.
-40,大ピンチずかん,76,ね,ねむれない,Can't sleep.
-41,大ピンチずかん,47,し,シャンプーがめにはいった,Got shampoo in my eyes.
-42,大ピンチずかん,51,ば,バッグのなかですいとうがもれた,The water bottle leaked inside the bag.
-43,大ピンチずかん,56,な,なまえがおもいだせない,Can't remember the name.
-44,大ピンチずかん,64,き,きんじょのおばさんが　ずっとなまえをまちがえている,The neighborhood lady has been getting my name wrong for a long time.
-45,大ピンチずかん,50,お,おゆがない,There is no hot water.
-46,大ピンチずかん,45,ど,ドアをあけられてさむい,Someone opened the door and it's cold.
-47,大ピンチずかん,40,せ,せんせいのメガネがとんだ,The teacher's glasses flew off.
-48,大ピンチずかん,36,ほ,ほねをとっていたら　ぐちゃぐちゃになった,It became a mess while I was trying to remove the bones.
-49,大ピンチずかん,29,ぎ,ぎゅうにゅうがこぼれた,The milk spilled.
-50,大ピンチずかん,96,か,かさがうらがえった,The umbrella turned inside out.
-51,大ピンチずかん,97,じ,じてんしゃがドミノだおし,The bicycles fell over like dominoes.
-52,大ピンチずかん,98,お,おもったよりみじかくなった,It became shorter than I thought.
-53,大ピンチずかん,99,ね,ネコがついてくる,A cat is following me.
-54,大ピンチずかん,100,ど,どしゃぶりなのにかさがない,It's pouring rain but I don't have an umbrella.
-55,大ピンチずかん,58,れ,れいとうこがしまらない,The freezer won't close.
-56,大ピンチずかん,59,さ,さようならのおじぎで　ランドセルのなかみがぜんぶでた,Everything fell out of my backpack when I bowed to say goodbye.
-57,大ピンチずかん,84,ま,まいご,I'm lost.
-58,大ピンチずかん,82,か,かいものがながい,Shopping is taking a long time.
-59,大ピンチずかん,81,じ,じてんしゃにハチがとまっている,A bee is sitting on the bicycle.
-60,大ピンチずかん,60,せ,せんせいに　おかあさんといってしまった,I accidentally called my teacher 'Mom'.
-61,大ピンチずかん,61,ぎ,ギターのなかにおかしがおちた,A snack fell inside the guitar.
-62,大ピンチずかん,62,ず,ズボンのゴムがきれた,The elastic in my pants snapped.
-63,大ピンチずかん,63,さ,さなぎからかえったカブトムシが　よなかにだっそうして　とびまわっている,The beetle that emerged from its pupa escaped at night and is flying around.
-64,大ピンチずかん,57,け,けしゴムにさした　えんぴつのしんが　けしたときにつく,The pencil lead stuck in the eraser leaves marks when I erase.
-65,大ピンチずかん,89,お,おきられない,Can't wake up.
-66,大ピンチずかん,91,で,かばしらに　じてんしゃで　つっこんだ,Crashed my bicycle into a mosquito swarm.
-67,大ピンチずかん,93,と,トイレがつまった,The toilet is clogged.
-68,大ピンチずかん,94,お,おかあさんがイライラしている,Mom is getting irritated.
-69,大ピンチずかん,95,お,プレゼントをわすれた,Forgot the present.
-70,大ピンチずかん,86,し,しんしつに　だれかいる,Someone is in the bedroom.
-71,大ピンチずかん,87,く,クモのすにかかった,Got caught in a spider web.
-72,大ピンチずかん,88,と,トイレにおおきなガがとまっている,A large moth is sitting in the toilet.
-73,大ピンチずかん,9,し,しゃっくりがとまらない,Can't stop hiccuping.
-74,大ピンチずかん,16,わ,わりばしがうまくわれない,Can't split the chopsticks properly.
-75,大ピンチずかん,11,ご,ゴミばこがやまもり,The trash can is overflowing.
-76,大ピンチずかん,70,お,おなかがすいてうごけない,So hungry I can't move.
-77,大ピンチずかん,67,ま,まちがえてシャワーがでた,The shower came on by mistake.
-78,大ピンチずかん,13,け,パンがくろこげ,The bread is burnt to a crisp.
-79,大ピンチずかん,10,け,けずりかすいれがはいってなかった,The pencil shavings container wasn't in.
-80,大ピンチずかん,71,ふ,ふとんのなかでおならがでた,Farted under the covers.
-81,大ピンチずかん,69,じ,じぶんのいえでトイレがつまった,The toilet at my own house is clogged.
-82,大ピンチずかん,8,あ,あたまにつけたわゴムがとれない,Can't remove the rubber band I put on my head.
-83,大ピンチずかん,12,や,ビニールぶくろがめくれない,Can't open the plastic bag.
-84,大ピンチずかん,15,し,しょくばんを　がんばってスライスしているうちに　ぺしゃんこになっていた,The bread got squashed while I was trying hard to slice it.
-85,大ピンチずかん,7,ぺ,ペンがしみてつくえについた,The pen leaked onto the desk.
-86,大ピンチずかん,80,や,やっぱりさむかった,It was cold after all.
-87,大ピンチずかん,74,と,トイレのかみがない,There is no toilet paper.
-88,大ピンチずかん,73,わ,ワサビいりだった,It had wasabi in it.
-89,大ピンチずかん,72,お,おべんとうをわすれた,Forgot my lunch box.
-90,大ピンチずかん,66,あ,あしがつちだらけ,Feet are covered in mud.
-91,大ピンチずかん,65,は,ハエがじぶんにばかりとまる,Flies only land on me.
-92,大ピンチずかん,83,い,イヌがすごくなめてくる,The dog is licking me a lot.
-93,大ピンチずかん,75,し,しらないひとのてをにぎっていた,Was holding a stranger's hand.
-94,大ピンチずかん,85,し,シロツメクサの　かんむりをよくみると　アブラムシだらけだった,"When I looked closely at the clover crown, it was full of aphids."
-95,大ピンチずかん,79,ば,バッグにアリがあつまってきた,Ants gathered on the bag.
-96,大ピンチずかん,78,し,しんしつの　てんじょうのもくめが　ひとのかおにみえてきた,The wood grain on the bedroom ceiling started to look like a person's face.
-97,大ピンチずかん,41,や,やすみじかんに　おいた　すいとうが　そのまま,The water bottle I left during recess is still there.
-98,大ピンチずかん,42,ご,ごはんが　たりない,Not enough food.
-99,大ピンチずかん,44,は,はなしを　きいてなかった,Wasn't listening.
-100,大ピンチずかん,2,の,のんだガムに　まだあじが　たくさんのこっていた,Swallowed the gum; it still had a lot of flavor left.
-101,大ピンチずかん,52,む,むかしの　おにぎりが　でてきた,An old rice ball appeared.
-102,国旗王,上級,し,人口密度が高い,High population density.
-103,国旗王,上級,ひ,一人当たりGDPが高い,High GDP per capita.
-104,国旗王,上級,し,首都 最東,Easternmost capital.
-105,国旗王,上級,し,首都が最北,Northernmost capital.
-106,国旗王,上級,は,排他的経済水域,Exclusive Economic Zone.
-107,国旗王,上級,く,軍事費が最小,Smallest military expenditure.
-108,国旗王,上級,へ,平均寿命が短い,Short average life expectancy.
-109,国旗王,初級,し,人口が多い,Large population.
-110,国旗王,初級,め,面積が最小,Smallest area.
-111,国旗王,初級,は,排他的経済水域が最小,Smallest Exclusive Economic Zone.
-112,国旗王,上級,さ,最高地点が高い,Highest point is high.
-113,国旗王,初級,こ,国内総生産GDPが低い,Low GDP.
-114,国旗王,初級,し,人口が少ない,Small population.
-115,国旗王,初級,せ,正式国名が長い,Long official country name.
-116,国旗王,上級,く,軍事費が大きい,Large military expenditure.
-117,国旗王,上級,さ,最高地点が低い,Highest point is low.
-118,国旗王,初級,こ,国内総生産GDPが高い,High GDP.
-119,国旗王,初級,せ,正式国名が短い,Short official country name.
-120,国旗王,初級,め,面積が大きい,Large area.
-121,国旗王,上級,へ,平均寿命が長い,Long average life expectancy.
-122,国旗王,初級,ひ,一人当たりGDPが低い,Low GDP per capita.
-123,国旗王,初級,し,人口密度が低い,Low population density.
-124,国旗王,初級,せ,正式国名 五十音順 アに近い,Official name closest to 'A' in Japanese syllabary.
-125,国旗王,初級,し,首都が最南,Southernmost capital.
-126,おばけかるた,-,ふ,ふでこぞうが　ひとふでがき,Fudekozo draws with a single stroke.
-127,おばけかるた,-,ね,ねこまたも　ねがおはかわいい,Even Nekomata looks cute when sleeping.
-128,おばけかるた,-,ち,ちょうちんぶらり　こっちへ　くるぞ,Chochin-burari is coming this way!
-129,おばけかるた,-,た,たまごがわれて　てんぐがうまれた,An egg cracked and a Tengu was born.
-130,おばけかるた,-,け,けむくじゃらな　うでだ　まけるな！,"It's a hairy arm, don't lose!"
-131,おばけかるた,-,く,くずかごからくろいてが！！！　きゃっ！！！,A black hand from the wastebasket!!! Kya!!!
-132,おばけかるた,-,あ,あめふりこぞうが　びちゃびちゃあるく,Amefuri-kozo walks with a squish-squish.
-133,おばけかるた,-,ひ,ひとつめのくには　ひとつめだらけだってさ,They say the one-eyed country is full of one-eyes.
-134,おばけかるた,-,ぬ,ぬらりとわらう　ぬっぺっぽう,Nureppon smiles eerily.
-135,おばけかるた,-,つ,つきよにでていくつく　もがみ,Tsuku-mogami goes out on a moonlit night.
-136,おばけかるた,-,そ,そろってあるく　ぞうりのおばけ,Zori ghosts walk in pairs.
-137,おばけかるた,-,こ,こんばんは～　どろどろどろどろ～,Good evening~ Doro-doro-doro-doro~
-138,おばけかるた,-,き,きゅうびのきつねは　ばけるめいじん,The nine-tailed fox is a master of disguise.
-139,おばけかるた,-,い,いったんもめんは　そらとべていいなあ,"Ittan-momen, it's nice to fly in the sky."
-140,おばけかるた,-,は,はたらけはたらけ　おばけもはたらけ,"Work, work, ghosts also work."
-141,おばけかるた,-,に,にっこりわらう　にかいのおんな,The woman on the second floor smiles.
-142,おばけかるた,-,て,てんぐのはながおれては　かわいそう,It would be pitiful if Tengu's nose broke.
-143,おばけかるた,-,せ,せんすだって　すてればばける,Even a fan will transform if you throw it away.
-144,おばけかるた,-,さ,さかさくびは　ぺろぺろなめる,Sakasa-kubi licks with a flick-flick.
-145,おばけかるた,-,か,かあさんかっぱ　とこどものかっぱ,Mother Kappa and baby Kappa.
-146,おばけかるた,-,う,うみぼうずのがっこう　せいとをぼしゅう,Umibozu's school is recruiting students.
-147,おばけかるた,-,の,のんきなのぶすま　のんびりとんだ,Carefree Nobusuma flew leisurely.
-148,おばけかるた,-,な,なきなきかえった　ちいさなゆうれい,A small ghost returned crying.
-149,おばけかるた,-,と,とらがねてたら　かみなりどしーん！！,"If a tiger sleeps, lightning strikes with a boom!!"
-150,おばけかるた,-,す,すりばちこぞうは　なにすってるの？,What is Suribachi-kozo grinding?
-151,おばけかるた,-,し,しろくてみえない　ゆきのひのゆうれい,A white and invisible ghost on a snowy day.
-152,おばけかるた,-,お,おにもおじいさんになる,Even an ogre grows old.
-153,おばけかるた,-,え,えだをもやしたら　えんえんらがでたぞ,"When I burned a branch, Enenra came out!"
-154,おばけかるた,-,る,るすばんしてるは　ぶるぶるひとり,"Staying home alone, trembling."
-155,おばけかるた,-,り,りゅうがいねむり　そらからおちる,"A dragon sleeping, falling from the sky."
-156,おばけかるた,-,む,むじなもばけたが　ちょっとむりだった,"Mujina tried to transform, but it was a bit impossible."
-157,おばけかるた,-,み,みこしにゅうどう　みかけよりよわい,"Mikoshi-Nyudo, weaker than he looks."
-158,おばけかるた,-,れ,れいぎただしい　ゆうれいもいる,There are polite ghosts too.
-159,おばけかるた,-,ら,らしょうもんの　おにはらんぼうだ,The demon of Rashomon is wild.
-160,おばけかるた,-,め,めだまをとられた　ひとつめこぞう,A one-eyed monster whose eye was taken.
-161,おばけかるた,-,ま,まくらがえしは　まいばんうるさい,Makura-gaeshi is noisy every night.
-162,おばけかるた,-,ろ,ろくろくねなかった　ろくろっくび,Rokurokubi who didn't sleep at all.
-163,おばけかるた,-,よ,よみちをこわがる　よわむしにゅうどう,A timid Nyudo who is scared of night roads.
-164,おばけかるた,-,も,もりんじのかまは　たぬきがばけた,Morinji's kettle was a transformed raccoon dog.
-165,おばけかるた,-,ほ,ほうきのおばけは　ほめてやろう,Let's praise the broom ghost.
-166,おばけかるた,-,を,「あしをけして　てをまえに」ゆうれいのおけいこ,"Delete legs, hands forward - a ghost's practice."
-167,おばけかるた,-,わ,わ、にゅうどうだ　わぁーっこわい！,"Oh, it's a Nyudo! Ahh, scary!"
-168,おばけかるた,-,ゆ,ゆきおんな　おゆにはいってとけちゃった,Yuki-onna went into hot water and melted.
-169,おばけかるた,-,や,やなぎのしたで　ゆうれいけんか,Ghosts fighting under a willow tree.
-170,おばけかるた,-,へ,へびよりこわい　ろくろっくび,"Rokurokubi, scarier than a snake."
-171,いろはかるた,-,ま,嘘から出たまこと,A lie can sometimes turn into the truth
-172,いろはかるた,-,こ,弘法にも筆の誤り,Even experts make mistakes
-173,いろはかるた,-,あ,得手に帆を揚げる,To take advantage of a good opportunity
-174,いろはかるた,-,あ,味なもの縁は異なもの,Romance works in mysterious ways
-175,いろはかるた,-,ぞ,芋の煮えたも御存じない,Completely clueless
-176,いろはかるた,-,て,文はやりたし書く手は持たぬ,Wanting to write a letter but lacking the skill
-177,いろはかるた,-,す,亭主の好きな赤烏帽子,One must go along with the head of the household
-178,いろはかるた,-,し,知らぬが仏,Ignorance is bliss
-179,いろはかるた,-,は,背に腹はかえられぬ,Needs must when driven
-180,いろはかるた,-,げ,芸は身を助ける,A skill will always help you
-181,いろはかるた,-,の,喉元過ぎれば熱さを忘れる,"Once the pain is gone, the lesson is forgotten"
-182,いろはかるた,-,あ,頭隠して尻隠さず,Trying to hide something but failing
-183,いろはかるた,-,み,身から出た錆,You reap what you sow
-184,いろはかるた,-,も,門前の小僧習わぬ経を読む,You learn things naturally by exposure
-185,いろはかるた,-,お,鬼に金棒,Adding strength to the strong
-186,いろはかるた,-,ま,負けるが勝ち,Sometimes losing leads to winning
-187,いろはかるた,-,さ,三遍回って煙草にしょ,Take time and be careful
-188,いろはかるた,-,め,目の上のたん瘤,A thorn in one’s side
-189,いろはかるた,-,ひ,貧乏暇なし,The poor have no leisure
-190,いろはかるた,-,く,臭い物に蓋をする,To cover up an inconvenient truth
-191,いろはかるた,-,や,安物買いの銭失い,Buying cheap ends up costing more
-192,いろはかるた,-,き,聞いて極楽見て地獄,Hearing and seeing are very different
-193,いろはかるた,-,ゆ,油断大敵,Carelessness is dangerous
-194,いろはかるた,-,い,犬も歩けば棒に当たる,Every action brings some result
-195,いろはかるた,-,ら,楽あれば苦あり,Life has ups and downs
-196,いろはかるた,-,む,無理が通れば道理が引っ込む,"When force prevails, reason disappears"
-197,いろはかるた,-,と,年寄りの冷や水,An old person acting recklessly
-198,いろはかるた,-,す,粋は身を食う,Showing off can ruin you
-199,いろはかるた,-,き,京の夢大阪の夢,Dreams are fleeting and strange
-200,いろはかるた,-,へ,下手の長談義,The unskilled talk the longest
-201,いろはかるた,-,ろ,論より証拠,Proof is better than argument
-202,いろはかるた,-,く,くたびれ儲け,All effort and no reward
-203,いろはかるた,-,に,憎まれっ子世にはばかる,The disliked often survive well
-204,いろはかるた,-,ち,塵も積もれば山となる,Many small things add up
-205,いろはかるた,-,こ,律義者の子だくさん,Honest people tend to have many children
-206,いろはかるた,-,ぬ,盗人の昼寝,Even bad acts have consequences
-207,いろはかるた,-,は,花より団子,Practicality over appearance
-208,いろはかるた,-,る,瑠璃も玻璃も照らせば光る,True talent shines anywhere
-209,いろはかるた,-,な,泣きっ面に蜂,Misfortune never comes alone
-210,いろはかるた,-,あ,葦の髄から天井のぞく,Judging the whole from a tiny part
-211,いろはかるた,-,か,蛙の面に水,Completely unfazed
-212,いろはかるた,-,わ,破れ鍋に綴じ蓋,Every pot has its lid
-213,いろはかるた,-,を,老いては子に従え,Let the younger generation lead
-214,いろはかるた,-,ね,念には念を入れよ,Double-check everything
-215,いろはかるた,-,た,旅は道連れ世は情け,Life is about helping each other
-216,いろはかるた,-,れ,良薬は口に苦し,Good medicine tastes bitter
-217,いろはかるた,-,そ,総領の甚六,The eldest son is often naive
-218,いろはかるた,-,つ,月とすっぽん,Like night and day
-219,いろはかるた（意味）,-,ま,でたらめに言ったことが、偶然にも事実になってしまうこと,A lie can sometimes turn into the truth
-220,いろはかるた（意味）,-,こ,どんな名人でも失敗することがあるというたとえ,Even experts make mistakes
-221,いろはかるた（意味）,-,あ,物事を行うのに絶好の機会を得ること,To take advantage of a good opportunity
-222,いろはかるた（意味）,-,あ,男女の仲は理屈では説明できないものだということ,Romance works in mysterious ways
-223,いろはかるた（意味）,-,ぞ,物事の様子がまったく分からない人をからかう言い方,Completely clueless
-224,いろはかるた（意味）,-,て,やりたい気持ちはあるが能力が伴わず困っていること,Wanting to write a letter but lacking the skill
-225,いろはかるた（意味）,-,す,家長の好みには家族も従うべきだという考え,One must go along with the head of the household
-226,いろはかるた（意味）,-,し,知らなければ悩まずにすむこともあるということ,Ignorance is bliss
-227,いろはかるた（意味）,-,は,大きな目的のためには多少の犠牲は仕方ないということ,Needs must when driven
-228,いろはかるた（意味）,-,げ,身につけた技や芸が困ったときに役立つこと,A skill will always help you
-229,いろはかるた（意味）,-,の,苦しい経験をしても時間がたつと忘れてしまうこと,"Once the pain is gone, the lesson is forgotten"
-230,いろはかるた（意味）,-,あ,一部しか隠していないのに全部隠したつもりでいること,Trying to hide something but failing
-231,いろはかるた（意味）,-,み,自分のした悪い行いの結果で自分が苦しむこと,You reap what you sow
-232,いろはかるた（意味）,-,も,日頃見聞きしているうちに自然と身につくことがある,You learn things naturally by exposure
-233,いろはかるた（意味）,-,お,強いものがさらに力を得て一層強くなること,Adding strength to the strong
-234,いろはかるた（意味）,-,ま,一歩引いた方が結果的に有利になることがある,Sometimes losing leads to winning
-235,いろはかるた（意味）,-,さ,急がず慎重に行動することが大切だということ,Take time and be careful
-236,いろはかるた（意味）,-,め,自分にとって邪魔で目障りな存在のたとえ,A thorn in one’s side
-237,いろはかるた（意味）,-,ひ,貧しい人ほど仕事に追われ時間の余裕がないこと,The poor have no leisure
-238,いろはかるた（意味）,-,く,都合の悪いことを一時的に隠そうとすること,To cover up an inconvenient truth
-239,いろはかるた（意味）,-,や,安い物を買うとかえって損をすること,Buying cheap ends up costing more
-240,いろはかるた（意味）,-,き,聞くのと実際に見るのとでは大きな違いがあること,Hearing and seeing are very different
-241,いろはかるた（意味）,-,ゆ,油断すると失敗や災難を招くということ,Carelessness is dangerous
-242,いろはかるた（意味）,-,い,行動すれば良くも悪くも何かが起こるということ,Every action brings some result
-243,いろはかるた（意味）,-,ら,人生には楽しいことと苦しいことの両方がある,Life has ups and downs
-244,いろはかるた（意味）,-,む,無茶がまかり通る世の中では道理が通らなくなる,"When force prevails, reason disappears"
-245,いろはかるた（意味）,-,と,年齢を考えず無理な振る舞いをすること,An old person acting recklessly
-246,いろはかるた（意味）,-,す,気取った振る舞いが身を滅ぼすことがある,Showing off can ruin you
-247,いろはかるた（意味）,-,き,夢というものはとりとめなく不思議なものだということ,Dreams are fleeting and strange
-248,いろはかるた（意味）,-,へ,下手な人ほど話が長くなること,The unskilled talk the longest
-249,いろはかるた（意味）,-,ろ,理屈よりも実際の証拠が大切だということ,Proof is better than argument
-250,いろはかるた（意味）,-,く,苦労したわりに何の得もないこと,All effort and no reward
-251,いろはかるた（意味）,-,に,憎まれるような人ほど世渡りがうまいこと,The disliked often survive well
-252,いろはかるた（意味）,-,ち,小さなことでも積み重なれば大きな成果になる,Many small things add up
-253,いろはかるた（意味）,-,こ,律義な人は家庭を大切にし子どもが多くなるという考え,Honest people tend to have many children
-254,いろはかるた（意味）,-,ぬ,どんな行いにも必ず報いがあるということ,Even bad acts have consequences
-255,いろはかるた（意味）,-,は,見た目より実利を重んじること,Practicality over appearance
-256,いろはかるた（意味）,-,る,才能のある人はどんな環境でも力を発揮する,True talent shines anywhere
-257,いろはかるた（意味）,-,な,不運なときにさらに不幸が重なること,Misfortune never comes alone
-258,いろはかるた（意味）,-,あ,わずかな知識で全て分かったつもりになること,Judging the whole from a tiny part
-259,いろはかるた（意味）,-,か,何をされても平然としていること,Completely unfazed
-260,いろはかるた（意味）,-,わ,どんな人にもふさわしい相手がいるということ,Every pot has its lid
-261,いろはかるた（意味）,-,を,年を取ったら若い者の意見に従うのがよい,Let the younger generation lead
-262,いろはかるた（意味）,-,ね,十分注意した上でさらに注意を重ねること,Double-check everything
-263,いろはかるた（意味）,-,た,人は助け合って生きていくものだということ,Life is about helping each other
-264,いろはかるた（意味）,-,れ,忠告は耳に痛いが自分のためになる,Good medicine tastes bitter
-265,いろはかるた（意味）,-,そ,長男は大事に育てられ世間知らずになりがちだということ,The eldest son is often naive
-266,いろはかるた（意味）,-,つ,似ているようで実際は大きな違いがある,Like night and day
-267,百人一首,-,あ,あきのたの かりほのいおの とまをあらみ わがころもでは つゆにぬれつつ,"In the autumn field, in the temporary hut's rough rush-mats, my sleeves are getting wet with dew."
-268,百人一首,-,あ,あきかぜに たなびくくもの たえまより もれいづるつきの かげのさやけさ,"Through the rifts in the clouds trailing in the autumn wind, how clear the moonlight leaks out."
-269,百人一首,-,あ,あしびきの やまどりのをの しだりをの ながながしよを ひとりかもねむ,"Must I sleep alone through the long, long night, like the long, trailing tail of the mountain pheasant?"
-270,百人一首,-,あ,あまのはら ふりさけみれば かすがなる みかさのやまに いでしつきかも,"When I look out over the plain of heaven, is that the same moon that rose over Mount Mikasa in Kasuga?"
-271,百人一首,-,あ,あわれとも いうべきひとは おもほえで みのいたずらに なりぬべきかな,"Since there is no one who might feel pity for me, I suppose I shall just pass away in vain."
-272,百人一首,-,い,いまはただ おもひたえなむ とばかりを ひとづてならで いうよしもがな,Now I just want to give up my love; if only I could tell you this directly and not through others.
-273,百人一首,-,い,いまこむと いいしばかりに ながつきの ありあけのつきを まちいでつるかな,"Just because you said 'I'll come soon', I have waited until the morning moon of the long month appeared."
-274,百人一首,-,い,いろはにほへど ちりぬるを わがよたれぞ つねならむ,"Though flowers are fragrant, they will fall; in our world, who can remain forever?"
-275,百人一首,-,い,いのちながくは かたみにあはず ひとりして ものおもふよぞ ながかりける,"If I live long, we might not meet again; the night I spend alone in thought is so very long."
-276,百人一首,-,い,いにしへの ならのみやこの やへざくら けふここのへに にほひぬるかな,The eight-layered cherry blossoms of the ancient capital of Nara are fragrantly blooming today in the imperial palace.
-277,百人一首,-,う,うかりける ひとをはつせの やまおろしよ はげしかれとは いのらぬものを,"O mountain wind of Hatsuse, I did not pray for you to be so harsh, though she is cold to me."
-278,百人一首,-,う,うらみわび ほさぬそでだに あるものを こひにくちなむ なこそをしけれ,"I resent her and am weary; my sleeves never dry, and I fear my reputation will rot away in this love."
-279,百人一首,-,え,えにしあらば あはむとぞおもふ いざさらば わがなとひとは わすれざらなむ,"If there is fate, I believe we shall meet; now farewell, and may you not forget my name."
-280,百人一首,-,お,おおえやま いくののみちの とおければ まだふみもみず あまのはしだて,The road to Ikuno over Mount Oe is so far that I have seen neither a letter nor Amanohashidate.
-281,百人一首,-,お,おくやまに もみぢふみわけ なくしかの こゑきくときぞ あきはかなしき,"When I hear the voice of the stag crying as he steps through the maple leaves deep in the mountains, autumn is truly sad."
-282,百人一首,-,か,かささぎの わたせるはしに おくしもの しろきをみれば よぞふけにける,"When I see the white frost on the bridge the magpies are said to have spread, I know the night has deepened."
-283,百人一首,-,か,かぜをいたみ いはうつなみの おのれのみ くだけてものを おもふころかな,"Like the waves breaking against the rocks in the fierce wind, I alone am broken as I think of my love."
-284,百人一首,-,き,きみがため はるののにいでて わかなつむ わがころもでに ゆきはふりつつ,"For your sake, I went out to the spring fields to pick young greens, while snow fell on my sleeves."
-285,百人一首,-,き,きみがため をしからざりし いのちさへ ながくもがなと おもひけるかな,"For your sake, I did not value my life, but now I wish it would be long."
-286,百人一首,-,く,くさもきも いろかはれども わたつみの なみのはなにぞ あきなかりける,"Though the colors of plants and trees change, there is no autumn in the flowers of the sea waves."
-287,百人一首,-,く,くれなゐに みづくくるとは ききしかど あきぞこのはに まじりけるかな,"I heard that the water is dyed crimson, but it seems autumn has mixed into the leaves."
-288,百人一首,-,こ,こころあてに をらばやをらむ はつしもの おきまどはせる しらぎくのはな,"If I were to pick them at random, I might pick the white chrysanthemums that the first frost has confused."
-289,百人一首,-,こ,このたびは ぬさもとりあへず たむけやま もみぢのにしき かみのまにまに,"At this time, I could not even bring an offering; let the gods take the brocade of maple leaves on Mount Tamuke."
-290,百人一首,-,さ,さびしさに やどをたちいでて ながむれば いづこもおなじ あきのゆふぐれ,"In my loneliness, I leave my house and look out; everywhere it is the same autumn evening."
-291,百人一首,-,し,しのぶれど いろにいでにけり わがこひは ものやおもふと ひとのとふまで,"Though I try to hide it, my love shows in my face, until people ask if I am lost in thought."
-292,百人一首,-,す,すみのえの きしによるなみ よるさへや ゆめのかよひぢ ひとめよくらむ,"Like the waves approaching the shore of Suminoe, even at night do you avoid people's eyes on the dream path?"
-293,百人一首,-,せ,せをはやみ いはにせかるる たきがはの われてもすゑに あはむとぞおもふ,"Like the river current split by a rock in the rapids, though divided, I know we shall meet in the end."
-294,百人一首,-,そ,そらしらぬ ゆきふみわけて いでつるは ひとつのえだに つるをたづねて,"I went out treading through the snow I didn't know, seeking a vine on a single branch."
-295,百人一首,-,た,たごのうらに うちいでてみれば しろたへの ふじのたかねに ゆきはふりつつ,"When I go out to the shore of Tago and look, snow is falling on the white peak of Mount Fuji."
-296,百人一首,-,ち,ちはやぶる かみよもきかず たつたがは からくれなゐに みづくくるとは,"Never heard of even in the age of the mighty gods, that the Tatsuta River is dyed in deep crimson."
-297,百人一首,-,つ,つくばねの みねよりおつる みなのがは こひぞつもりて ふちとなりぬる,"Like the Minano River falling from the peak of Tsukubane, my love has accumulated and become a deep pool."
-298,百人一首,-,て,てふことも いまはむかしに なりぬれば たがためにかは なにかうらみむ,"Since even that has become a thing of the past, for whose sake should I hold any resentment?"
-299,百人一首,-,と,ともしびを かきたつるまも なつかしき いづれのよひに みえぬまにまに,"Even while trimming the lamp, I miss you; on which evening did I not see you?"
-300,百人一首,-,な,ながからむ こころもしらず くろかみの みだれてけさは ものをこそおもへ,"Uncertain of how long his heart will stay,my black hair lies in disarray this morning and so, I am lost in troubled thoughts."
-301,百人一首,-,に,にしきなる ふくろにいれて いはざかり いづれのやまを こえぬとぞおもふ,I put it in a brocade bag; I wonder which mountain it crossed in its peak of silence.
-302,百人一首,-,ぬ,ぬさもとりあへず たむけやま もみぢのにしき かみのまにまに,I could not even bring an offering; let the gods take the brocade of maple leaves on Mount Tamuke.
-303,百人一首,-,ね,ねがはくは はなのしたにて はるしなむ そのきさらぎの もちづきのころ,"My wish is to die in spring under the flowers, around the time of the full moon in the second month."
-304,百人一首,-,の,のちのよを おもへばかろし ほととぎす あかつきかけて なきつるものを,"Thinking of the afterlife makes it seem light, while the cuckoo cries toward the dawn."
-305,百人一首,-,は,はるすぎて なつきにけらし しろたへの ころもほすてふ あまのかぐやま,Spring has passed and summer seems to have come; white robes are said to be dried on the heavenly Mount Kagu.
-306,百人一首,-,ひ,ひさかたの ひかりのどけき はるのひに しづこころなく はなのちるらむ,"On this spring day when the light is so calm, why do the cherry blossoms scatter with such unquiet hearts?"
-307,百人一首,-,ふ,ふくからに あきのくさきの しをるれば むべやまかぜを あらしといふらむ,"Since the autumn plants and trees wither as soon as it blows, it is no wonder the mountain wind is called a storm."
-308,百人一首,-,へ,へにける いくよをかさね たまづさの ふみをひらけば こひぞつもりぬる,"As I open the letter after many passing nights, my love has truly accumulated."
-309,百人一首,-,ほ,ほととぎす なきつるかたを ながむれば ただありあけの つきぞのこれる,"When I look toward where the cuckoo cried, only the morning moon remains."
-310,百人一首,-,ま,まつとしき たかしのはまの あまごろも ぬれにぞぬれし いろはかはらず,"Waiting on the beach of Takashi, the fisher's robe got soaked and soaked, but its color remained unchanged."
-311,百人一首,-,み,みかのはら わきてながるる いづみがは いつみきとてか こひしかるらむ,"Like the Izumi River flowing through the plain of Mika, when did I see you that I should love you so?"
-312,百人一首,-,む,むらさめの つゆもまだひぬ まきのはに きりたちのぼる あきのゆふぐれ,"Before the dew of the passing shower has dried on the fir leaves, the mist rises on an autumn evening."
-313,百人一首,-,め,めぐりあひて みしやそれとも わかぬまに くもがくれにし よはのつきかな,"Meeting by chance, before I could even tell if it was you, you were hidden by clouds like the midnight moon."
-314,百人一首,-,も,ももしきや ふるきのきばの しのぶにも なほあまりある むかしなりけり,"In the palace, even the ferns on the old eaves make me yearn for the past more than I can bear."
-315,百人一首,-,や,やすらはで ねなましものを さよふけて かたぶくまでの つきをみしかな,I should have gone to sleep without waiting; I watched the moon until it began to sink late at night.
-316,百人一首,-,ゆ,ゆらのとを わたるふなびと かぢをたえ ゆくへもしらぬ こひのみちかな,"Like a mariner crossing the Yura Strait with a lost oar, I know not where the path of my love leads."
-317,百人一首,-,よ,よをこめて とりのそらねは はかるとも よにあふさかの せきはゆるさじ,"Though you try to deceive with a bird's false cry in the dead of night, the gate of Osaka shall not let you pass."
-318,百人一首,-,ら,らいしやうの いのちのはてを しらぬまに けふをかぎりと おもひけるかな,"Not knowing the end of my life in the next world, I thought today would be the limit."
-319,百人一首,-,り,りくかぜの さむきにたへて みちのくの しのぶもぢずり たれゆゑにけむ,"Enduring the cold land wind, for whose sake was the tangled print of Michinoku's Shinobu?"
-320,百人一首,-,る,るりのつぼ いづれのひとも すむらむと こころをかけし いろはみえず,"In the lapis lazuli jar where everyone might live, I cannot see the colors I set my heart on."
-321,百人一首,-,れ,れいよりも こころをつくせ さくらばな ちりぬるのちも にほひをこそ,"Exert your heart more than usual, cherry blossoms; even after you fall, leave your fragrance."
-322,百人一首,-,ろ,ろばたにて こまをつなぎて みるほどに はなぞちりける さくらかな,"While tethering my horse by the roadside, the cherry blossoms were scattering."
-323,百人一首,-,わ,わたのはら やそしまかけて こぎいでぬと ひとにはつげよ あまのつりぶね,"Tell the people that I have rowed out over the wide sea toward the many islands, O fisher's boat."
-324,百人一首,-,を,をぐらやま みねのもみぢば こころあらば いまひとたびの みゆきまたなむ,"O maple leaves on the peak of Mount Ogura, if you have a heart, wait for one more imperial visit."
-325,百人一首,-,ん,んにゃくにしゅう つねのことばを うたにして こころをつたふ みちぞたふとき,"Turning ordinary words into songs to convey the heart, the path is truly noble."
-326,大ピンチずかん,92,た,たからものいれが　あかない,"I can't open treasure box."
-327,大ピンチずかん,1,が,がむを　のんだ,"I swallowed gum."
-400,しょうがっこうかるた,-,あ,あさきたら あいさつしよう げんきよく,"When morning comes, greet cheerfully."
-401,しょうがっこうかるた,-,い,いねむりは たいちょうくずす はじまりだ,"Dozing off is the start of feeling unwell."
-402,しょうがっこうかるた,-,う,うんどうで からだをきたえ よくねよう,"Exercise your body and sleep well."
-403,しょうがっこうかるた,-,え,えがおでね すごせばみんな うれしいよ,"If you spend time smiling, everyone is happy."
-404,しょうがっこうかるた,-,お,おはようと げんきなこえで あいさつだ,"Say good morning with a cheerful voice."
-405,しょうがっこうかるた,-,か,かさをさし あめのひだって たのしいよ,"Even rainy days can be fun with an umbrella."
-406,しょうがっこうかるた,-,き,きちんとね つかったあとは かたづけよう,"After using things, tidy them properly."
-407,しょうがっこうかるた,-,く,くつぬいで そろえておけば きもちいい,"Take off and line up your shoes neatly."
-408,しょうがっこうかるた,-,け,けいさんは あせらずゆっくり かくにんだ,"Do calculations calmly and check carefully."
-409,しょうがっこうかるた,-,こ,こころには あんぜんまもる やくそくだ,"Keep safety rules in your heart."
-410,しょうがっこうかるた,-,さ,さくらさく にゅうがくきせつ はるがきた,"Cherry blossoms bloom—spring and school begin."
-411,しょうがっこうかるた,-,し,しゃべらずに どうろをあるこう あぶないよ,"Walk quietly on roads—it’s dangerous otherwise."
-412,しょうがっこうかるた,-,す,すきなもの ちゃんとえらんで たいせつに,"Choose what you like and value it."
-413,しょうがっこうかるた,-,せ,せいりして つかえばいつも きもちいい,"Keep things organized and feel good."
-414,しょうがっこうかるた,-,そ,そうじして みんなできれいに しようね,"Let’s all clean and make it neat."
-415,しょうがっこうかるた,-,た,たのしいね みんなであそぶと えがおさく,"Playing together brings smiles."
-416,しょうがっこうかるた,-,ち,ちいさくても ルールまもれば りっぱだよ,"Even small acts matter if you follow rules."
-417,しょうがっこうかるた,-,つ,つかうもの たいせつにして ながくつかう,"Take care of things and use them long."
-418,しょうがっこうかるた,-,て,てをあらい きれいにすれば びょうきよぼう,"Wash your hands to prevent illness."
-419,しょうがっこうかるた,-,と,ともだちと なかよくすごす がっこうだ,"School is for getting along with friends."
-420,しょうがっこうかるた,-,な,なかよくね けんかしないで すごそうよ,"Let’s get along without fighting."
-421,しょうがっこうかるた,-,に,にこにこと えがおであいさつ きもちいい,"Smiling greetings feel good."
-422,しょうがっこうかるた,-,ぬ,ぬいだくつ そろえておけば きれいだね,"Neatly arranged shoes look nice."
-423,しょうがっこうかるた,-,ね,ねるまえに あしたのじゅんび しておこう,"Prepare for tomorrow before sleeping."
-424,しょうがっこうかるた,-,の,のこさずに きゅうしょくたべて げんきだよ,"Eat your lunch fully to stay healthy."
-425,しょうがっこうかるた,-,は,はやおきで こころもからだも げんきだよ,"Waking early keeps you healthy."
-426,しょうがっこうかるた,-,ひ,ひとりでも できることから がんばろう,"Do what you can, even alone."
-427,しょうがっこうかるた,-,ふ,ふざけずに じゅぎょううけよう しっかりと,"Take class seriously without fooling around."
-428,しょうがっこうかるた,-,へ,へやのなか きれいにすれば きもちいい,"A clean room feels nice."
-429,しょうがっこうかるた,-,ほ,ほんをよみ こころをそだて かしこくね,"Read books to grow your mind."
-430,しょうがっこうかるた,-,ま,まいにちを たいせつにして すごそうね,"Cherish each day."
-431,しょうがっこうかるた,-,み,みんなでね ちからをあわせ がんばろう,"Let’s work together."
-432,しょうがっこうかるた,-,む,むりしない じぶんのペースで すすもうね,"Go at your own pace."
-433,しょうがっこうかるた,-,め,めあてもち がくしゅうすれば ちからつく,"Study with goals to improve."
-434,しょうがっこうかるた,-,も,ものはね たいせつにして つかおうね,"Take care of your belongings."
-435,しょうがっこうかるた,-,や,やくそくを まもればみんな しんらいだ,"Keeping promises builds trust."
-436,しょうがっこうかるた,-,ゆ,ゆっくりと あせらずいこう だいじょうぶ,"Take it slow, no need to rush."
-437,しょうがっこうかるた,-,よ,よるふかし しないでねむろう はやめにね,"Don’t stay up late, sleep early."
-438,しょうがっこうかるた,-,ら,らくがきは してはいけない たいせつに,"Don’t scribble—respect things."
-439,しょうがっこうかるた,-,り,りゆうある こうどうすれば せいちょうだ,"Act with purpose to grow."
-440,しょうがっこうかるた,-,る,ルールまもり みんながたのしく すごせるよ,"Follow rules so everyone enjoys."
-441,しょうがっこうかるた,-,れ,れいぎよく あいさつできる いいこだね,"Polite greetings are great."
-442,しょうがっこうかるた,-,ろ,ろうかでは はしらずあるこう あんぜんに,"Walk in hallways safely."
-443,しょうがっこうかるた,-,わ,わすれもの しないようにね かくにんだ,"Check so you don’t forget things."
-444,しょうがっこうかるた,-,を,しゅくだいを きちんとやろう わすれずに,"Do your homework properly without forgetting."
-445,しょうがっこうかるた,-,ん,さんかんび パパやママは みてるかな,"On open school day, I wonder if mom and dad are watching."
+id,category,level,kana,phrase,phrase_en,answer
+1,テスト用,5,あ,アメンボ赤いな　あいうえお,"A red water strider — A, I, U, E, O.",-
+2,テスト用,100,い,犬も歩けば　棒に当たる,"If you go out, you may run into trouble.",-
+3,大ピンチずかん,77,え,エスカレーターが　ぎゃくだった,The escalator was going the opposite way.,-
+4,大ピンチずかん,20,あ,アイスが　とけてきた,The ice cream started melting.,-
+5,大ピンチずかん,4,へ,へんな　ひやけを　した,Made a strange face.,-
+6,大ピンチずかん,30,た,たんじょうびケーキが　たおれて　イチゴが　ころがった,The birthday cake fell over and the strawberries rolled away.,-
+7,大ピンチずかん,23,ご,ごはんつぶを　ふんだ,Stepped on a grain of rice.,-
+8,大ピンチずかん,21,お,おふろの　ごみが　すくえない,Can't scoop the debris out of the bathtub.,-
+9,大ピンチずかん,18,ふ,ふたが　ない,There is no lid.,-
+10,大ピンチずかん,6,て,テープの　はしが　みつからない,Can't find the end of the tape.,-
+11,大ピンチずかん,28,え,えだまめが　とんだ,The edamame flew away.,-
+12,大ピンチずかん,24,か,カップめんの　おゆが　たりない,Not enough hot water for the cup noodles.,-
+13,大ピンチずかん,68,う,うんてんちゅうの　くるまの　なかに　おおきな　クモが　いる,There is a big spider in the car while driving.,-
+14,大ピンチずかん,35,ゆ,ゆでたまごが　ボロボロ,The boiled egg is falling apart.,-
+15,大ピンチずかん,5,す,ストローが　とれない,Can't take out the straw.,-
+16,大ピンチずかん,27,う,「う」の　もじが　はんたいだった,The letter 'u' was backwards.,-
+17,大ピンチずかん,19,け,おちたけしゴムがみつからない,Can't find the dropped eraser.,-
+18,大ピンチずかん,17,し,しょうゆをいれすぎた,Poured too much soy sauce.,-
+19,大ピンチずかん,34,しゃ,シャワーがみつからない,Can't find the shower.,-
+20,大ピンチずかん,3,こ,こおりがしたにくっついた,The ice stuck to my tongue.,-
+21,大ピンチずかん,26,た,たんじょうびケーキがたおれそう,The birthday cake is about to fall.,-
+22,大ピンチずかん,22,じ,じゅうでんができていなかった,It wasn't charged.,-
+23,大ピンチずかん,14,し,シャボンえきをすった,Accidentally inhaled the bubble solution.,-
+24,大ピンチずかん,33,け,ケチャップがとんだ,Ketchup splattered.,-
+25,大ピンチずかん,31,ぽ,ポケットからすながたくさんでてきた,A lot of sand came out of the pocket.,-
+26,大ピンチずかん,25,せ,せんたくきのうしろにくつしたがおちた,A sock fell behind the washing machine.,-
+27,大ピンチずかん,90,ふ,フンをふんだ,Stepped on poop.,-
+28,大ピンチずかん,55,い,いおうとしていたことをわすれた,Forgot what I was about to say.,-
+29,大ピンチずかん,46,に,にくがきれない,Can't cut the meat.,-
+30,大ピンチずかん,39,た,たんじょうびケーキのろうそくがきえない,The birthday cake candles won't go out.,-
+31,大ピンチずかん,52,む,むかしのおにぎりがでてきた,An old rice ball appeared.,-
+32,大ピンチずかん,54,れ,れいとうこがあかない,The freezer won't open.,-
+33,大ピンチずかん,48,ふ,ふくのピラピラがきになる,The loose thread on my clothes is bothering me.,-
+34,大ピンチずかん,43,し,しゅくだいノートと　じゆうちょうをまちがえた,Confused the homework notebook with the sketchbook.,-
+35,大ピンチずかん,38,ふ,ふたがしまらない,The lid won't close.,-
+36,大ピンチずかん,32,め,めんつゆがすごくあまった,A lot of noodle dipping sauce was left over.,-
+37,大ピンチずかん,53,な,ながしのみずがスプーンではねた,The water in the sink splashed off the spoon.,-
+38,大ピンチずかん,49,べ,べんざをあけたまますわった,Sat down with the toilet seat up.,-
+39,大ピンチずかん,37,あ,アメリカンドッグがまわる,The corn dog is spinning.,-
+40,大ピンチずかん,76,ね,ねむれない,Can't sleep.,-
+41,大ピンチずかん,47,し,シャンプーがめにはいった,Got shampoo in my eyes.,-
+42,大ピンチずかん,51,ば,バッグのなかですいとうがもれた,The water bottle leaked inside the bag.,-
+43,大ピンチずかん,56,な,なまえがおもいだせない,Can't remember the name.,-
+44,大ピンチずかん,64,き,きんじょのおばさんが　ずっとなまえをまちがえている,The neighborhood lady has been getting my name wrong for a long time.,-
+45,大ピンチずかん,50,お,おゆがない,There is no hot water.,-
+46,大ピンチずかん,45,ど,ドアをあけられてさむい,Someone opened the door and it's cold.,-
+47,大ピンチずかん,40,せ,せんせいのメガネがとんだ,The teacher's glasses flew off.,-
+48,大ピンチずかん,36,ほ,ほねをとっていたら　ぐちゃぐちゃになった,It became a mess while I was trying to remove the bones.,-
+49,大ピンチずかん,29,ぎ,ぎゅうにゅうがこぼれた,The milk spilled.,-
+50,大ピンチずかん,96,か,かさがうらがえった,The umbrella turned inside out.,-
+51,大ピンチずかん,97,じ,じてんしゃがドミノだおし,The bicycles fell over like dominoes.,-
+52,大ピンチずかん,98,お,おもったよりみじかくなった,It became shorter than I thought.,-
+53,大ピンチずかん,99,ね,ネコがついてくる,A cat is following me.,-
+54,大ピンチずかん,100,ど,どしゃぶりなのにかさがない,It's pouring rain but I don't have an umbrella.,-
+55,大ピンチずかん,58,れ,れいとうこがしまらない,The freezer won't close.,-
+56,大ピンチずかん,59,さ,さようならのおじぎで　ランドセルのなかみがぜんぶでた,Everything fell out of my backpack when I bowed to say goodbye.,-
+57,大ピンチずかん,84,ま,まいご,I'm lost.,-
+58,大ピンチずかん,82,か,かいものがながい,Shopping is taking a long time.,-
+59,大ピンチずかん,81,じ,じてんしゃにハチがとまっている,A bee is sitting on the bicycle.,-
+60,大ピンチずかん,60,せ,せんせいに　おかあさんといってしまった,I accidentally called my teacher 'Mom'.,-
+61,大ピンチずかん,61,ぎ,ギターのなかにおかしがおちた,A snack fell inside the guitar.,-
+62,大ピンチずかん,62,ず,ズボンのゴムがきれた,The elastic in my pants snapped.,-
+63,大ピンチずかん,63,さ,さなぎからかえったカブトムシが　よなかにだっそうして　とびまわっている,The beetle that emerged from its pupa escaped at night and is flying around.,-
+64,大ピンチずかん,57,け,けしゴムにさした　えんぴつのしんが　けしたときにつく,The pencil lead stuck in the eraser leaves marks when I erase.,-
+65,大ピンチずかん,89,お,おきられない,Can't wake up.,-
+66,大ピンチずかん,91,で,かばしらに　じてんしゃで　つっこんだ,Crashed my bicycle into a mosquito swarm.,-
+67,大ピンチずかん,93,と,トイレがつまった,The toilet is clogged.,-
+68,大ピンチずかん,94,お,おかあさんがイライラしている,Mom is getting irritated.,-
+69,大ピンチずかん,95,お,プレゼントをわすれた,Forgot the present.,-
+70,大ピンチずかん,86,し,しんしつに　だれかいる,Someone is in the bedroom.,-
+71,大ピンチずかん,87,く,クモのすにかかった,Got caught in a spider web.,-
+72,大ピンチずかん,88,と,トイレにおおきなガがとまっている,A large moth is sitting in the toilet.,-
+73,大ピンチずかん,9,し,しゃっくりがとまらない,Can't stop hiccuping.,-
+74,大ピンチずかん,16,わ,わりばしがうまくわれない,Can't split the chopsticks properly.,-
+75,大ピンチずかん,11,ご,ゴミばこがやまもり,The trash can is overflowing.,-
+76,大ピンチずかん,70,お,おなかがすいてうごけない,So hungry I can't move.,-
+77,大ピンチずかん,67,ま,まちがえてシャワーがでた,The shower came on by mistake.,-
+78,大ピンチずかん,13,け,パンがくろこげ,The bread is burnt to a crisp.,-
+79,大ピンチずかん,10,け,けずりかすいれがはいってなかった,The pencil shavings container wasn't in.,-
+80,大ピンチずかん,71,ふ,ふとんのなかでおならがでた,Farted under the covers.,-
+81,大ピンチずかん,69,じ,じぶんのいえでトイレがつまった,The toilet at my own house is clogged.,-
+82,大ピンチずかん,8,あ,あたまにつけたわゴムがとれない,Can't remove the rubber band I put on my head.,-
+83,大ピンチずかん,12,や,ビニールぶくろがめくれない,Can't open the plastic bag.,-
+84,大ピンチずかん,15,し,しょくばんを　がんばってスライスしているうちに　ぺしゃんこになっていた,The bread got squashed while I was trying hard to slice it.,-
+85,大ピンチずかん,7,ぺ,ペンがしみてつくえについた,The pen leaked onto the desk.,-
+86,大ピンチずかん,80,や,やっぱりさむかった,It was cold after all.,-
+87,大ピンチずかん,74,と,トイレのかみがない,There is no toilet paper.,-
+88,大ピンチずかん,73,わ,ワサビいりだった,It had wasabi in it.,-
+89,大ピンチずかん,72,お,おべんとうをわすれた,Forgot my lunch box.,-
+90,大ピンチずかん,66,あ,あしがつちだらけ,Feet are covered in mud.,-
+91,大ピンチずかん,65,は,ハエがじぶんにばかりとまる,Flies only land on me.,-
+92,大ピンチずかん,83,い,イヌがすごくなめてくる,The dog is licking me a lot.,-
+93,大ピンチずかん,75,し,しらないひとのてをにぎっていた,Was holding a stranger's hand.,-
+94,大ピンチずかん,85,し,シロツメクサの　かんむりをよくみると　アブラムシだらけだった,"When I looked closely at the clover crown, it was full of aphids.",-
+95,大ピンチずかん,79,ば,バッグにアリがあつまってきた,Ants gathered on the bag.,-
+96,大ピンチずかん,78,し,しんしつの　てんじょうのもくめが　ひとのかおにみえてきた,The wood grain on the bedroom ceiling started to look like a person's face.,-
+97,大ピンチずかん,41,や,やすみじかんに　おいた　すいとうが　そのまま,The water bottle I left during recess is still there.,-
+98,大ピンチずかん,42,ご,ごはんが　たりない,Not enough food.,-
+99,大ピンチずかん,44,は,はなしを　きいてなかった,Wasn't listening.,-
+100,大ピンチずかん,2,の,のんだガムに　まだあじが　たくさんのこっていた,Swallowed the gum; it still had a lot of flavor left.,-
+101,大ピンチずかん,52,む,むかしの　おにぎりが　でてきた,An old rice ball appeared.,-
+102,国旗王,上級,し,人口密度が高い,High population density.,-
+103,国旗王,上級,ひ,一人当たりGDPが高い,High GDP per capita.,-
+104,国旗王,上級,し,首都 最東,Easternmost capital.,-
+105,国旗王,上級,し,首都が最北,Northernmost capital.,-
+106,国旗王,上級,は,排他的経済水域,Exclusive Economic Zone.,-
+107,国旗王,上級,く,軍事費が最小,Smallest military expenditure.,-
+108,国旗王,上級,へ,平均寿命が短い,Short average life expectancy.,-
+109,国旗王,初級,し,人口が多い,Large population.,-
+110,国旗王,初級,め,面積が最小,Smallest area.,-
+111,国旗王,初級,は,排他的経済水域が最小,Smallest Exclusive Economic Zone.,-
+112,国旗王,上級,さ,最高地点が高い,Highest point is high.,-
+113,国旗王,初級,こ,国内総生産GDPが低い,Low GDP.,-
+114,国旗王,初級,し,人口が少ない,Small population.,-
+115,国旗王,初級,せ,正式国名が長い,Long official country name.,-
+116,国旗王,上級,く,軍事費が大きい,Large military expenditure.,-
+117,国旗王,上級,さ,最高地点が低い,Highest point is low.,-
+118,国旗王,初級,こ,国内総生産GDPが高い,High GDP.,-
+119,国旗王,初級,せ,正式国名が短い,Short official country name.,-
+120,国旗王,初級,め,面積が大きい,Large area.,-
+121,国旗王,上級,へ,平均寿命が長い,Long average life expectancy.,-
+122,国旗王,初級,ひ,一人当たりGDPが低い,Low GDP per capita.,-
+123,国旗王,初級,し,人口密度が低い,Low population density.,-
+124,国旗王,初級,せ,正式国名 五十音順 アに近い,Official name closest to 'A' in Japanese syllabary.,-
+125,国旗王,初級,し,首都が最南,Southernmost capital.,-
+126,おばけかるた,-,ふ,ふでこぞうが　ひとふでがき,Fudekozo draws with a single stroke.,-
+127,おばけかるた,-,ね,ねこまたも　ねがおはかわいい,Even Nekomata looks cute when sleeping.,-
+128,おばけかるた,-,ち,ちょうちんぶらり　こっちへ　くるぞ,Chochin-burari is coming this way!,-
+129,おばけかるた,-,た,たまごがわれて　てんぐがうまれた,An egg cracked and a Tengu was born.,-
+130,おばけかるた,-,け,けむくじゃらな　うでだ　まけるな！,"It's a hairy arm, don't lose!",-
+131,おばけかるた,-,く,くずかごからくろいてが！！！　きゃっ！！！,A black hand from the wastebasket!!! Kya!!!,-
+132,おばけかるた,-,あ,あめふりこぞうが　びちゃびちゃあるく,Amefuri-kozo walks with a squish-squish.,-
+133,おばけかるた,-,ひ,ひとつめのくには　ひとつめだらけだってさ,They say the one-eyed country is full of one-eyes.,-
+134,おばけかるた,-,ぬ,ぬらりとわらう　ぬっぺっぽう,Nureppon smiles eerily.,-
+135,おばけかるた,-,つ,つきよにでていくつく　もがみ,Tsuku-mogami goes out on a moonlit night.,-
+136,おばけかるた,-,そ,そろってあるく　ぞうりのおばけ,Zori ghosts walk in pairs.,-
+137,おばけかるた,-,こ,こんばんは～　どろどろどろどろ～,Good evening~ Doro-doro-doro-doro~,-
+138,おばけかるた,-,き,きゅうびのきつねは　ばけるめいじん,The nine-tailed fox is a master of disguise.,-
+139,おばけかるた,-,い,いったんもめんは　そらとべていいなあ,"Ittan-momen, it's nice to fly in the sky.",-
+140,おばけかるた,-,は,はたらけはたらけ　おばけもはたらけ,"Work, work, ghosts also work.",-
+141,おばけかるた,-,に,にっこりわらう　にかいのおんな,The woman on the second floor smiles.,-
+142,おばけかるた,-,て,てんぐのはながおれては　かわいそう,It would be pitiful if Tengu's nose broke.,-
+143,おばけかるた,-,せ,せんすだって　すてればばける,Even a fan will transform if you throw it away.,-
+144,おばけかるた,-,さ,さかさくびは　ぺろぺろなめる,Sakasa-kubi licks with a flick-flick.,-
+145,おばけかるた,-,か,かあさんかっぱ　とこどものかっぱ,Mother Kappa and baby Kappa.,-
+146,おばけかるた,-,う,うみぼうずのがっこう　せいとをぼしゅう,Umibozu's school is recruiting students.,-
+147,おばけかるた,-,の,のんきなのぶすま　のんびりとんだ,Carefree Nobusuma flew leisurely.,-
+148,おばけかるた,-,な,なきなきかえった　ちいさなゆうれい,A small ghost returned crying.,-
+149,おばけかるた,-,と,とらがねてたら　かみなりどしーん！！,"If a tiger sleeps, lightning strikes with a boom!!",-
+150,おばけかるた,-,す,すりばちこぞうは　なにすってるの？,What is Suribachi-kozo grinding?,-
+151,おばけかるた,-,し,しろくてみえない　ゆきのひのゆうれい,A white and invisible ghost on a snowy day.,-
+152,おばけかるた,-,お,おにもおじいさんになる,Even an ogre grows old.,-
+153,おばけかるた,-,え,えだをもやしたら　えんえんらがでたぞ,"When I burned a branch, Enenra came out!",-
+154,おばけかるた,-,る,るすばんしてるは　ぶるぶるひとり,"Staying home alone, trembling.",-
+155,おばけかるた,-,り,りゅうがいねむり　そらからおちる,"A dragon sleeping, falling from the sky.",-
+156,おばけかるた,-,む,むじなもばけたが　ちょっとむりだった,"Mujina tried to transform, but it was a bit impossible.",-
+157,おばけかるた,-,み,みこしにゅうどう　みかけよりよわい,"Mikoshi-Nyudo, weaker than he looks.",-
+158,おばけかるた,-,れ,れいぎただしい　ゆうれいもいる,There are polite ghosts too.,-
+159,おばけかるた,-,ら,らしょうもんの　おにはらんぼうだ,The demon of Rashomon is wild.,-
+160,おばけかるた,-,め,めだまをとられた　ひとつめこぞう,A one-eyed monster whose eye was taken.,-
+161,おばけかるた,-,ま,まくらがえしは　まいばんうるさい,Makura-gaeshi is noisy every night.,-
+162,おばけかるた,-,ろ,ろくろくねなかった　ろくろっくび,Rokurokubi who didn't sleep at all.,-
+163,おばけかるた,-,よ,よみちをこわがる　よわむしにゅうどう,A timid Nyudo who is scared of night roads.,-
+164,おばけかるた,-,も,もりんじのかまは　たぬきがばけた,Morinji's kettle was a transformed raccoon dog.,-
+165,おばけかるた,-,ほ,ほうきのおばけは　ほめてやろう,Let's praise the broom ghost.,-
+166,おばけかるた,-,を,「あしをけして　てをまえに」ゆうれいのおけいこ,"Delete legs, hands forward - a ghost's practice.",-
+167,おばけかるた,-,わ,わ、にゅうどうだ　わぁーっこわい！,"Oh, it's a Nyudo! Ahh, scary!",-
+168,おばけかるた,-,ゆ,ゆきおんな　おゆにはいってとけちゃった,Yuki-onna went into hot water and melted.,-
+169,おばけかるた,-,や,やなぎのしたで　ゆうれいけんか,Ghosts fighting under a willow tree.,-
+170,おばけかるた,-,へ,へびよりこわい　ろくろっくび,"Rokurokubi, scarier than a snake.",-
+171,いろはかるた,-,ま,嘘から出たまこと,A lie can sometimes turn into the truth,-
+172,いろはかるた,-,こ,弘法にも筆の誤り,Even experts make mistakes,-
+173,いろはかるた,-,あ,得手に帆を揚げる,To take advantage of a good opportunity,-
+174,いろはかるた,-,あ,味なもの縁は異なもの,Romance works in mysterious ways,-
+175,いろはかるた,-,ぞ,芋の煮えたも御存じない,Completely clueless,-
+176,いろはかるた,-,て,文はやりたし書く手は持たぬ,Wanting to write a letter but lacking the skill,-
+177,いろはかるた,-,す,亭主の好きな赤烏帽子,One must go along with the head of the household,-
+178,いろはかるた,-,し,知らぬが仏,Ignorance is bliss,-
+179,いろはかるた,-,は,背に腹はかえられぬ,Needs must when driven,-
+180,いろはかるた,-,げ,芸は身を助ける,A skill will always help you,-
+181,いろはかるた,-,の,喉元過ぎれば熱さを忘れる,"Once the pain is gone, the lesson is forgotten",-
+182,いろはかるた,-,あ,頭隠して尻隠さず,Trying to hide something but failing,-
+183,いろはかるた,-,み,身から出た錆,You reap what you sow,-
+184,いろはかるた,-,も,門前の小僧習わぬ経を読む,You learn things naturally by exposure,-
+185,いろはかるた,-,お,鬼に金棒,Adding strength to the strong,-
+186,いろはかるた,-,ま,負けるが勝ち,Sometimes losing leads to winning,-
+187,いろはかるた,-,さ,三遍回って煙草にしょ,Take time and be careful,-
+188,いろはかるた,-,め,目の上のたん瘤,A thorn in one’s side,-
+189,いろはかるた,-,ひ,貧乏暇なし,The poor have no leisure,-
+190,いろはかるた,-,く,臭い物に蓋をする,To cover up an inconvenient truth,-
+191,いろはかるた,-,や,安物買いの銭失い,Buying cheap ends up costing more,-
+192,いろはかるた,-,き,聞いて極楽見て地獄,Hearing and seeing are very different,-
+193,いろはかるた,-,ゆ,油断大敵,Carelessness is dangerous,-
+194,いろはかるた,-,い,犬も歩けば棒に当たる,Every action brings some result,-
+195,いろはかるた,-,ら,楽あれば苦あり,Life has ups and downs,-
+196,いろはかるた,-,む,無理が通れば道理が引っ込む,"When force prevails, reason disappears",-
+197,いろはかるた,-,と,年寄りの冷や水,An old person acting recklessly,-
+198,いろはかるた,-,す,粋は身を食う,Showing off can ruin you,-
+199,いろはかるた,-,き,京の夢大阪の夢,Dreams are fleeting and strange,-
+200,いろはかるた,-,へ,下手の長談義,The unskilled talk the longest,-
+201,いろはかるた,-,ろ,論より証拠,Proof is better than argument,-
+202,いろはかるた,-,く,くたびれ儲け,All effort and no reward,-
+203,いろはかるた,-,に,憎まれっ子世にはばかる,The disliked often survive well,-
+204,いろはかるた,-,ち,塵も積もれば山となる,Many small things add up,-
+205,いろはかるた,-,こ,律義者の子だくさん,Honest people tend to have many children,-
+206,いろはかるた,-,ぬ,盗人の昼寝,Even bad acts have consequences,-
+207,いろはかるた,-,は,花より団子,Practicality over appearance,-
+208,いろはかるた,-,る,瑠璃も玻璃も照らせば光る,True talent shines anywhere,-
+209,いろはかるた,-,な,泣きっ面に蜂,Misfortune never comes alone,-
+210,いろはかるた,-,あ,葦の髄から天井のぞく,Judging the whole from a tiny part,-
+211,いろはかるた,-,か,蛙の面に水,Completely unfazed,-
+212,いろはかるた,-,わ,破れ鍋に綴じ蓋,Every pot has its lid,-
+213,いろはかるた,-,を,老いては子に従え,Let the younger generation lead,-
+214,いろはかるた,-,ね,念には念を入れよ,Double-check everything,-
+215,いろはかるた,-,た,旅は道連れ世は情け,Life is about helping each other,-
+216,いろはかるた,-,れ,良薬は口に苦し,Good medicine tastes bitter,-
+217,いろはかるた,-,そ,総領の甚六,The eldest son is often naive,-
+218,いろはかるた,-,つ,月とすっぽん,Like night and day,-
+219,いろはかるた（意味）,-,ま,でたらめに言ったことが、偶然にも事実になってしまうこと,A lie can sometimes turn into the truth,-
+220,いろはかるた（意味）,-,こ,どんな名人でも失敗することがあるというたとえ,Even experts make mistakes,-
+221,いろはかるた（意味）,-,あ,物事を行うのに絶好の機会を得ること,To take advantage of a good opportunity,-
+222,いろはかるた（意味）,-,あ,男女の仲は理屈では説明できないものだということ,Romance works in mysterious ways,-
+223,いろはかるた（意味）,-,ぞ,物事の様子がまったく分からない人をからかう言い方,Completely clueless,-
+224,いろはかるた（意味）,-,て,やりたい気持ちはあるが能力が伴わず困っていること,Wanting to write a letter but lacking the skill,-
+225,いろはかるた（意味）,-,す,家長の好みには家族も従うべきだという考え,One must go along with the head of the household,-
+226,いろはかるた（意味）,-,し,知らなければ悩まずにすむこともあるということ,Ignorance is bliss,-
+227,いろはかるた（意味）,-,は,大きな目的のためには多少の犠牲は仕方ないということ,Needs must when driven,-
+228,いろはかるた（意味）,-,げ,身につけた技や芸が困ったときに役立つこと,A skill will always help you,-
+229,いろはかるた（意味）,-,の,苦しい経験をしても時間がたつと忘れてしまうこと,"Once the pain is gone, the lesson is forgotten",-
+230,いろはかるた（意味）,-,あ,一部しか隠していないのに全部隠したつもりでいること,Trying to hide something but failing,-
+231,いろはかるた（意味）,-,み,自分のした悪い行いの結果で自分が苦しむこと,You reap what you sow,-
+232,いろはかるた（意味）,-,も,日頃見聞きしているうちに自然と身につくことがある,You learn things naturally by exposure,-
+233,いろはかるた（意味）,-,お,強いものがさらに力を得て一層強くなること,Adding strength to the strong,-
+234,いろはかるた（意味）,-,ま,一歩引いた方が結果的に有利になることがある,Sometimes losing leads to winning,-
+235,いろはかるた（意味）,-,さ,急がず慎重に行動することが大切だということ,Take time and be careful,-
+236,いろはかるた（意味）,-,め,自分にとって邪魔で目障りな存在のたとえ,A thorn in one’s side,-
+237,いろはかるた（意味）,-,ひ,貧しい人ほど仕事に追われ時間の余裕がないこと,The poor have no leisure,-
+238,いろはかるた（意味）,-,く,都合の悪いことを一時的に隠そうとすること,To cover up an inconvenient truth,-
+239,いろはかるた（意味）,-,や,安い物を買うとかえって損をすること,Buying cheap ends up costing more,-
+240,いろはかるた（意味）,-,き,聞くのと実際に見るのとでは大きな違いがあること,Hearing and seeing are very different,-
+241,いろはかるた（意味）,-,ゆ,油断すると失敗や災難を招くということ,Carelessness is dangerous,-
+242,いろはかるた（意味）,-,い,行動すれば良くも悪くも何かが起こるということ,Every action brings some result,-
+243,いろはかるた（意味）,-,ら,人生には楽しいことと苦しいことの両方がある,Life has ups and downs,-
+244,いろはかるた（意味）,-,む,無茶がまかり通る世の中では道理が通らなくなる,"When force prevails, reason disappears",-
+245,いろはかるた（意味）,-,と,年齢を考えず無理な振る舞いをすること,An old person acting recklessly,-
+246,いろはかるた（意味）,-,す,気取った振る舞いが身を滅ぼすことがある,Showing off can ruin you,-
+247,いろはかるた（意味）,-,き,夢というものはとりとめなく不思議なものだということ,Dreams are fleeting and strange,-
+248,いろはかるた（意味）,-,へ,下手な人ほど話が長くなること,The unskilled talk the longest,-
+249,いろはかるた（意味）,-,ろ,理屈よりも実際の証拠が大切だということ,Proof is better than argument,-
+250,いろはかるた（意味）,-,く,苦労したわりに何の得もないこと,All effort and no reward,-
+251,いろはかるた（意味）,-,に,憎まれるような人ほど世渡りがうまいこと,The disliked often survive well,-
+252,いろはかるた（意味）,-,ち,小さなことでも積み重なれば大きな成果になる,Many small things add up,-
+253,いろはかるた（意味）,-,こ,律義な人は家庭を大切にし子どもが多くなるという考え,Honest people tend to have many children,-
+254,いろはかるた（意味）,-,ぬ,どんな行いにも必ず報いがあるということ,Even bad acts have consequences,-
+255,いろはかるた（意味）,-,は,見た目より実利を重んじること,Practicality over appearance,-
+256,いろはかるた（意味）,-,る,才能のある人はどんな環境でも力を発揮する,True talent shines anywhere,-
+257,いろはかるた（意味）,-,な,不運なときにさらに不幸が重なること,Misfortune never comes alone,-
+258,いろはかるた（意味）,-,あ,わずかな知識で全て分かったつもりになること,Judging the whole from a tiny part,-
+259,いろはかるた（意味）,-,か,何をされても平然としていること,Completely unfazed,-
+260,いろはかるた（意味）,-,わ,どんな人にもふさわしい相手がいるということ,Every pot has its lid,-
+261,いろはかるた（意味）,-,を,年を取ったら若い者の意見に従うのがよい,Let the younger generation lead,-
+262,いろはかるた（意味）,-,ね,十分注意した上でさらに注意を重ねること,Double-check everything,-
+263,いろはかるた（意味）,-,た,人は助け合って生きていくものだということ,Life is about helping each other,-
+264,いろはかるた（意味）,-,れ,忠告は耳に痛いが自分のためになる,Good medicine tastes bitter,-
+265,いろはかるた（意味）,-,そ,長男は大事に育てられ世間知らずになりがちだということ,The eldest son is often naive,-
+266,いろはかるた（意味）,-,つ,似ているようで実際は大きな違いがある,Like night and day,-
+267,百人一首,-,あ,あきのたの かりほのいおの とまをあらみ わがころもでは つゆにぬれつつ,"In the autumn field, in the temporary hut's rough rush-mats, my sleeves are getting wet with dew.",-
+268,百人一首,-,あ,あきかぜに たなびくくもの たえまより もれいづるつきの かげのさやけさ,"Through the rifts in the clouds trailing in the autumn wind, how clear the moonlight leaks out.",-
+269,百人一首,-,あ,あしびきの やまどりのをの しだりをの ながながしよを ひとりかもねむ,"Must I sleep alone through the long, long night, like the long, trailing tail of the mountain pheasant?",-
+270,百人一首,-,あ,あまのはら ふりさけみれば かすがなる みかさのやまに いでしつきかも,"When I look out over the plain of heaven, is that the same moon that rose over Mount Mikasa in Kasuga?",-
+271,百人一首,-,あ,あわれとも いうべきひとは おもほえで みのいたずらに なりぬべきかな,"Since there is no one who might feel pity for me, I suppose I shall just pass away in vain.",-
+272,百人一首,-,い,いまはただ おもひたえなむ とばかりを ひとづてならで いうよしもがな,Now I just want to give up my love; if only I could tell you this directly and not through others.,-
+273,百人一首,-,い,いまこむと いいしばかりに ながつきの ありあけのつきを まちいでつるかな,"Just because you said 'I'll come soon', I have waited until the morning moon of the long month appeared.",-
+274,百人一首,-,い,いろはにほへど ちりぬるを わがよたれぞ つねならむ,"Though flowers are fragrant, they will fall; in our world, who can remain forever?",-
+275,百人一首,-,い,いのちながくは かたみにあはず ひとりして ものおもふよぞ ながかりける,"If I live long, we might not meet again; the night I spend alone in thought is so very long.",-
+276,百人一首,-,い,いにしへの ならのみやこの やへざくら けふここのへに にほひぬるかな,The eight-layered cherry blossoms of the ancient capital of Nara are fragrantly blooming today in the imperial palace.,-
+277,百人一首,-,う,うかりける ひとをはつせの やまおろしよ はげしかれとは いのらぬものを,"O mountain wind of Hatsuse, I did not pray for you to be so harsh, though she is cold to me.",-
+278,百人一首,-,う,うらみわび ほさぬそでだに あるものを こひにくちなむ なこそをしけれ,"I resent her and am weary; my sleeves never dry, and I fear my reputation will rot away in this love.",-
+279,百人一首,-,え,えにしあらば あはむとぞおもふ いざさらば わがなとひとは わすれざらなむ,"If there is fate, I believe we shall meet; now farewell, and may you not forget my name.",-
+280,百人一首,-,お,おおえやま いくののみちの とおければ まだふみもみず あまのはしだて,The road to Ikuno over Mount Oe is so far that I have seen neither a letter nor Amanohashidate.,-
+281,百人一首,-,お,おくやまに もみぢふみわけ なくしかの こゑきくときぞ あきはかなしき,"When I hear the voice of the stag crying as he steps through the maple leaves deep in the mountains, autumn is truly sad.",-
+282,百人一首,-,か,かささぎの わたせるはしに おくしもの しろきをみれば よぞふけにける,"When I see the white frost on the bridge the magpies are said to have spread, I know the night has deepened.",-
+283,百人一首,-,か,かぜをいたみ いはうつなみの おのれのみ くだけてものを おもふころかな,"Like the waves breaking against the rocks in the fierce wind, I alone am broken as I think of my love.",-
+284,百人一首,-,き,きみがため はるののにいでて わかなつむ わがころもでに ゆきはふりつつ,"For your sake, I went out to the spring fields to pick young greens, while snow fell on my sleeves.",-
+285,百人一首,-,き,きみがため をしからざりし いのちさへ ながくもがなと おもひけるかな,"For your sake, I did not value my life, but now I wish it would be long.",-
+286,百人一首,-,く,くさもきも いろかはれども わたつみの なみのはなにぞ あきなかりける,"Though the colors of plants and trees change, there is no autumn in the flowers of the sea waves.",-
+287,百人一首,-,く,くれなゐに みづくくるとは ききしかど あきぞこのはに まじりけるかな,"I heard that the water is dyed crimson, but it seems autumn has mixed into the leaves.",-
+288,百人一首,-,こ,こころあてに をらばやをらむ はつしもの おきまどはせる しらぎくのはな,"If I were to pick them at random, I might pick the white chrysanthemums that the first frost has confused.",-
+289,百人一首,-,こ,このたびは ぬさもとりあへず たむけやま もみぢのにしき かみのまにまに,"At this time, I could not even bring an offering; let the gods take the brocade of maple leaves on Mount Tamuke.",-
+290,百人一首,-,さ,さびしさに やどをたちいでて ながむれば いづこもおなじ あきのゆふぐれ,"In my loneliness, I leave my house and look out; everywhere it is the same autumn evening.",-
+291,百人一首,-,し,しのぶれど いろにいでにけり わがこひは ものやおもふと ひとのとふまで,"Though I try to hide it, my love shows in my face, until people ask if I am lost in thought.",-
+292,百人一首,-,す,すみのえの きしによるなみ よるさへや ゆめのかよひぢ ひとめよくらむ,"Like the waves approaching the shore of Suminoe, even at night do you avoid people's eyes on the dream path?",-
+293,百人一首,-,せ,せをはやみ いはにせかるる たきがはの われてもすゑに あはむとぞおもふ,"Like the river current split by a rock in the rapids, though divided, I know we shall meet in the end.",-
+294,百人一首,-,そ,そらしらぬ ゆきふみわけて いでつるは ひとつのえだに つるをたづねて,"I went out treading through the snow I didn't know, seeking a vine on a single branch.",-
+295,百人一首,-,た,たごのうらに うちいでてみれば しろたへの ふじのたかねに ゆきはふりつつ,"When I go out to the shore of Tago and look, snow is falling on the white peak of Mount Fuji.",-
+296,百人一首,-,ち,ちはやぶる かみよもきかず たつたがは からくれなゐに みづくくるとは,"Never heard of even in the age of the mighty gods, that the Tatsuta River is dyed in deep crimson.",-
+297,百人一首,-,つ,つくばねの みねよりおつる みなのがは こひぞつもりて ふちとなりぬる,"Like the Minano River falling from the peak of Tsukubane, my love has accumulated and become a deep pool.",-
+298,百人一首,-,て,てふことも いまはむかしに なりぬれば たがためにかは なにかうらみむ,"Since even that has become a thing of the past, for whose sake should I hold any resentment?",-
+299,百人一首,-,と,ともしびを かきたつるまも なつかしき いづれのよひに みえぬまにまに,"Even while trimming the lamp, I miss you; on which evening did I not see you?",-
+300,百人一首,-,な,ながからむ こころもしらず くろかみの みだれてけさは ものをこそおもへ,"Uncertain of how long his heart will stay,my black hair lies in disarray this morning and so, I am lost in troubled thoughts.",-
+301,百人一首,-,に,にしきなる ふくろにいれて いはざかり いづれのやまを こえぬとぞおもふ,I put it in a brocade bag; I wonder which mountain it crossed in its peak of silence.,-
+302,百人一首,-,ぬ,ぬさもとりあへず たむけやま もみぢのにしき かみのまにまに,I could not even bring an offering; let the gods take the brocade of maple leaves on Mount Tamuke.,-
+303,百人一首,-,ね,ねがはくは はなのしたにて はるしなむ そのきさらぎの もちづきのころ,"My wish is to die in spring under the flowers, around the time of the full moon in the second month.",-
+304,百人一首,-,の,のちのよを おもへばかろし ほととぎす あかつきかけて なきつるものを,"Thinking of the afterlife makes it seem light, while the cuckoo cries toward the dawn.",-
+305,百人一首,-,は,はるすぎて なつきにけらし しろたへの ころもほすてふ あまのかぐやま,Spring has passed and summer seems to have come; white robes are said to be dried on the heavenly Mount Kagu.,-
+306,百人一首,-,ひ,ひさかたの ひかりのどけき はるのひに しづこころなく はなのちるらむ,"On this spring day when the light is so calm, why do the cherry blossoms scatter with such unquiet hearts?",-
+307,百人一首,-,ふ,ふくからに あきのくさきの しをるれば むべやまかぜを あらしといふらむ,"Since the autumn plants and trees wither as soon as it blows, it is no wonder the mountain wind is called a storm.",-
+308,百人一首,-,へ,へにける いくよをかさね たまづさの ふみをひらけば こひぞつもりぬる,"As I open the letter after many passing nights, my love has truly accumulated.",-
+309,百人一首,-,ほ,ほととぎす なきつるかたを ながむれば ただありあけの つきぞのこれる,"When I look toward where the cuckoo cried, only the morning moon remains.",-
+310,百人一首,-,ま,まつとしき たかしのはまの あまごろも ぬれにぞぬれし いろはかはらず,"Waiting on the beach of Takashi, the fisher's robe got soaked and soaked, but its color remained unchanged.",-
+311,百人一首,-,み,みかのはら わきてながるる いづみがは いつみきとてか こひしかるらむ,"Like the Izumi River flowing through the plain of Mika, when did I see you that I should love you so?",-
+312,百人一首,-,む,むらさめの つゆもまだひぬ まきのはに きりたちのぼる あきのゆふぐれ,"Before the dew of the passing shower has dried on the fir leaves, the mist rises on an autumn evening.",-
+313,百人一首,-,め,めぐりあひて みしやそれとも わかぬまに くもがくれにし よはのつきかな,"Meeting by chance, before I could even tell if it was you, you were hidden by clouds like the midnight moon.",-
+314,百人一首,-,も,ももしきや ふるきのきばの しのぶにも なほあまりある むかしなりけり,"In the palace, even the ferns on the old eaves make me yearn for the past more than I can bear.",-
+315,百人一首,-,や,やすらはで ねなましものを さよふけて かたぶくまでの つきをみしかな,I should have gone to sleep without waiting; I watched the moon until it began to sink late at night.,-
+316,百人一首,-,ゆ,ゆらのとを わたるふなびと かぢをたえ ゆくへもしらぬ こひのみちかな,"Like a mariner crossing the Yura Strait with a lost oar, I know not where the path of my love leads.",-
+317,百人一首,-,よ,よをこめて とりのそらねは はかるとも よにあふさかの せきはゆるさじ,"Though you try to deceive with a bird's false cry in the dead of night, the gate of Osaka shall not let you pass.",-
+318,百人一首,-,ら,らいしやうの いのちのはてを しらぬまに けふをかぎりと おもひけるかな,"Not knowing the end of my life in the next world, I thought today would be the limit.",-
+319,百人一首,-,り,りくかぜの さむきにたへて みちのくの しのぶもぢずり たれゆゑにけむ,"Enduring the cold land wind, for whose sake was the tangled print of Michinoku's Shinobu?",-
+320,百人一首,-,る,るりのつぼ いづれのひとも すむらむと こころをかけし いろはみえず,"In the lapis lazuli jar where everyone might live, I cannot see the colors I set my heart on.",-
+321,百人一首,-,れ,れいよりも こころをつくせ さくらばな ちりぬるのちも にほひをこそ,"Exert your heart more than usual, cherry blossoms; even after you fall, leave your fragrance.",-
+322,百人一首,-,ろ,ろばたにて こまをつなぎて みるほどに はなぞちりける さくらかな,"While tethering my horse by the roadside, the cherry blossoms were scattering.",-
+323,百人一首,-,わ,わたのはら やそしまかけて こぎいでぬと ひとにはつげよ あまのつりぶね,"Tell the people that I have rowed out over the wide sea toward the many islands, O fisher's boat.",-
+324,百人一首,-,を,をぐらやま みねのもみぢば こころあらば いまひとたびの みゆきまたなむ,"O maple leaves on the peak of Mount Ogura, if you have a heart, wait for one more imperial visit.",-
+325,百人一首,-,ん,んにゃくにしゅう つねのことばを うたにして こころをつたふ みちぞたふとき,"Turning ordinary words into songs to convey the heart, the path is truly noble.",-
+326,大ピンチずかん,92,た,たからものいれが　あかない,I can't open treasure box.,-
+327,大ピンチずかん,1,が,がむを　のんだ,I swallowed gum.,-
+400,しょうがっこうかるた,-,あ,あさきたら あいさつしよう げんきよく,"When morning comes, greet cheerfully.",-
+401,しょうがっこうかるた,-,い,いねむりは たいちょうくずす はじまりだ,Dozing off is the start of feeling unwell.,-
+402,しょうがっこうかるた,-,う,うんどうで からだをきたえ よくねよう,Exercise your body and sleep well.,-
+403,しょうがっこうかるた,-,え,えがおでね すごせばみんな うれしいよ,"If you spend time smiling, everyone is happy.",-
+404,しょうがっこうかるた,-,お,おはようと げんきなこえで あいさつだ,Say good morning with a cheerful voice.,-
+405,しょうがっこうかるた,-,か,かさをさし あめのひだって たのしいよ,Even rainy days can be fun with an umbrella.,-
+406,しょうがっこうかるた,-,き,きちんとね つかったあとは かたづけよう,"After using things, tidy them properly.",-
+407,しょうがっこうかるた,-,く,くつぬいで そろえておけば きもちいい,Take off and line up your shoes neatly.,-
+408,しょうがっこうかるた,-,け,けいさんは あせらずゆっくり かくにんだ,Do calculations calmly and check carefully.,-
+409,しょうがっこうかるた,-,こ,こころには あんぜんまもる やくそくだ,Keep safety rules in your heart.,-
+410,しょうがっこうかるた,-,さ,さくらさく にゅうがくきせつ はるがきた,Cherry blossoms bloom—spring and school begin.,-
+411,しょうがっこうかるた,-,し,しゃべらずに どうろをあるこう あぶないよ,Walk quietly on roads—it’s dangerous otherwise.,-
+412,しょうがっこうかるた,-,す,すきなもの ちゃんとえらんで たいせつに,Choose what you like and value it.,-
+413,しょうがっこうかるた,-,せ,せいりして つかえばいつも きもちいい,Keep things organized and feel good.,-
+414,しょうがっこうかるた,-,そ,そうじして みんなできれいに しようね,Let’s all clean and make it neat.,-
+415,しょうがっこうかるた,-,た,たのしいね みんなであそぶと えがおさく,Playing together brings smiles.,-
+416,しょうがっこうかるた,-,ち,ちいさくても ルールまもれば りっぱだよ,Even small acts matter if you follow rules.,-
+417,しょうがっこうかるた,-,つ,つかうもの たいせつにして ながくつかう,Take care of things and use them long.,-
+418,しょうがっこうかるた,-,て,てをあらい きれいにすれば びょうきよぼう,Wash your hands to prevent illness.,-
+419,しょうがっこうかるた,-,と,ともだちと なかよくすごす がっこうだ,School is for getting along with friends.,-
+420,しょうがっこうかるた,-,な,なかよくね けんかしないで すごそうよ,Let’s get along without fighting.,-
+421,しょうがっこうかるた,-,に,にこにこと えがおであいさつ きもちいい,Smiling greetings feel good.,-
+422,しょうがっこうかるた,-,ぬ,ぬいだくつ そろえておけば きれいだね,Neatly arranged shoes look nice.,-
+423,しょうがっこうかるた,-,ね,ねるまえに あしたのじゅんび しておこう,Prepare for tomorrow before sleeping.,-
+424,しょうがっこうかるた,-,の,のこさずに きゅうしょくたべて げんきだよ,Eat your lunch fully to stay healthy.,-
+425,しょうがっこうかるた,-,は,はやおきで こころもからだも げんきだよ,Waking early keeps you healthy.,-
+426,しょうがっこうかるた,-,ひ,ひとりでも できることから がんばろう,"Do what you can, even alone.",-
+427,しょうがっこうかるた,-,ふ,ふざけずに じゅぎょううけよう しっかりと,Take class seriously without fooling around.,-
+428,しょうがっこうかるた,-,へ,へやのなか きれいにすれば きもちいい,A clean room feels nice.,-
+429,しょうがっこうかるた,-,ほ,ほんをよみ こころをそだて かしこくね,Read books to grow your mind.,-
+430,しょうがっこうかるた,-,ま,まいにちを たいせつにして すごそうね,Cherish each day.,-
+431,しょうがっこうかるた,-,み,みんなでね ちからをあわせ がんばろう,Let’s work together.,-
+432,しょうがっこうかるた,-,む,むりしない じぶんのペースで すすもうね,Go at your own pace.,-
+433,しょうがっこうかるた,-,め,めあてもち がくしゅうすれば ちからつく,Study with goals to improve.,-
+434,しょうがっこうかるた,-,も,ものはね たいせつにして つかおうね,Take care of your belongings.,-
+435,しょうがっこうかるた,-,や,やくそくを まもればみんな しんらいだ,Keeping promises builds trust.,-
+436,しょうがっこうかるた,-,ゆ,ゆっくりと あせらずいこう だいじょうぶ,"Take it slow, no need to rush.",-
+437,しょうがっこうかるた,-,よ,よるふかし しないでねむろう はやめにね,"Don’t stay up late, sleep early.",-
+438,しょうがっこうかるた,-,ら,らくがきは してはいけない たいせつに,Don’t scribble—respect things.,-
+439,しょうがっこうかるた,-,り,りゆうある こうどうすれば せいちょうだ,Act with purpose to grow.,-
+440,しょうがっこうかるた,-,る,ルールまもり みんながたのしく すごせるよ,Follow rules so everyone enjoys.,-
+441,しょうがっこうかるた,-,れ,れいぎよく あいさつできる いいこだね,Polite greetings are great.,-
+442,しょうがっこうかるた,-,ろ,ろうかでは はしらずあるこう あんぜんに,Walk in hallways safely.,-
+443,しょうがっこうかるた,-,わ,わすれもの しないようにね かくにんだ,Check so you don’t forget things.,-
+444,しょうがっこうかるた,-,を,しゅくだいを きちんとやろう わすれずに,Do your homework properly without forgetting.,-
+445,しょうがっこうかるた,-,ん,さんかんび パパやママは みてるかな,"On open school day, I wonder if mom and dad are watching.",-
+1001,HTTPステータスコードかるた,-,よ,要求は成功しました,The request succeeded.,200 OK
+1002,HTTPステータスコードかるた,-,あ,新しいリソースが作成されました,A new resource has been created.,201 Created
+1003,HTTPステータスコードかるた,-,し,処理は成功したが返す内容がない,The request succeeded but there is no content to return.,204 No Content
+1004,HTTPステータスコードかるた,-,り,リソースが恒久的に移動した,The resource has permanently moved.,301 Moved Permanently
+1005,HTTPステータスコードかるた,-,り,リソースが一時的に移動した,The resource has temporarily moved.,302 Found
+1006,HTTPステータスコードかるた,-,き,キャッシュされた内容が更新されていない,The cached content has not changed.,304 Not Modified
+1007,HTTPステータスコードかるた,-,り,リクエストの形式が正しくない,The request is malformed.,400 Bad Request
+1008,HTTPステータスコードかるた,-,に,認証が必要です,Authentication is required.,401 Unauthorized
+1009,HTTPステータスコードかるた,-,に,認証は済んでいるが権限がありません,"Authenticated, but not authorized to access this resource.",403 Forbidden
+1010,HTTPステータスコードかるた,-,り,リソースが見つかりません,The requested resource was not found.,404 Not Found
+1011,HTTPステータスコードかるた,-,き,許可されていないHTTPメソッドが使われた,The HTTP method used is not allowed.,405 Method Not Allowed
+1012,HTTPステータスコードかるた,-,り,リクエストが時間内に完了しなかった,The request timed out.,408 Request Timeout
+1013,HTTPステータスコードかるた,-,り,リソースの状態が競合している,The request conflicts with the current state of the resource.,409 Conflict
+1014,HTTPステータスコードかるた,-,り,リソースは存在したが今は削除された,The resource existed but has since been deleted.,410 Gone
+1015,HTTPステータスコードかるた,-,そ,送信データが大きすぎる,The request payload is too large.,413 Payload Too Large
+1016,HTTPステータスコードかるた,-,た,対応していない形式のデータが送られた,The media type of the request is not supported.,415 Unsupported Media Type
+1017,HTTPステータスコードかるた,-,こ,構文は正しいが内容を処理できない,The request is well-formed but cannot be processed.,422 Unprocessable Entity
+1018,HTTPステータスコードかるた,-,た,短時間にリクエストを送りすぎた,Too many requests were sent in a short time.,429 Too Many Requests
+1019,HTTPステータスコードかるた,-,さ,サーバー内部で予期しないエラーが発生した,An unexpected error occurred on the server.,500 Internal Server Error
+1020,HTTPステータスコードかるた,-,さ,サーバーがその機能に対応していない,The server does not support the requested functionality.,501 Not Implemented
+1021,HTTPステータスコードかるた,-,じ,上流サーバーから不正な応答を受け取った,Received an invalid response from an upstream server.,502 Bad Gateway
+1022,HTTPステータスコードかるた,-,さ,サーバーが一時的に利用できない,The server is temporarily unavailable.,503 Service Unavailable
+1023,HTTPステータスコードかるた,-,じ,上流サーバーからの応答が時間内に来なかった,Did not receive a timely response from an upstream server.,504 Gateway Timeout
+1101,Linuxコマンドかるた,-,で,ディレクトリ一覧を表示する,Display a list of directory contents.,ls
+1102,Linuxコマンドかるた,-,げ,現在のディレクトリを表示する,Display the current directory.,pwd
+1103,Linuxコマンドかるた,-,で,ディレクトリを移動する,Change the current directory.,cd
+1104,Linuxコマンドかるた,-,あ,新しいディレクトリを作成する,Create a new directory.,mkdir
+1105,Linuxコマンドかるた,-,か,空のディレクトリを削除する,Remove an empty directory.,rmdir
+1106,Linuxコマンドかるた,-,ふ,ファイルを削除する,Delete a file.,rm
+1107,Linuxコマンドかるた,-,ふ,ファイルをコピーする,Copy a file.,cp
+1108,Linuxコマンドかるた,-,ふ,ファイルを移動する、または名前を変更する,Move or rename a file.,mv
+1109,Linuxコマンドかるた,-,か,空のファイルを作成する、タイムスタンプを更新する,Create an empty file or update its timestamp.,touch
+1110,Linuxコマンドかるた,-,ふ,ファイルの内容を表示する,Display the contents of a file.,cat
+1111,Linuxコマンドかるた,-,ふ,ファイルを検索する,Search for files.,find
+1112,Linuxコマンドかるた,-,ふ,ファイルの中から文字列を検索する,Search for a string within files.,grep
+1113,Linuxコマンドかるた,-,ふ,ファイルの権限を変更する,Change file permissions.,chmod
+1114,Linuxコマンドかるた,-,ふ,ファイルの所有者を変更する,Change file ownership.,chown
+1115,Linuxコマンドかるた,-,じ,実行中のプロセスを表示する,Display running processes.,ps
+1116,Linuxコマンドかるた,-,ぷ,プロセスを終了させる,Terminate a process.,kill
+1117,Linuxコマンドかるた,-,し,システムのリソース使用状況をリアルタイムで表示する,Display real-time system resource usage.,top
+1118,Linuxコマンドかるた,-,で,ディスクの空き容量を表示する,Display free disk space.,df
+1119,Linuxコマンドかるた,-,ふ,ファイルやディレクトリのサイズを表示する,Display the size of files or directories.,du
+1120,Linuxコマンドかるた,-,ふ,複数のファイルをひとつにまとめて圧縮・展開する,Archive or extract multiple files.,tar
+1121,Linuxコマンドかるた,-,べ,別のサーバーにリモートでログインする,Log in to a remote server.,ssh
+1122,Linuxコマンドかるた,-,さ,サーバー間でファイルを安全にコピーする,Securely copy files between servers.,scp
+1123,Linuxコマンドかるた,-,ゆ,URLを指定してデータを送受信する,Transfer data to or from a URL.,curl
+1124,Linuxコマンドかるた,-,ゆ,URLからファイルをダウンロードする,Download a file from a URL.,wget
+1125,Linuxコマンドかるた,-,こ,コマンドの使い方を調べる,Look up how to use a command.,man
+1126,Linuxコマンドかるた,-,こ,これまでに実行したコマンドの履歴を表示する,Display the history of executed commands.,history
+1127,Linuxコマンドかるた,-,も,文字列を画面に出力する,Print a string to the screen.,echo
+1128,Linuxコマンドかるた,-,ふ,ファイルの内容をスクロールしながら表示する,View a file's contents one screen at a time.,less
+1129,Linuxコマンドかるた,-,ふ,ファイルの先頭部分を表示する,Display the beginning of a file.,head
+1130,Linuxコマンドかるた,-,ふ,ファイルの末尾部分を表示する,Display the end of a file.,tail
+1131,Linuxコマンドかるた,-,ぎ,行を並び替える,Sort lines of text.,sort
+1132,Linuxコマンドかるた,-,じ,重複する行を取り除く,Remove duplicate adjacent lines.,uniq
+1133,Linuxコマンドかるた,-,ぎ,行数や単語数、文字数を数える,"Count lines, words, and characters.",wc
+1134,Linuxコマンドかるた,-,ふ,ファイルのリンクを作成する,Create a link to a file.,ln
+1135,Linuxコマンドかるた,-,こ,コマンドに別名をつける,Define a shortcut name for a command.,alias
+1136,Linuxコマンドかるた,-,か,環境変数を設定する,Set an environment variable.,export
+1137,Linuxコマンドかるた,-,か,管理者権限でコマンドを実行する,Run a command with administrator privileges.,sudo
+1138,Linuxコマンドかるた,-,こ,コマンドの実行ファイルの場所を調べる,Find the location of a command's executable.,which
+1139,Linuxコマンドかるた,-,げ,現在ログインしているユーザー名を表示する,Display the current logged-in user name.,whoami
+1140,Linuxコマンドかるた,-,こ,コンピュータのホスト名を表示する,Display the computer's host name.,hostname
+1201,Gitかるた,-,あ,新しいリポジトリを作成する,Create a new repository.,git init
+1202,Gitかるた,-,き,既存のリポジトリを複製する,Clone an existing repository.,git clone
+1203,Gitかるた,-,へ,変更をステージングする,Stage changes.,git add
+1204,Gitかるた,-,へ,変更をコミットする,Commit changes.,git commit
+1205,Gitかるた,-,ろ,ローカルの変更をリモートに送る,Push local changes to a remote.,git push
+1206,Gitかるた,-,り,リモートの変更を取得して取り込む,Fetch and merge changes from a remote.,git pull
+1207,Gitかるた,-,り,リモートの変更情報だけを取得する,Fetch changes from a remote without merging.,git fetch
+1208,Gitかるた,-,さ,作業ディレクトリの状態を確認する,Check the status of the working directory.,git status
+1209,Gitかるた,-,へ,変更の差分を確認する,Show changes between commits or the working directory.,git diff
+1210,Gitかるた,-,こ,コミットの履歴を表示する,Show commit history.,git log
+1211,Gitかるた,-,ぶ,ブランチを作成・一覧表示する,Create or list branches.,git branch
+1212,Gitかるた,-,ぶ,ブランチやファイルの状態を切り替える,Switch branches or restore files.,git checkout
+1213,Gitかるた,-,ぶ,ブランチを切り替える,Switch branches.,git switch
+1214,Gitかるた,-,べ,別のブランチの変更を取り込む,Merge changes from another branch.,git merge
+1215,Gitかるた,-,こ,コミットの履歴を別のベースに付け替える,Reapply commits on top of another base.,git rebase
+1216,Gitかるた,-,さ,作業内容を一時退避する,Temporarily shelve changes.,git stash
+1217,Gitかるた,-,こ,コミットやステージングの状態を戻す,Undo commits or staged changes.,git reset
+1218,Gitかるた,-,か,過去のコミットを打ち消す新しいコミットを作る,Create a new commit that undoes a past commit.,git revert
+1219,Gitかるた,-,こ,コミットに目印となるタグを付ける,Mark a commit with a tag.,git tag
+1220,Gitかるた,-,り,リモートリポジトリの情報を管理する,Manage remote repository information.,git remote
+1221,Gitかるた,-,ぎ,Gitの設定を変更する,Change Git configuration.,git config
+1222,Gitかるた,-,と,特定のコミットだけを取り込む,Apply a specific commit onto the current branch.,git cherry-pick
+1223,Gitかるた,-,か,各行を最後に変更した人を調べる,Find out who last modified each line.,git blame
+1224,Gitかるた,-,こ,コミットの詳細な内容を表示する,Show the details of a commit.,git show
+1225,Gitかるた,-,ふ,ファイルを削除してその変更を記録する,Delete a file and stage the removal.,git rm
+1301,SQLかるた,-,し,取得する列を指定する,Specify which columns to retrieve.,SELECT
+1302,SQLかるた,-,で,データを取得するテーブルを指定する,Specify the table to retrieve data from.,FROM
+1303,SQLかるた,-,じ,条件に一致するデータを取得する,Retrieve data that matches a condition.,WHERE
+1304,SQLかるた,-,し,指定した列の値でグループ化する,Group rows by the values of specified columns.,GROUP BY
+1305,SQLかるた,-,ぐ,グループ化した後の結果に条件をつける,Filter results after grouping.,HAVING
+1306,SQLかるた,-,け,結果を並び替える,Sort the results.,ORDER BY
+1307,SQLかるた,-,し,取得する件数を制限する,Limit the number of rows returned.,LIMIT
+1308,SQLかるた,-,い,一致する行だけを複数テーブルから結合する,"Join tables, returning only matching rows.",INNER JOIN
+1309,SQLかるた,-,ひ,左側のテーブルを基準に結合する,"Join tables, keeping all rows from the left table.",LEFT JOIN
+1310,SQLかるた,-,み,右側のテーブルを基準に結合する,"Join tables, keeping all rows from the right table.",RIGHT JOIN
+1311,SQLかるた,-,り,両方のテーブルの行をすべて結合する,"Join tables, keeping all rows from both tables.",FULL OUTER JOIN
+1312,SQLかるた,-,ふ,複数の検索結果を縦に結合する,Combine the results of multiple queries.,UNION
+1313,SQLかるた,-,じ,重複を除外する,Exclude duplicate rows.,DISTINCT
+1314,SQLかるた,-,あ,新しい行を追加する,Insert a new row.,INSERT INTO
+1315,SQLかるた,-,き,既存の行を更新する,Update existing rows.,UPDATE
+1316,SQLかるた,-,ぎ,行を削除する,Delete rows.,DELETE
+1317,SQLかるた,-,あ,新しいテーブルを作成する,Create a new table.,CREATE TABLE
+1318,SQLかるた,-,て,テーブルの構造を変更する,Modify a table's structure.,ALTER TABLE
+1319,SQLかるた,-,て,テーブルを削除する,Delete a table.,DROP TABLE
+1320,SQLかるた,-,ぎ,行を一意に識別する列を指定する,Designate a column that uniquely identifies each row.,PRIMARY KEY
+1321,SQLかるた,-,ほ,他のテーブルの行を参照する制約,A constraint that references a row in another table.,FOREIGN KEY
+1322,SQLかるた,-,あ,値が存在しないことを表す,Represents the absence of a value.,NULL
+1323,SQLかるた,-,し,指定した範囲内のデータを取得する,Retrieve data within a specified range.,BETWEEN
+1324,SQLかるた,-,も,文字列のパターンに一致するか調べる,Check whether a string matches a pattern.,LIKE
+1325,SQLかるた,-,ふ,複数の値のいずれかに一致するか調べる,Check whether a value matches any in a list.,IN
+1326,SQLかるた,-,ぎ,行数を数える,Count the number of rows.,COUNT
+1327,SQLかるた,-,あ,値の合計を求める,Calculate the sum of values.,SUM
+1328,SQLかるた,-,あ,値の平均を求める,Calculate the average of values.,AVG
+1329,SQLかるた,-,れ,列やテーブルに別名をつける,Give a column or table an alias.,AS
+1330,SQLかるた,-,じ,条件によって異なる値を返す,Return different values depending on a condition.,CASE WHEN
+1331,SQLかるた,-,へ,変更をデータベースに確定する,Commit changes to the database.,COMMIT
+1332,SQLかるた,-,へ,変更を取り消して元に戻す,Undo changes and revert to the previous state.,ROLLBACK
+1401,AWSかるた,-,さ,サーバレスでコードを実行する,Run code without managing servers.,Lambda
+1402,AWSかるた,-,お,オブジェクトストレージ,Object storage.,S3
+1403,AWSかるた,-,の,NoSQLデータベース,A NoSQL database.,DynamoDB
+1404,AWSかるた,-,か,仮想サーバーを提供する,Provides virtual servers.,EC2
+1405,AWSかるた,-,ま,マネージドなリレーショナルデータベース,A managed relational database.,RDS
+1406,AWSかるた,-,か,仮想的なネットワーク環境を作る,Create an isolated virtual network.,VPC
+1407,AWSかるた,-,ゆ,ユーザーや権限を管理する,Manage users and permissions.,IAM
+1408,AWSかるた,-,こ,コンテンツ配信網(CDN)サービス,A content delivery network (CDN) service.,CloudFront
+1409,AWSかるた,-,で,DNSサービス,A DNS service.,Route 53
+1410,AWSかるた,-,え,APIの作成・公開・管理を行う,"Create, publish, and manage APIs.",API Gateway
+1411,AWSかるた,-,め,メッセージを溜めておくキューサービス,A queue service for storing messages.,SQS
+1412,AWSかるた,-,め,メッセージを配信する通知サービス,A notification service for delivering messages.,SNS
+1413,AWSかるた,-,り,リソースの監視やログ収集を行う,Monitor resources and collect logs.,CloudWatch
+1414,AWSかるた,-,い,インフラをコードで構築・管理する,Provision and manage infrastructure as code.,CloudFormation
+1415,AWSかるた,-,こ,コンテナを管理・実行するサービス,A service for managing and running containers.,ECS
+1416,AWSかるた,-,ま,マネージドなKubernetesサービス,A managed Kubernetes service.,EKS
+1417,AWSかるた,-,さ,サーバー管理が不要なコンテナ実行環境,A serverless container runtime that needs no server management.,Fargate
+1418,AWSかるた,-,あ,アプリケーションのデプロイを簡単にする,Simplifies application deployment.,Elastic Beanstalk
+1419,AWSかるた,-,ふ,負荷に応じてサーバー台数を自動調整する,Automatically adjusts server count based on load.,Auto Scaling
+1420,AWSかるた,-,つ,通信を複数サーバーに振り分ける,Distributes traffic across multiple servers.,Elastic Load Balancing
+1421,AWSかるた,-,で,データを抽出・変換・ロードするETLサービス,"An ETL service for extracting, transforming, and loading data.",Glue
+1422,AWSかるた,-,え,S3のデータをSQLで分析する,Analyze data in S3 using SQL.,Athena
+1423,AWSかるた,-,た,大量のストリーミングデータを処理する,Process large volumes of streaming data.,Kinesis
+1424,AWSかるた,-,ふ,複数のサービスをワークフローでつなぐ,Coordinate multiple services into a workflow.,Step Functions
+1425,AWSかるた,-,ゆ,ユーザーの認証や認可を管理する,Manage user authentication and authorization.,Cognito
+1426,AWSかるた,-,ぱ,パスワードなどの機密情報を管理する,Manage secrets such as passwords.,Secrets Manager
+1427,AWSかるた,-,び,ビルドからデプロイまでを自動化する,Automate the process from build to deployment.,CodePipeline
+1428,AWSかるた,-,い,EC2にアタッチするブロックストレージ,Block storage attached to EC2 instances.,EBS
+1429,AWSかるた,-,た,高い性能を持つマネージドリレーショナルDB,A high-performance managed relational database.,Aurora
+1430,AWSかるた,-,だ,大規模なデータウェアハウス,A large-scale data warehouse.,Redshift
+1501,Javaかるた,-,ぬ,Null参照時に発生する例外,An exception thrown when dereferencing a null reference.,NullPointerException
+1502,Javaかるた,-,に,入出力で発生する例外,An exception thrown for input/output failures.,IOException
+1503,Javaかるた,-,き,キーと値を保持するコレクション,A collection that holds key-value pairs.,HashMap
+1504,Javaかるた,-,は,配列の範囲外にアクセスした時の例外,An exception thrown when accessing an array out of bounds.,ArrayIndexOutOfBoundsException
+1505,Javaかるた,-,し,指定したクラスが見つからない時の例外,An exception thrown when a specified class cannot be found.,ClassNotFoundException
+1506,Javaかるた,-,も,文字列を数値に変換できない時の例外,An exception thrown when a string cannot be converted to a number.,NumberFormatException
+1507,Javaかるた,-,ふ,不正な引数が渡された時の例外,An exception thrown when an invalid argument is passed.,IllegalArgumentException
+1508,Javaかるた,-,お,オブジェクトの状態が不正な時の例外,An exception thrown when an object is in an invalid state.,IllegalStateException
+1509,Javaかるた,-,ぜ,0で割るなど算術エラー時の例外,An exception thrown for arithmetic errors such as division by zero.,ArithmeticException
+1510,Javaかるた,-,る,ループ中にコレクションを変更した時の例外,An exception thrown when a collection is modified during iteration.,ConcurrentModificationException
+1511,Javaかるた,-,め,メモリ不足で発生するエラー,An error thrown when the JVM runs out of memory.,OutOfMemoryError
+1512,Javaかるた,-,さ,再帰呼び出しが深すぎて発生するエラー,An error thrown when recursive calls go too deep.,StackOverflowError
+1513,Javaかるた,-,か,可変長の配列のようなコレクション,A resizable array-like collection.,ArrayList
+1514,Javaかるた,-,よ,要素を連結して保持するリスト,A list that holds elements as a linked sequence.,LinkedList
+1515,Javaかるた,-,じ,重複を許さないコレクション,A collection that does not allow duplicate elements.,HashSet
+1516,Javaかるた,-,き,キーで自動的に並び替えられるマップ,A map that is automatically sorted by its keys.,TreeMap
+1517,Javaかるた,-,も,文字列を効率的に組み立てるクラス,A class for efficiently building strings.,StringBuilder
+1518,Javaかるた,-,あ,値が存在しないかもしれないことを表すクラス,A class representing a value that may or may not be present.,Optional
+1519,Javaかるた,-,こ,コレクションを関数的に処理するAPI,An API for processing collections in a functional style.,Stream
+1520,Javaかるた,-,め,メソッドの仕様だけを定義する型,A type that defines only method signatures.,Interface
+1521,Javaかるた,-,い,一部だけ実装したクラス,A class that is only partially implemented.,Abstract Class
+1522,Javaかるた,-,か,型を汎用的に扱う仕組み,A mechanism for handling types generically.,Generics
+1523,Javaかるた,-,れ,例外処理を記述する構文,Syntax for handling exceptions.,try-catch-finally
+1524,Javaかるた,-,ふ,複数スレッドからの同時アクセスを制御する,Controls concurrent access from multiple threads.,synchronized
+1525,Javaかるた,-,へ,並行して処理を実行する単位,A unit of execution that runs concurrently.,Thread
+1526,Javaかるた,-,お,親クラスのメソッドを子クラスで上書きする,Overrides a parent class's method in a subclass.,Override
+1527,Javaかるた,-,お,オブジェクトの等価性を判定する仕組み,A mechanism for determining object equality.,equals/hashCode
+1528,Javaかるた,-,あ,値や継承を変更不可にするキーワード,A keyword that makes a value or inheritance unchangeable.,final
+1529,Javaかるた,-,い,インスタンスに依存しないメンバーを定義するキーワード,A keyword for defining members that don't depend on an instance.,static
+1601,コードレビューかるた,-,お,同じコードが複数箇所に存在する,The same code exists in multiple places.,DRY原則
+1602,コードレビューかるた,-,へ,変数名から役割が分からない,It's unclear what a variable does from its name.,可読性
+1603,コードレビューかるた,-,ひ,1つのメソッドが長すぎる,A single method is too long.,単一責任の原則
+1604,コードレビューかるた,-,い,意味のわからない数値が直接書かれている,An unexplained number is hard-coded directly in the code.,マジックナンバー
+1605,コードレビューかるた,-,じ,条件分岐が何重にも入れ子になっている,Conditional branches are nested many levels deep.,ネストが深い
+1606,コードレビューかるた,-,へ,変数名やクラス名のつけ方が統一されていない,Variable and class naming is inconsistent.,命名規則違反
+1607,コードレビューかるた,-,じ,重要な処理にテストが書かれていない,Critical logic has no tests.,テストカバレッジ不足
+1608,コードレビューかるた,-,せ,設定値がコード中に直接埋め込まれている,Configuration values are embedded directly in the code.,ハードコーディング
+1609,コードレビューかるた,-,き,catchした例外を何もせず無視している,A caught exception is silently ignored.,例外の握りつぶし
+1610,コードレビューかるた,-,ど,どこからでも書き換えられる変数を多用している,Overuse of variables that can be modified from anywhere.,グローバル変数の濫用
+1611,コードレビューかるた,-,ふ,複雑な処理の意図が説明されていない,The intent behind complex logic is not explained.,コメント不足
+1612,コードレビューかるた,-,お,同じロジックが何箇所にもコピーされている,The same logic is copy-pasted in many places.,重複コード
+1613,コードレビューかるた,-,じ,条件を満たしたらすぐに関数を抜けず深く入れ子にしている,"Doesn't exit early when a condition is met, leading to deep nesting.",早期return
+1614,コードレビューかるた,-,な,名前から想像できない値の変更を行う関数,A function that changes values in ways its name doesn't suggest.,副作用のある関数
+1615,コードレビューかるた,-,く,クラス同士が内部実装に強く依存している,Classes depend heavily on each other's internal implementation.,密結合
+1616,コードレビューかるた,-,よ,呼び出されない不要なコードが残っている,Unused code that is never called remains in the codebase.,デッドコード
+1617,コードレビューかるた,-,ゆ,ユーザー入力をそのままSQLに組み込んでいる,User input is embedded directly into SQL without sanitization.,SQLインジェクション脆弱性
+1618,コードレビューかるた,-,つ,使われていないモジュールが読み込まれている,Unused modules are imported.,不要なimport
+1619,コードレビューかるた,-,え,エラー発生時に原因を追えるログがない,There are no logs to trace the cause when an error occurs.,ログ出力不足
+1620,コードレビューかるた,-,に,入力値の検証が行われていない,Input values are not validated.,バリデーション漏れ
+1621,コードレビューかるた,-,へ,並行処理の実行順序によって結果が変わる不具合,A bug where the result depends on the timing of concurrent execution.,レースコンディション
+1622,コードレビューかるた,-,し,将来使うかもしれない機能を先に作り込んでいる,Building functionality preemptively for hypothetical future use.,過剰な抽象化

--- a/backend/seed.js
+++ b/backend/seed.js
@@ -53,6 +53,7 @@ async function seed() {
         kana: record.kana ? record.kana.trim() : "-",
         phrase: record.phrase ? record.phrase.trim() : "",
         phrase_en: record.phrase_en ? record.phrase_en.trim() : "",
+        answer: record.answer ? record.answer.trim() : "-",
         readCount: existingItem ? existingItem.readCount : 0,
         averageTime: existingItem ? existingItem.averageTime : 0,
         averageDifficulty: existingItem ? (existingItem.averageDifficulty || 0) : 0


### PR DESCRIPTION
クイズ形式のテーマ向けにanswer列をphrases.csvに追加し、既存行は後方互換のため"-"を補完。新テーマは将来の追加に備えテーマごと100番台のIDブロックを割り当て、既存IDは変更していない。