### PR TITLE
feat(backend): おばけ・いろはかるたの答えデータを追加

### DIFF
--- a/backend/phrases.csv
+++ b/backend/phrases.csv
@@ -124,147 +124,147 @@ id,category,level,kana,phrase,phrase_en,answer
 123,国旗王,初級,し,人口密度が低い,Low population density.,-
 124,国旗王,初級,せ,正式国名 五十音順 アに近い,Official name closest to 'A' in Japanese syllabary.,-
 125,国旗王,初級,し,首都が最南,Southernmost capital.,-
-126,おばけかるた,-,ふ,ふでこぞうが　ひとふでがき,Fudekozo draws with a single stroke.,-
-127,おばけかるた,-,ね,ねこまたも　ねがおはかわいい,Even Nekomata looks cute when sleeping.,-
-128,おばけかるた,-,ち,ちょうちんぶらり　こっちへ　くるぞ,Chochin-burari is coming this way!,-
-129,おばけかるた,-,た,たまごがわれて　てんぐがうまれた,An egg cracked and a Tengu was born.,-
-130,おばけかるた,-,け,けむくじゃらな　うでだ　まけるな！,"It's a hairy arm, don't lose!",-
-131,おばけかるた,-,く,くずかごからくろいてが！！！　きゃっ！！！,A black hand from the wastebasket!!! Kya!!!,-
-132,おばけかるた,-,あ,あめふりこぞうが　びちゃびちゃあるく,Amefuri-kozo walks with a squish-squish.,-
-133,おばけかるた,-,ひ,ひとつめのくには　ひとつめだらけだってさ,They say the one-eyed country is full of one-eyes.,-
-134,おばけかるた,-,ぬ,ぬらりとわらう　ぬっぺっぽう,Nureppon smiles eerily.,-
-135,おばけかるた,-,つ,つきよにでていくつく　もがみ,Tsuku-mogami goes out on a moonlit night.,-
-136,おばけかるた,-,そ,そろってあるく　ぞうりのおばけ,Zori ghosts walk in pairs.,-
-137,おばけかるた,-,こ,こんばんは～　どろどろどろどろ～,Good evening~ Doro-doro-doro-doro~,-
-138,おばけかるた,-,き,きゅうびのきつねは　ばけるめいじん,The nine-tailed fox is a master of disguise.,-
-139,おばけかるた,-,い,いったんもめんは　そらとべていいなあ,"Ittan-momen, it's nice to fly in the sky.",-
-140,おばけかるた,-,は,はたらけはたらけ　おばけもはたらけ,"Work, work, ghosts also work.",-
-141,おばけかるた,-,に,にっこりわらう　にかいのおんな,The woman on the second floor smiles.,-
-142,おばけかるた,-,て,てんぐのはながおれては　かわいそう,It would be pitiful if Tengu's nose broke.,-
-143,おばけかるた,-,せ,せんすだって　すてればばける,Even a fan will transform if you throw it away.,-
-144,おばけかるた,-,さ,さかさくびは　ぺろぺろなめる,Sakasa-kubi licks with a flick-flick.,-
-145,おばけかるた,-,か,かあさんかっぱ　とこどものかっぱ,Mother Kappa and baby Kappa.,-
-146,おばけかるた,-,う,うみぼうずのがっこう　せいとをぼしゅう,Umibozu's school is recruiting students.,-
-147,おばけかるた,-,の,のんきなのぶすま　のんびりとんだ,Carefree Nobusuma flew leisurely.,-
-148,おばけかるた,-,な,なきなきかえった　ちいさなゆうれい,A small ghost returned crying.,-
-149,おばけかるた,-,と,とらがねてたら　かみなりどしーん！！,"If a tiger sleeps, lightning strikes with a boom!!",-
-150,おばけかるた,-,す,すりばちこぞうは　なにすってるの？,What is Suribachi-kozo grinding?,-
-151,おばけかるた,-,し,しろくてみえない　ゆきのひのゆうれい,A white and invisible ghost on a snowy day.,-
-152,おばけかるた,-,お,おにもおじいさんになる,Even an ogre grows old.,-
-153,おばけかるた,-,え,えだをもやしたら　えんえんらがでたぞ,"When I burned a branch, Enenra came out!",-
-154,おばけかるた,-,る,るすばんしてるは　ぶるぶるひとり,"Staying home alone, trembling.",-
-155,おばけかるた,-,り,りゅうがいねむり　そらからおちる,"A dragon sleeping, falling from the sky.",-
-156,おばけかるた,-,む,むじなもばけたが　ちょっとむりだった,"Mujina tried to transform, but it was a bit impossible.",-
-157,おばけかるた,-,み,みこしにゅうどう　みかけよりよわい,"Mikoshi-Nyudo, weaker than he looks.",-
-158,おばけかるた,-,れ,れいぎただしい　ゆうれいもいる,There are polite ghosts too.,-
-159,おばけかるた,-,ら,らしょうもんの　おにはらんぼうだ,The demon of Rashomon is wild.,-
-160,おばけかるた,-,め,めだまをとられた　ひとつめこぞう,A one-eyed monster whose eye was taken.,-
-161,おばけかるた,-,ま,まくらがえしは　まいばんうるさい,Makura-gaeshi is noisy every night.,-
-162,おばけかるた,-,ろ,ろくろくねなかった　ろくろっくび,Rokurokubi who didn't sleep at all.,-
-163,おばけかるた,-,よ,よみちをこわがる　よわむしにゅうどう,A timid Nyudo who is scared of night roads.,-
-164,おばけかるた,-,も,もりんじのかまは　たぬきがばけた,Morinji's kettle was a transformed raccoon dog.,-
-165,おばけかるた,-,ほ,ほうきのおばけは　ほめてやろう,Let's praise the broom ghost.,-
-166,おばけかるた,-,を,「あしをけして　てをまえに」ゆうれいのおけいこ,"Delete legs, hands forward - a ghost's practice.",-
-167,おばけかるた,-,わ,わ、にゅうどうだ　わぁーっこわい！,"Oh, it's a Nyudo! Ahh, scary!",-
-168,おばけかるた,-,ゆ,ゆきおんな　おゆにはいってとけちゃった,Yuki-onna went into hot water and melted.,-
-169,おばけかるた,-,や,やなぎのしたで　ゆうれいけんか,Ghosts fighting under a willow tree.,-
-170,おばけかるた,-,へ,へびよりこわい　ろくろっくび,"Rokurokubi, scarier than a snake.",-
-171,いろはかるた,-,ま,嘘から出たまこと,A lie can sometimes turn into the truth,-
-172,いろはかるた,-,こ,弘法にも筆の誤り,Even experts make mistakes,-
-173,いろはかるた,-,あ,得手に帆を揚げる,To take advantage of a good opportunity,-
-174,いろはかるた,-,あ,味なもの縁は異なもの,Romance works in mysterious ways,-
-175,いろはかるた,-,ぞ,芋の煮えたも御存じない,Completely clueless,-
-176,いろはかるた,-,て,文はやりたし書く手は持たぬ,Wanting to write a letter but lacking the skill,-
-177,いろはかるた,-,す,亭主の好きな赤烏帽子,One must go along with the head of the household,-
-178,いろはかるた,-,し,知らぬが仏,Ignorance is bliss,-
-179,いろはかるた,-,は,背に腹はかえられぬ,Needs must when driven,-
-180,いろはかるた,-,げ,芸は身を助ける,A skill will always help you,-
-181,いろはかるた,-,の,喉元過ぎれば熱さを忘れる,"Once the pain is gone, the lesson is forgotten",-
-182,いろはかるた,-,あ,頭隠して尻隠さず,Trying to hide something but failing,-
-183,いろはかるた,-,み,身から出た錆,You reap what you sow,-
-184,いろはかるた,-,も,門前の小僧習わぬ経を読む,You learn things naturally by exposure,-
-185,いろはかるた,-,お,鬼に金棒,Adding strength to the strong,-
-186,いろはかるた,-,ま,負けるが勝ち,Sometimes losing leads to winning,-
-187,いろはかるた,-,さ,三遍回って煙草にしょ,Take time and be careful,-
-188,いろはかるた,-,め,目の上のたん瘤,A thorn in one’s side,-
-189,いろはかるた,-,ひ,貧乏暇なし,The poor have no leisure,-
-190,いろはかるた,-,く,臭い物に蓋をする,To cover up an inconvenient truth,-
-191,いろはかるた,-,や,安物買いの銭失い,Buying cheap ends up costing more,-
-192,いろはかるた,-,き,聞いて極楽見て地獄,Hearing and seeing are very different,-
-193,いろはかるた,-,ゆ,油断大敵,Carelessness is dangerous,-
-194,いろはかるた,-,い,犬も歩けば棒に当たる,Every action brings some result,-
-195,いろはかるた,-,ら,楽あれば苦あり,Life has ups and downs,-
-196,いろはかるた,-,む,無理が通れば道理が引っ込む,"When force prevails, reason disappears",-
-197,いろはかるた,-,と,年寄りの冷や水,An old person acting recklessly,-
-198,いろはかるた,-,す,粋は身を食う,Showing off can ruin you,-
-199,いろはかるた,-,き,京の夢大阪の夢,Dreams are fleeting and strange,-
-200,いろはかるた,-,へ,下手の長談義,The unskilled talk the longest,-
-201,いろはかるた,-,ろ,論より証拠,Proof is better than argument,-
-202,いろはかるた,-,く,くたびれ儲け,All effort and no reward,-
-203,いろはかるた,-,に,憎まれっ子世にはばかる,The disliked often survive well,-
-204,いろはかるた,-,ち,塵も積もれば山となる,Many small things add up,-
-205,いろはかるた,-,こ,律義者の子だくさん,Honest people tend to have many children,-
-206,いろはかるた,-,ぬ,盗人の昼寝,Even bad acts have consequences,-
-207,いろはかるた,-,は,花より団子,Practicality over appearance,-
-208,いろはかるた,-,る,瑠璃も玻璃も照らせば光る,True talent shines anywhere,-
-209,いろはかるた,-,な,泣きっ面に蜂,Misfortune never comes alone,-
-210,いろはかるた,-,あ,葦の髄から天井のぞく,Judging the whole from a tiny part,-
-211,いろはかるた,-,か,蛙の面に水,Completely unfazed,-
-212,いろはかるた,-,わ,破れ鍋に綴じ蓋,Every pot has its lid,-
-213,いろはかるた,-,を,老いては子に従え,Let the younger generation lead,-
-214,いろはかるた,-,ね,念には念を入れよ,Double-check everything,-
-215,いろはかるた,-,た,旅は道連れ世は情け,Life is about helping each other,-
-216,いろはかるた,-,れ,良薬は口に苦し,Good medicine tastes bitter,-
-217,いろはかるた,-,そ,総領の甚六,The eldest son is often naive,-
-218,いろはかるた,-,つ,月とすっぽん,Like night and day,-
-219,いろはかるた（意味）,-,ま,でたらめに言ったことが、偶然にも事実になってしまうこと,A lie can sometimes turn into the truth,-
-220,いろはかるた（意味）,-,こ,どんな名人でも失敗することがあるというたとえ,Even experts make mistakes,-
-221,いろはかるた（意味）,-,あ,物事を行うのに絶好の機会を得ること,To take advantage of a good opportunity,-
-222,いろはかるた（意味）,-,あ,男女の仲は理屈では説明できないものだということ,Romance works in mysterious ways,-
-223,いろはかるた（意味）,-,ぞ,物事の様子がまったく分からない人をからかう言い方,Completely clueless,-
-224,いろはかるた（意味）,-,て,やりたい気持ちはあるが能力が伴わず困っていること,Wanting to write a letter but lacking the skill,-
-225,いろはかるた（意味）,-,す,家長の好みには家族も従うべきだという考え,One must go along with the head of the household,-
-226,いろはかるた（意味）,-,し,知らなければ悩まずにすむこともあるということ,Ignorance is bliss,-
-227,いろはかるた（意味）,-,は,大きな目的のためには多少の犠牲は仕方ないということ,Needs must when driven,-
-228,いろはかるた（意味）,-,げ,身につけた技や芸が困ったときに役立つこと,A skill will always help you,-
-229,いろはかるた（意味）,-,の,苦しい経験をしても時間がたつと忘れてしまうこと,"Once the pain is gone, the lesson is forgotten",-
-230,いろはかるた（意味）,-,あ,一部しか隠していないのに全部隠したつもりでいること,Trying to hide something but failing,-
-231,いろはかるた（意味）,-,み,自分のした悪い行いの結果で自分が苦しむこと,You reap what you sow,-
-232,いろはかるた（意味）,-,も,日頃見聞きしているうちに自然と身につくことがある,You learn things naturally by exposure,-
-233,いろはかるた（意味）,-,お,強いものがさらに力を得て一層強くなること,Adding strength to the strong,-
-234,いろはかるた（意味）,-,ま,一歩引いた方が結果的に有利になることがある,Sometimes losing leads to winning,-
-235,いろはかるた（意味）,-,さ,急がず慎重に行動することが大切だということ,Take time and be careful,-
-236,いろはかるた（意味）,-,め,自分にとって邪魔で目障りな存在のたとえ,A thorn in one’s side,-
-237,いろはかるた（意味）,-,ひ,貧しい人ほど仕事に追われ時間の余裕がないこと,The poor have no leisure,-
-238,いろはかるた（意味）,-,く,都合の悪いことを一時的に隠そうとすること,To cover up an inconvenient truth,-
-239,いろはかるた（意味）,-,や,安い物を買うとかえって損をすること,Buying cheap ends up costing more,-
-240,いろはかるた（意味）,-,き,聞くのと実際に見るのとでは大きな違いがあること,Hearing and seeing are very different,-
-241,いろはかるた（意味）,-,ゆ,油断すると失敗や災難を招くということ,Carelessness is dangerous,-
-242,いろはかるた（意味）,-,い,行動すれば良くも悪くも何かが起こるということ,Every action brings some result,-
-243,いろはかるた（意味）,-,ら,人生には楽しいことと苦しいことの両方がある,Life has ups and downs,-
-244,いろはかるた（意味）,-,む,無茶がまかり通る世の中では道理が通らなくなる,"When force prevails, reason disappears",-
-245,いろはかるた（意味）,-,と,年齢を考えず無理な振る舞いをすること,An old person acting recklessly,-
-246,いろはかるた（意味）,-,す,気取った振る舞いが身を滅ぼすことがある,Showing off can ruin you,-
-247,いろはかるた（意味）,-,き,夢というものはとりとめなく不思議なものだということ,Dreams are fleeting and strange,-
-248,いろはかるた（意味）,-,へ,下手な人ほど話が長くなること,The unskilled talk the longest,-
-249,いろはかるた（意味）,-,ろ,理屈よりも実際の証拠が大切だということ,Proof is better than argument,-
-250,いろはかるた（意味）,-,く,苦労したわりに何の得もないこと,All effort and no reward,-
-251,いろはかるた（意味）,-,に,憎まれるような人ほど世渡りがうまいこと,The disliked often survive well,-
-252,いろはかるた（意味）,-,ち,小さなことでも積み重なれば大きな成果になる,Many small things add up,-
-253,いろはかるた（意味）,-,こ,律義な人は家庭を大切にし子どもが多くなるという考え,Honest people tend to have many children,-
-254,いろはかるた（意味）,-,ぬ,どんな行いにも必ず報いがあるということ,Even bad acts have consequences,-
-255,いろはかるた（意味）,-,は,見た目より実利を重んじること,Practicality over appearance,-
-256,いろはかるた（意味）,-,る,才能のある人はどんな環境でも力を発揮する,True talent shines anywhere,-
-257,いろはかるた（意味）,-,な,不運なときにさらに不幸が重なること,Misfortune never comes alone,-
-258,いろはかるた（意味）,-,あ,わずかな知識で全て分かったつもりになること,Judging the whole from a tiny part,-
-259,いろはかるた（意味）,-,か,何をされても平然としていること,Completely unfazed,-
-260,いろはかるた（意味）,-,わ,どんな人にもふさわしい相手がいるということ,Every pot has its lid,-
-261,いろはかるた（意味）,-,を,年を取ったら若い者の意見に従うのがよい,Let the younger generation lead,-
-262,いろはかるた（意味）,-,ね,十分注意した上でさらに注意を重ねること,Double-check everything,-
-263,いろはかるた（意味）,-,た,人は助け合って生きていくものだということ,Life is about helping each other,-
-264,いろはかるた（意味）,-,れ,忠告は耳に痛いが自分のためになる,Good medicine tastes bitter,-
-265,いろはかるた（意味）,-,そ,長男は大事に育てられ世間知らずになりがちだということ,The eldest son is often naive,-
-266,いろはかるた（意味）,-,つ,似ているようで実際は大きな違いがある,Like night and day,-
+126,おばけかるた,-,ふ,ふでこぞうが　ひとふでがき,Fudekozo draws with a single stroke.,ふでこぞう
+127,おばけかるた,-,ね,ねこまたも　ねがおはかわいい,Even Nekomata looks cute when sleeping.,ねこまた
+128,おばけかるた,-,ち,ちょうちんぶらり　こっちへ　くるぞ,Chochin-burari is coming this way!,ちょうちんぶらり
+129,おばけかるた,-,た,たまごがわれて　てんぐがうまれた,An egg cracked and a Tengu was born.,てんぐ
+130,おばけかるた,-,け,けむくじゃらな　うでだ　まけるな！,"It's a hairy arm, don't lose!",けむくじゃらなうで
+131,おばけかるた,-,く,くずかごからくろいてが！！！　きゃっ！！！,A black hand from the wastebasket!!! Kya!!!,くろいて
+132,おばけかるた,-,あ,あめふりこぞうが　びちゃびちゃあるく,Amefuri-kozo walks with a squish-squish.,あめふりこぞう
+133,おばけかるた,-,ひ,ひとつめのくには　ひとつめだらけだってさ,They say the one-eyed country is full of one-eyes.,ひとつめ
+134,おばけかるた,-,ぬ,ぬらりとわらう　ぬっぺっぽう,Nureppon smiles eerily.,ぬっぺっぽう
+135,おばけかるた,-,つ,つきよにでていくつく　もがみ,Tsuku-mogami goes out on a moonlit night.,つくもがみ
+136,おばけかるた,-,そ,そろってあるく　ぞうりのおばけ,Zori ghosts walk in pairs.,ぞうりのおばけ
+137,おばけかるた,-,こ,こんばんは～　どろどろどろどろ～,Good evening~ Doro-doro-doro-doro~,ゆうれい
+138,おばけかるた,-,き,きゅうびのきつねは　ばけるめいじん,The nine-tailed fox is a master of disguise.,きゅうびのきつね
+139,おばけかるた,-,い,いったんもめんは　そらとべていいなあ,"Ittan-momen, it's nice to fly in the sky.",いったんもめん
+140,おばけかるた,-,は,はたらけはたらけ　おばけもはたらけ,"Work, work, ghosts also work.",おばけ
+141,おばけかるた,-,に,にっこりわらう　にかいのおんな,The woman on the second floor smiles.,にかいのおんな
+142,おばけかるた,-,て,てんぐのはながおれては　かわいそう,It would be pitiful if Tengu's nose broke.,てんぐ
+143,おばけかるた,-,せ,せんすだって　すてればばける,Even a fan will transform if you throw it away.,せんす
+144,おばけかるた,-,さ,さかさくびは　ぺろぺろなめる,Sakasa-kubi licks with a flick-flick.,さかさくび
+145,おばけかるた,-,か,かあさんかっぱ　とこどものかっぱ,Mother Kappa and baby Kappa.,かっぱ
+146,おばけかるた,-,う,うみぼうずのがっこう　せいとをぼしゅう,Umibozu's school is recruiting students.,うみぼうず
+147,おばけかるた,-,の,のんきなのぶすま　のんびりとんだ,Carefree Nobusuma flew leisurely.,のぶすま
+148,おばけかるた,-,な,なきなきかえった　ちいさなゆうれい,A small ghost returned crying.,ちいさなゆうれい
+149,おばけかるた,-,と,とらがねてたら　かみなりどしーん！！,"If a tiger sleeps, lightning strikes with a boom!!",かみなり
+150,おばけかるた,-,す,すりばちこぞうは　なにすってるの？,What is Suribachi-kozo grinding?,すりばちこぞう
+151,おばけかるた,-,し,しろくてみえない　ゆきのひのゆうれい,A white and invisible ghost on a snowy day.,ゆきのひのゆうれい
+152,おばけかるた,-,お,おにもおじいさんになる,Even an ogre grows old.,おに
+153,おばけかるた,-,え,えだをもやしたら　えんえんらがでたぞ,"When I burned a branch, Enenra came out!",えんえんら
+154,おばけかるた,-,る,るすばんしてるは　ぶるぶるひとり,"Staying home alone, trembling.",ゆうれい
+155,おばけかるた,-,り,りゅうがいねむり　そらからおちる,"A dragon sleeping, falling from the sky.",りゅう
+156,おばけかるた,-,む,むじなもばけたが　ちょっとむりだった,"Mujina tried to transform, but it was a bit impossible.",むじな
+157,おばけかるた,-,み,みこしにゅうどう　みかけよりよわい,"Mikoshi-Nyudo, weaker than he looks.",みこしにゅうどう
+158,おばけかるた,-,れ,れいぎただしい　ゆうれいもいる,There are polite ghosts too.,ゆうれい
+159,おばけかるた,-,ら,らしょうもんの　おにはらんぼうだ,The demon of Rashomon is wild.,らしょうもんのおに
+160,おばけかるた,-,め,めだまをとられた　ひとつめこぞう,A one-eyed monster whose eye was taken.,ひとつめこぞう
+161,おばけかるた,-,ま,まくらがえしは　まいばんうるさい,Makura-gaeshi is noisy every night.,まくらがえし
+162,おばけかるた,-,ろ,ろくろくねなかった　ろくろっくび,Rokurokubi who didn't sleep at all.,ろくろっくび
+163,おばけかるた,-,よ,よみちをこわがる　よわむしにゅうどう,A timid Nyudo who is scared of night roads.,よわむしにゅうどう
+164,おばけかるた,-,も,もりんじのかまは　たぬきがばけた,Morinji's kettle was a transformed raccoon dog.,たぬき
+165,おばけかるた,-,ほ,ほうきのおばけは　ほめてやろう,Let's praise the broom ghost.,ほうきのおばけ
+166,おばけかるた,-,を,「あしをけして　てをまえに」ゆうれいのおけいこ,"Delete legs, hands forward - a ghost's practice.",ゆうれい
+167,おばけかるた,-,わ,わ、にゅうどうだ　わぁーっこわい！,"Oh, it's a Nyudo! Ahh, scary!",にゅうどう
+168,おばけかるた,-,ゆ,ゆきおんな　おゆにはいってとけちゃった,Yuki-onna went into hot water and melted.,ゆきおんな
+169,おばけかるた,-,や,やなぎのしたで　ゆうれいけんか,Ghosts fighting under a willow tree.,ゆうれい
+170,おばけかるた,-,へ,へびよりこわい　ろくろっくび,"Rokurokubi, scarier than a snake.",ろくろっくび
+171,いろはかるた,-,ま,嘘から出たまこと,A lie can sometimes turn into the truth,でたらめに言ったことが、偶然にも事実になってしまうこと
+172,いろはかるた,-,こ,弘法にも筆の誤り,Even experts make mistakes,どんな名人でも失敗することがあるというたとえ
+173,いろはかるた,-,あ,得手に帆を揚げる,To take advantage of a good opportunity,物事を行うのに絶好の機会を得ること
+174,いろはかるた,-,あ,味なもの縁は異なもの,Romance works in mysterious ways,男女の仲は理屈では説明できないものだということ
+175,いろはかるた,-,ぞ,芋の煮えたも御存じない,Completely clueless,物事の様子がまったく分からない人をからかう言い方
+176,いろはかるた,-,て,文はやりたし書く手は持たぬ,Wanting to write a letter but lacking the skill,やりたい気持ちはあるが能力が伴わず困っていること
+177,いろはかるた,-,す,亭主の好きな赤烏帽子,One must go along with the head of the household,家長の好みには家族も従うべきだという考え
+178,いろはかるた,-,し,知らぬが仏,Ignorance is bliss,知らなければ悩まずにすむこともあるということ
+179,いろはかるた,-,は,背に腹はかえられぬ,Needs must when driven,大きな目的のためには多少の犠牲は仕方ないということ
+180,いろはかるた,-,げ,芸は身を助ける,A skill will always help you,身につけた技や芸が困ったときに役立つこと
+181,いろはかるた,-,の,喉元過ぎれば熱さを忘れる,"Once the pain is gone, the lesson is forgotten",苦しい経験をしても時間がたつと忘れてしまうこと
+182,いろはかるた,-,あ,頭隠して尻隠さず,Trying to hide something but failing,一部しか隠していないのに全部隠したつもりでいること
+183,いろはかるた,-,み,身から出た錆,You reap what you sow,自分のした悪い行いの結果で自分が苦しむこと
+184,いろはかるた,-,も,門前の小僧習わぬ経を読む,You learn things naturally by exposure,日頃見聞きしているうちに自然と身につくことがある
+185,いろはかるた,-,お,鬼に金棒,Adding strength to the strong,強いものがさらに力を得て一層強くなること
+186,いろはかるた,-,ま,負けるが勝ち,Sometimes losing leads to winning,一歩引いた方が結果的に有利になることがある
+187,いろはかるた,-,さ,三遍回って煙草にしょ,Take time and be careful,急がず慎重に行動することが大切だということ
+188,いろはかるた,-,め,目の上のたん瘤,A thorn in one’s side,自分にとって邪魔で目障りな存在のたとえ
+189,いろはかるた,-,ひ,貧乏暇なし,The poor have no leisure,貧しい人ほど仕事に追われ時間の余裕がないこと
+190,いろはかるた,-,く,臭い物に蓋をする,To cover up an inconvenient truth,都合の悪いことを一時的に隠そうとすること
+191,いろはかるた,-,や,安物買いの銭失い,Buying cheap ends up costing more,安い物を買うとかえって損をすること
+192,いろはかるた,-,き,聞いて極楽見て地獄,Hearing and seeing are very different,聞くのと実際に見るのとでは大きな違いがあること
+193,いろはかるた,-,ゆ,油断大敵,Carelessness is dangerous,油断すると失敗や災難を招くということ
+194,いろはかるた,-,い,犬も歩けば棒に当たる,Every action brings some result,行動すれば良くも悪くも何かが起こるということ
+195,いろはかるた,-,ら,楽あれば苦あり,Life has ups and downs,人生には楽しいことと苦しいことの両方がある
+196,いろはかるた,-,む,無理が通れば道理が引っ込む,"When force prevails, reason disappears",無茶がまかり通る世の中では道理が通らなくなる
+197,いろはかるた,-,と,年寄りの冷や水,An old person acting recklessly,年齢を考えず無理な振る舞いをすること
+198,いろはかるた,-,す,粋は身を食う,Showing off can ruin you,気取った振る舞いが身を滅ぼすことがある
+199,いろはかるた,-,き,京の夢大阪の夢,Dreams are fleeting and strange,夢というものはとりとめなく不思議なものだということ
+200,いろはかるた,-,へ,下手の長談義,The unskilled talk the longest,下手な人ほど話が長くなること
+201,いろはかるた,-,ろ,論より証拠,Proof is better than argument,理屈よりも実際の証拠が大切だということ
+202,いろはかるた,-,く,くたびれ儲け,All effort and no reward,苦労したわりに何の得もないこと
+203,いろはかるた,-,に,憎まれっ子世にはばかる,The disliked often survive well,憎まれるような人ほど世渡りがうまいこと
+204,いろはかるた,-,ち,塵も積もれば山となる,Many small things add up,小さなことでも積み重なれば大きな成果になる
+205,いろはかるた,-,こ,律義者の子だくさん,Honest people tend to have many children,律義な人は家庭を大切にし子どもが多くなるという考え
+206,いろはかるた,-,ぬ,盗人の昼寝,Even bad acts have consequences,どんな行いにも必ず報いがあるということ
+207,いろはかるた,-,は,花より団子,Practicality over appearance,見た目より実利を重んじること
+208,いろはかるた,-,る,瑠璃も玻璃も照らせば光る,True talent shines anywhere,才能のある人はどんな環境でも力を発揮する
+209,いろはかるた,-,な,泣きっ面に蜂,Misfortune never comes alone,不運なときにさらに不幸が重なること
+210,いろはかるた,-,あ,葦の髄から天井のぞく,Judging the whole from a tiny part,わずかな知識で全て分かったつもりになること
+211,いろはかるた,-,か,蛙の面に水,Completely unfazed,何をされても平然としていること
+212,いろはかるた,-,わ,破れ鍋に綴じ蓋,Every pot has its lid,どんな人にもふさわしい相手がいるということ
+213,いろはかるた,-,を,老いては子に従え,Let the younger generation lead,年を取ったら若い者の意見に従うのがよい
+214,いろはかるた,-,ね,念には念を入れよ,Double-check everything,十分注意した上でさらに注意を重ねること
+215,いろはかるた,-,た,旅は道連れ世は情け,Life is about helping each other,人は助け合って生きていくものだということ
+216,いろはかるた,-,れ,良薬は口に苦し,Good medicine tastes bitter,忠告は耳に痛いが自分のためになる
+217,いろはかるた,-,そ,総領の甚六,The eldest son is often naive,長男は大事に育てられ世間知らずになりがちだということ
+218,いろはかるた,-,つ,月とすっぽん,Like night and day,似ているようで実際は大きな違いがある
+219,いろはかるた（意味）,-,ま,でたらめに言ったことが、偶然にも事実になってしまうこと,A lie can sometimes turn into the truth,嘘から出たまこと
+220,いろはかるた（意味）,-,こ,どんな名人でも失敗することがあるというたとえ,Even experts make mistakes,弘法にも筆の誤り
+221,いろはかるた（意味）,-,あ,物事を行うのに絶好の機会を得ること,To take advantage of a good opportunity,得手に帆を揚げる
+222,いろはかるた（意味）,-,あ,男女の仲は理屈では説明できないものだということ,Romance works in mysterious ways,味なもの縁は異なもの
+223,いろはかるた（意味）,-,ぞ,物事の様子がまったく分からない人をからかう言い方,Completely clueless,芋の煮えたも御存じない
+224,いろはかるた（意味）,-,て,やりたい気持ちはあるが能力が伴わず困っていること,Wanting to write a letter but lacking the skill,文はやりたし書く手は持たぬ
+225,いろはかるた（意味）,-,す,家長の好みには家族も従うべきだという考え,One must go along with the head of the household,亭主の好きな赤烏帽子
+226,いろはかるた（意味）,-,し,知らなければ悩まずにすむこともあるということ,Ignorance is bliss,知らぬが仏
+227,いろはかるた（意味）,-,は,大きな目的のためには多少の犠牲は仕方ないということ,Needs must when driven,背に腹はかえられぬ
+228,いろはかるた（意味）,-,げ,身につけた技や芸が困ったときに役立つこと,A skill will always help you,芸は身を助ける
+229,いろはかるた（意味）,-,の,苦しい経験をしても時間がたつと忘れてしまうこと,"Once the pain is gone, the lesson is forgotten",喉元過ぎれば熱さを忘れる
+230,いろはかるた（意味）,-,あ,一部しか隠していないのに全部隠したつもりでいること,Trying to hide something but failing,頭隠して尻隠さず
+231,いろはかるた（意味）,-,み,自分のした悪い行いの結果で自分が苦しむこと,You reap what you sow,身から出た錆
+232,いろはかるた（意味）,-,も,日頃見聞きしているうちに自然と身につくことがある,You learn things naturally by exposure,門前の小僧習わぬ経を読む
+233,いろはかるた（意味）,-,お,強いものがさらに力を得て一層強くなること,Adding strength to the strong,鬼に金棒
+234,いろはかるた（意味）,-,ま,一歩引いた方が結果的に有利になることがある,Sometimes losing leads to winning,負けるが勝ち
+235,いろはかるた（意味）,-,さ,急がず慎重に行動することが大切だということ,Take time and be careful,三遍回って煙草にしょ
+236,いろはかるた（意味）,-,め,自分にとって邪魔で目障りな存在のたとえ,A thorn in one’s side,目の上のたん瘤
+237,いろはかるた（意味）,-,ひ,貧しい人ほど仕事に追われ時間の余裕がないこと,The poor have no leisure,貧乏暇なし
+238,いろはかるた（意味）,-,く,都合の悪いことを一時的に隠そうとすること,To cover up an inconvenient truth,臭い物に蓋をする
+239,いろはかるた（意味）,-,や,安い物を買うとかえって損をすること,Buying cheap ends up costing more,安物買いの銭失い
+240,いろはかるた（意味）,-,き,聞くのと実際に見るのとでは大きな違いがあること,Hearing and seeing are very different,聞いて極楽見て地獄
+241,いろはかるた（意味）,-,ゆ,油断すると失敗や災難を招くということ,Carelessness is dangerous,油断大敵
+242,いろはかるた（意味）,-,い,行動すれば良くも悪くも何かが起こるということ,Every action brings some result,犬も歩けば棒に当たる
+243,いろはかるた（意味）,-,ら,人生には楽しいことと苦しいことの両方がある,Life has ups and downs,楽あれば苦あり
+244,いろはかるた（意味）,-,む,無茶がまかり通る世の中では道理が通らなくなる,"When force prevails, reason disappears",無理が通れば道理が引っ込む
+245,いろはかるた（意味）,-,と,年齢を考えず無理な振る舞いをすること,An old person acting recklessly,年寄りの冷や水
+246,いろはかるた（意味）,-,す,気取った振る舞いが身を滅ぼすことがある,Showing off can ruin you,粋は身を食う
+247,いろはかるた（意味）,-,き,夢というものはとりとめなく不思議なものだということ,Dreams are fleeting and strange,京の夢大阪の夢
+248,いろはかるた（意味）,-,へ,下手な人ほど話が長くなること,The unskilled talk the longest,下手の長談義
+249,いろはかるた（意味）,-,ろ,理屈よりも実際の証拠が大切だということ,Proof is better than argument,論より証拠
+250,いろはかるた（意味）,-,く,苦労したわりに何の得もないこと,All effort and no reward,くたびれ儲け
+251,いろはかるた（意味）,-,に,憎まれるような人ほど世渡りがうまいこと,The disliked often survive well,憎まれっ子世にはばかる
+252,いろはかるた（意味）,-,ち,小さなことでも積み重なれば大きな成果になる,Many small things add up,塵も積もれば山となる
+253,いろはかるた（意味）,-,こ,律義な人は家庭を大切にし子どもが多くなるという考え,Honest people tend to have many children,律義者の子だくさん
+254,いろはかるた（意味）,-,ぬ,どんな行いにも必ず報いがあるということ,Even bad acts have consequences,盗人の昼寝
+255,いろはかるた（意味）,-,は,見た目より実利を重んじること,Practicality over appearance,花より団子
+256,いろはかるた（意味）,-,る,才能のある人はどんな環境でも力を発揮する,True talent shines anywhere,瑠璃も玻璃も照らせば光る
+257,いろはかるた（意味）,-,な,不運なときにさらに不幸が重なること,Misfortune never comes alone,泣きっ面に蜂
+258,いろはかるた（意味）,-,あ,わずかな知識で全て分かったつもりになること,Judging the whole from a tiny part,葦の髄から天井のぞく
+259,いろはかるた（意味）,-,か,何をされても平然としていること,Completely unfazed,蛙の面に水
+260,いろはかるた（意味）,-,わ,どんな人にもふさわしい相手がいるということ,Every pot has its lid,破れ鍋に綴じ蓋
+261,いろはかるた（意味）,-,を,年を取ったら若い者の意見に従うのがよい,Let the younger generation lead,老いては子に従え
+262,いろはかるた（意味）,-,ね,十分注意した上でさらに注意を重ねること,Double-check everything,念には念を入れよ
+263,いろはかるた（意味）,-,た,人は助け合って生きていくものだということ,Life is about helping each other,旅は道連れ世は情け
+264,いろはかるた（意味）,-,れ,忠告は耳に痛いが自分のためになる,Good medicine tastes bitter,良薬は口に苦し
+265,いろはかるた（意味）,-,そ,長男は大事に育てられ世間知らずになりがちだということ,The eldest son is often naive,総領の甚六
+266,いろはかるた（意味）,-,つ,似ているようで実際は大きな違いがある,Like night and day,月とすっぽん
 267,百人一首,-,あ,あきのたの かりほのいおの とまをあらみ わがころもでは つゆにぬれつつ,"In the autumn field, in the temporary hut's rough rush-mats, my sleeves are getting wet with dew.",-
 268,百人一首,-,あ,あきかぜに たなびくくもの たえまより もれいづるつきの かげのさやけさ,"Through the rifts in the clouds trailing in the autumn wind, how clear the moonlight leaks out.",-
 269,百人一首,-,あ,あしびきの やまどりのをの しだりをの ながながしよを ひとりかもねむ,"Must I sleep alone through the long, long night, like the long, trailing tail of the mountain pheasant?",-


