### PR TITLE
feat(frontend): 絵札印刷画面を追加

### DIFF
--- a/backend/handler.js
+++ b/backend/handler.js
@@ -378,7 +378,7 @@ exports.getPhrasesList = async (event) => {
         ExpressionAttributeValues: {
           ":cat": category,
         },
-        ProjectionExpression: "id, category, phrase, #lvl, kana, readCount, averageTime, averageDifficulty",
+        ProjectionExpression: "id, category, phrase, #lvl, kana, answer, readCount, averageTime, averageDifficulty",
         ExpressionAttributeNames: {
           "#lvl": "level",
         },
@@ -388,7 +388,7 @@ exports.getPhrasesList = async (event) => {
     } else {
       const scanParams = {
         TableName: process.env.TABLE_NAME,
-        ProjectionExpression: "id, category, phrase, #lvl, kana, readCount, averageTime, averageDifficulty",
+        ProjectionExpression: "id, category, phrase, #lvl, kana, answer, readCount, averageTime, averageDifficulty",
         ExpressionAttributeNames: {
           "#lvl": "level",
         },

--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -86,23 +86,41 @@ describe('getPhrasesList', () => {
           { id: '3', category: 'Category1' },
         ],
       });
-  
+
       const event = {
         queryStringParameters: {
           category: 'Category1',
         },
       };
-  
+
       const response = await getPhrasesList(event);
       const body = JSON.parse(response.body);
-  
+
       expect(response.statusCode).toBe(200);
       expect(body.phrases).toEqual([
         { id: '1', category: 'Category1' },
         { id: '3', category: 'Category1' },
       ]);
     });
-  
+
+    it('should request the answer field for the efuda print view (category query)', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+      await getPhrasesList({ queryStringParameters: { category: 'Category1' } });
+
+      const call = ddbMock.commandCalls(QueryCommand)[0];
+      expect(call.args[0].input.ProjectionExpression).toContain('answer');
+    });
+
+    it('should request the answer field for the efuda print view (scan all)', async () => {
+      ddbMock.on(ScanCommand).resolves({ Items: [] });
+
+      await getPhrasesList({});
+
+      const call = ddbMock.commandCalls(ScanCommand)[0];
+      expect(call.args[0].input.ProjectionExpression).toContain('answer');
+    });
+
     it('should handle errors', async () => {
       ddbMock.on(ScanCommand).rejects(new Error('DynamoDB error'));
       const response = await getPhrasesList({});

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -133,3 +133,101 @@ button:hover:not(:disabled) {
 button:active:not(:disabled) {
   transform: translateY(2px);
 }
+
+/* 絵札印刷（エーワン マルチカード マイクロミシン・厚口 A4・10面 51261系 準拠） */
+.efuda-print-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.efuda-page {
+  position: relative;
+  width: 210mm;
+  height: 297mm;
+  background: white;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.2);
+}
+
+.efuda-grid {
+  position: absolute;
+  top: 11mm;
+  left: 14mm;
+  width: 182mm;
+  height: 275mm;
+  display: grid;
+  grid-template-columns: 91mm 91mm;
+  grid-template-rows: repeat(5, 55mm);
+}
+
+.efuda-card {
+  width: 91mm;
+  height: 55mm;
+  box-sizing: border-box;
+  border: 0.2mm dashed #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  padding: 4mm;
+  overflow: hidden;
+}
+
+.efuda-card-kana {
+  position: absolute;
+  top: 3mm;
+  left: 3mm;
+  width: 10mm;
+  height: 10mm;
+  border-radius: 50%;
+  border: 0.4mm solid #e44d26;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 6mm;
+  color: #e44d26;
+  background: white;
+}
+
+.efuda-card-text {
+  font-weight: bold;
+  font-size: 6mm;
+  text-align: center;
+  line-height: 1.3;
+  word-break: break-word;
+}
+
+@media print {
+  .no-print {
+    display: none !important;
+  }
+
+  .efuda-print-container {
+    max-width: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+
+  .efuda-print-area {
+    position: fixed;
+    top: 0;
+    left: 0;
+    gap: 0;
+  }
+
+  .efuda-page {
+    box-shadow: none;
+    page-break-after: always;
+  }
+
+  .efuda-page:last-child {
+    page-break-after: auto;
+  }
+
+  @page {
+    size: A4;
+    margin: 0;
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -68,6 +68,16 @@ function App() {
     return selectedCategory ? (historyByCategory[selectedCategory] || []) : [];
   }, [selectedCategory, historyByCategory]);
 
+  const EFUDA_PER_PAGE = 10;
+  const efudaPages = useMemo(() => {
+    const pages = [];
+    for (let i = 0; i < allPhrasesForCategory.length; i += EFUDA_PER_PAGE) {
+      pages.push(allPhrasesForCategory.slice(i, i + EFUDA_PER_PAGE));
+    }
+    if (pages.length === 0) pages.push([]);
+    return pages;
+  }, [allPhrasesForCategory]);
+
   const handleSort = (key) => {
     let direction = 'asc';
     if (sortConfig.key === key && sortConfig.direction === 'asc') {
@@ -480,7 +490,7 @@ function App() {
       params.delete("id");
     }
 
-    if (view === "comments" || view === "changelog" || view === "all-phrases") {
+    if (view === "comments" || view === "changelog" || view === "all-phrases" || view === "print-efuda") {
       params.set("view", view);
     } else {
       params.delete("view");
@@ -509,6 +519,8 @@ function App() {
       document.title = "更新履歴 | かるた読み上げアプリ";
     } else if (view === "all-phrases") {
       document.title = "全札一覧 | かるた読み上げアプリ";
+    } else if (view === "print-efuda") {
+      document.title = `${selectedCategory || ""}の絵札印刷 | かるた読み上げアプリ`;
     } else if (detailPhraseId && detailPhrase) {
       document.title = `${detailPhrase.phrase} | ${selectedCategory}`;
     } else if (selectedCategory) {
@@ -642,6 +654,62 @@ function App() {
             </div>
           )}
         </main>
+      </div>
+    );
+  }
+
+  if (view === "print-efuda") {
+    const getEfudaText = (p) => (p.answer && p.answer !== "-") ? p.answer : p.phrase;
+
+    return (
+      <div className="container efuda-print-container py-4 mx-auto">
+        <header className="text-center mb-4 border-bottom pb-3 no-print">
+          <div className="d-flex justify-content-between align-items-center">
+            <button onClick={() => setView("game")} className="btn btn-sm btn-outline-secondary rounded-pill">← 戻る</button>
+            <h1 className="h4 m-0 fw-bold notranslate">{selectedCategory}の絵札印刷</h1>
+            <div style={{ width: "60px" }}></div>
+          </div>
+        </header>
+
+        {!selectedCategory ? (
+          <p className="text-muted text-center py-5 no-print">カテゴリを選択してください。</p>
+        ) : allPhrasesForCategory.length === 0 ? (
+          <p className="text-muted text-center py-5 no-print">読み込み中...</p>
+        ) : (
+          <>
+            <div className="no-print text-center mb-4">
+              <p className="text-muted small mb-3">
+                用紙: エーワン マルチカード（マイクロミシン・厚口）A4・10面用<br />
+                印刷ダイアログで「用紙サイズ: A4」「余白: なし」「拡大縮小: 実際のサイズ(100%)」「ヘッダーとフッター: オフ」に設定してください。
+              </p>
+              <button onClick={() => window.print()} className="btn btn-lg px-5 py-2 fw-bold rounded-pill shadow btn-karuta">
+                印刷する
+              </button>
+            </div>
+
+            <div className="efuda-print-area">
+              {efudaPages.map((pageItems, pageIndex) => (
+                <div className="efuda-page" key={pageIndex}>
+                  <div className="efuda-grid">
+                    {Array.from({ length: EFUDA_PER_PAGE }).map((_, slotIndex) => {
+                      const p = pageItems[slotIndex];
+                      return (
+                        <div className="efuda-card" key={slotIndex}>
+                          {p && (
+                            <>
+                              <div className="efuda-card-kana">{p.kana}</div>
+                              <div className="efuda-card-text">{getEfudaText(p)}</div>
+                            </>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
       </div>
     );
   }
@@ -966,7 +1034,10 @@ function App() {
           </div>
         </section>
       <p className="text-muted small mb-4">リロードすると履歴はリセットされます。</p>
-      <button onClick={resetGame} className="btn btn-outline-secondary px-4 rounded-pill">かるたの種類を選び直す</button>
+      <div className="d-flex flex-wrap gap-2 justify-content-center">
+        <button onClick={() => setView("print-efuda")} className="btn btn-outline-dark px-4 rounded-pill">絵札を印刷する</button>
+        <button onClick={resetGame} className="btn btn-outline-secondary px-4 rounded-pill">かるたの種類を選び直す</button>
+      </div>
     </footer>
     </div>
   );

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -111,6 +111,49 @@ describe('App', () => {
     });
   });
 
+  it('shows efuda print view with answer fallback to phrase and paginates by 10', async () => {
+    const phrases = Array.from({ length: 11 }, (_, i) => ({
+      id: `p${i}`,
+      category: 'Cat1',
+      kana: 'あ',
+      phrase: `読み札テキスト${i}`,
+      answer: i === 0 ? '-' : `回答${i}`,
+    }));
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: ['Cat1'] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases }) };
+      return { ok: false };
+    });
+
+    window.print = vi.fn();
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    const categoryButton = await screen.findByRole('button', { name: 'Cat1' });
+    fireEvent.click(categoryButton);
+    fireEvent.click(screen.getByText('はい'));
+
+    await waitFor(() => screen.getByText('絵札を印刷する'));
+    fireEvent.click(screen.getByText('絵札を印刷する'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Cat1の絵札印刷')).toBeInTheDocument();
+      // answerが"-"のカードは読み札(phrase)をそのまま使う
+      expect(screen.getByText('読み札テキスト0')).toBeInTheDocument();
+      // answerがあるカードはanswerを使う
+      expect(screen.getByText('回答1')).toBeInTheDocument();
+    });
+
+    // 11枚 → 10面/ページなので2ページ生成される
+    expect(document.querySelectorAll('.efuda-page').length).toBe(2);
+
+    fireEvent.click(screen.getByText('印刷する'));
+    expect(window.print).toHaveBeenCalled();
+  });
+
   it('updates settings (lang, sort order, speech rate)', async () => {
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: ['Cat1'] }) };

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,1 +1,28 @@
 import '@testing-library/jest-dom';
+
+// Node 22+ がフラグなしの `localStorage` グローバルを提供するが、
+// `--localstorage-file` 未指定だと getItem/setItem が機能せず jsdom の実装を覆ってしまう。
+// テスト用にメモリ上で動作する localStorage を明示的に補完する。
+if (typeof globalThis.localStorage?.setItem !== 'function') {
+  class MemoryStorage {
+    constructor() {
+      this.store = new Map();
+    }
+    getItem(key) {
+      return this.store.has(key) ? this.store.get(key) : null;
+    }
+    setItem(key, value) {
+      this.store.set(key, String(value));
+    }
+    removeItem(key) {
+      this.store.delete(key);
+    }
+    clear() {
+      this.store.clear();
+    }
+  }
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: new MemoryStorage(),
+    configurable: true,
+  });
+}


### PR DESCRIPTION
設計:
- 選定内容: 既存のカテゴリ別フェッチ処理(allPhrasesForCategory)を再利用し、 view="print-efuda" を追加してA4・10面(エーワン マルチカード マイクロミシン・ 厚口 51261系、カード91×55mm、上11mm/左14mm余白、列間・行間ゼロの2列×5段)に ぴったり収まる絵札レイアウトをCSS mm単位で実装。カード文言は「回答(answer)」 を優先し、回答データが無い("-")場合は読み札(phrase)をそのまま使用する フォールバックを追加。バックエンドはgetPhrasesListのProjectionExpressionに answerを追加して新フィールドを露出。
- 却下内容: 印刷専用の新規データ取得エンドポイントの追加は見送り、既存の allPhrasesForCategoryを再利用。印刷用@media printのレイアウトリセットは グローバルな.containerではなく新設の.efuda-print-container に限定し、 他画面(ゲーム/全札一覧/指摘一覧/更新履歴)の印刷時レイアウトに影響しない ようにした。
- 理由: カードサイズ・余白はA-One公式テストプリントPDF(51261)から実測した 数値であり、印刷時のズレを避けるため。他画面への影響回避はセルフレビュー で指摘された既存設計破壊の回避のため。

影響:
- 影響モジュール: frontend/src/App.jsx, App.css, backend/handler.js (getPhrasesList)
- 振る舞いの変更: get-phrases-list APIのレスポンスにanswerフィールドが 追加される(既存利用箇所には影響なし)。カテゴリ選択後の画面に 「絵札を印刷する」ボタンを追加。
- 付随対応: Node 22以降がフラグ無しで提供するlocalStorageグローバルが jsdom実装を上書きしテストが全滅する環境問題を frontend/src/setupTests.js のメモリ内ポリフィルで回避(本機能と無関係だが、テストゲートを満たすため に必要だったもの)。

テスト:
- 追加済み: backend/handler.test.jsにProjectionExpressionへのanswer追加を 検証するテスト2件。frontend/src/App.test.jsxに絵札印刷ビューの表示・ 回答フォールバック・10枚毎のページ分割・印刷ボタンのwindow.print()呼び出し を検証するテスト1件。Playwrightでの実機能確認(カテゴリ選択→印刷ビュー→ @media print適用)を実施し、コンソールエラー無し・カード配置を確認。
- 未追加: 実プリンタでの物理的な印刷ズレの確認(手元の用紙が無いため未実施)。