### PR DESCRIPTION
設計:
- 選定内容: いろはかるた／いろはかるた（意味）は同一順序で対応する48行ペアのため、互いのphraseを答えとして突き合わせて設定。おばけかるたは各札のphrase本文中に登場する妖怪名・主体名を抽出して答えに設定。
- 却下内容: おばけかるたで本文に名称のない2件（id137, 154）に専用の固有名を新たに考案すること。
- 理由: 既存データに記載のない事実を推測で創作するとCLAUDE.mdの「推測で仕様を追加しない」に反するため、本文から抽出可能な情報のみを用いた。本文に主体名がない2件は、データセット内の他の同種ジェネリックな行（ゆうれい等）と表記を揃えた。

影響:
- 影響モジュール: backend/phrases.csv のみ（おばけかるた45行、いろはかるた48行、いろはかるた（意味）48行のanswer列）。他カテゴリ・他列は変更なし。
- 振る舞いの変更: フロントエンドの絵札印刷画面（App.jsx の getEfudaText）で、これらのカテゴリでも answer が "-" 以外になり、絵札にanswerテキストが表示されるようになる。

テスト:
- 追加済み: なし（既存テストはanswer列の具体的な値ではなくフィールド名の存在のみを検証しており、本変更による既存テストへの影響はないことをコード確認済み）。
- 未追加: CSVデータ内容を検証する新規テストは追加していない（既存のテスト方針がデータ値を対象にしていないため）。