### PR TITLE
feat(frontend): 結果画面と全札一覧に答えを表示

### DIFF
--- a/backend/handler.js
+++ b/backend/handler.js
@@ -236,12 +236,12 @@ exports.getPhrase = async (event) => {
       // それ以外は従来通りScan（またはQueryに最適化可能だが一旦Scan）
       const scanParams = {
         TableName: process.env.TABLE_NAME,
-        ProjectionExpression: "id, category, phrase, #lvl, kana, phrase_en, readCount, averageTime, averageDifficulty",
+        ProjectionExpression: "id, category, phrase, #lvl, kana, phrase_en, answer, readCount, averageTime, averageDifficulty",
         ExpressionAttributeNames: {
           "#lvl": "level",
         },
       };
-      
+
       const scanResult = await docClient.send(new ScanCommand(scanParams));
       let items = scanResult.Items || [];
 
@@ -342,6 +342,7 @@ exports.getPhrase = async (event) => {
       phrase_en: selectedItem.phrase_en,
       level: selectedItem.level,
       kana: selectedItem.kana,
+      answer: selectedItem.answer,
       audioData: audioData,
       readCount: selectedItem.readCount || 0,
       averageTime: selectedItem.averageTime || 0,

--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -327,6 +327,24 @@ describe('getPhrase', () => {
         expect(body.averageTime).toBe(12.3);
     });
 
+    it('should include the answer field in the response when present', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', level: '1', answer: '回答A' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined }); // Cache miss
+        ddbMock.on(PutCommand).resolves({}); // Cache put
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1' } };
+        const response = await getPhrase(event);
+        const body = JSON.parse(response.body);
+        expect(body.answer).toBe('回答A');
+    });
+
     it('should handle speechRate with %', async () => {
         ddbMock.on(ScanCommand).resolves({
             Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', level: '1' }],

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -106,6 +106,14 @@ function App() {
         } else if (sortConfig.key === 'readCount' || sortConfig.key === 'averageDifficulty' || sortConfig.key === 'averageTime') {
             aValue = aValue || 0;
             bValue = bValue || 0;
+        } else if (sortConfig.key === 'answer') {
+            const aMissing = !aValue || aValue === '-';
+            const bMissing = !bValue || bValue === '-';
+            if (aMissing && !bMissing) return 1;
+            if (!aMissing && bMissing) return -1;
+            if (aMissing && bMissing) return 0;
+            aValue = aValue.toLowerCase();
+            bValue = bValue.toLowerCase();
         } else if (typeof aValue === 'string') {
             aValue = aValue.toLowerCase();
             bValue = bValue.toLowerCase();
@@ -365,7 +373,7 @@ function App() {
 
         nextContentRef.current = {
           type: "result",
-          content: { time: elapsedTime, difficulty, isFast },
+          content: { time: elapsedTime, difficulty, isFast, answer: targetPhrase.answer },
         };
         setIsFadingOut(true);
         
@@ -739,6 +747,9 @@ function App() {
                     <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('phrase')}>
                       読み札{renderSortArrow('phrase')}
                     </th>
+                    <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('answer')}>
+                      答え{renderSortArrow('answer')}
+                    </th>
                     <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('level')}>
                       Lv{renderSortArrow('level')}
                     </th>
@@ -759,6 +770,7 @@ function App() {
                     <tr key={p.id} style={{ cursor: "pointer" }} onClick={() => openDetail(p.id, p.category)}>
                       <td className="ps-4 text-muted small">{p.category}</td>
                       <td className="fw-bold">{p.phrase}</td>
+                      <td>{p.answer && p.answer !== "-" ? p.answer : ""}</td>
                       <td>{p.level !== "-" ? p.level : ""}</td>
                       <td>{p.readCount || 0}</td>
                       <td>{(p.averageTime || 0).toFixed(2)}s</td>
@@ -932,6 +944,13 @@ function App() {
           
           <div className="text-muted mb-2">難易度レベル</div>
           <div className="h3 fw-bold text-danger">{result.difficulty.toFixed(2)}</div>
+
+          {result.answer && result.answer !== "-" && (
+            <>
+              <div className="text-muted mt-4 mb-2">答え</div>
+              <div className="h4 fw-bold text-dark">{result.answer}</div>
+            </>
+          )}
         </div>
       </div>
     );

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -8,18 +8,24 @@ window.alert = vi.fn();
 window.fetch = vi.fn();
 
 // Mock Audio
-window.Audio = vi.fn().mockImplementation(() => ({
-  play: vi.fn().mockResolvedValue(),
-  load: vi.fn(),
-  // Simulate successful loading
-  set src(url) {
-    setTimeout(() => {
-      if (this.oncanplaythrough) this.oncanplaythrough();
-      // Simulate audio ending immediately for tests
-      if (this.onended) setTimeout(this.onended, 0);
-    }, 0);
-  },
-}));
+// アプリ側は `new Audio(url)` のコンストラクタ引数でsrcを渡すため(後からの代入はしない)、
+// コンストラクタ引数を受け取ったらsrcセッターと同じ処理を実行する。
+window.Audio = vi.fn().mockImplementation((url) => {
+  const audio = {
+    play: vi.fn().mockResolvedValue(),
+    load: vi.fn(),
+    // Simulate successful loading
+    set src(url) {
+      setTimeout(() => {
+        if (this.oncanplaythrough) this.oncanplaythrough();
+        // Simulate audio ending immediately for tests
+        if (this.onended) setTimeout(this.onended, 0);
+      }, 0);
+    },
+  };
+  if (url) audio.src = url;
+  return audio;
+});
 
 // Mock window.scrollTo
 window.scrollTo = vi.fn();
@@ -154,6 +160,64 @@ describe('App', () => {
     expect(window.print).toHaveBeenCalled();
   });
 
+  it('shows the answer on the result screen after reading a phrase with answer data', async () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0); // 常にp1を選ばせる
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        return { ok: true, json: async () => ({ categories: ['Cat1'] }) };
+      }
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({
+            phrases: [
+              { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: '回答A' },
+              { id: 'p2', category: 'Cat1', kana: 'い', phrase: '読み札2', level: '-', answer: '回答B' },
+            ],
+          }),
+        };
+      }
+      if (url.includes('get-phrase')) {
+        const id = new URL(url).searchParams.get('id');
+        const phraseById = {
+          p1: { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: '回答A' },
+          p2: { id: 'p2', category: 'Cat1', kana: 'い', phrase: '読み札2', level: '-', answer: '回答B' },
+        };
+        return { ok: true, json: async () => ({ ...phraseById[id], audioData: 'dummy' }) };
+      }
+      if (url.includes('get-congratulation-audio')) {
+        return { ok: true, json: async () => ({ audioData: 'dummy' }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    const categoryButton = await screen.findByRole('button', { name: 'Cat1' });
+    fireEvent.click(categoryButton);
+    fireEvent.click(screen.getByText('はい'));
+
+    await waitFor(() => screen.getByText('次の札'));
+    fireEvent.click(screen.getByText('次の札'));
+
+    // 読み上げの待機(イントロ300ms + 表示までの3000ms + フェード500ms)後に読み札がめくられて表示される
+    // (「読み札1」というテキストは履歴リストにも即時表示されるため、本体の表示領域に絞って待機する)
+    await waitFor(() => {
+      expect(screen.getByText('読み札1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+    }, { timeout: 8000 });
+
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(screen.getByText('答え')).toBeInTheDocument();
+      expect(screen.getByText('回答A')).toBeInTheDocument();
+    }, { timeout: 4000 });
+
+    randomSpy.mockRestore();
+  }, 15000);
+
   it('updates settings (lang, sort order, speech rate)', async () => {
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: ['Cat1'] }) };
@@ -182,6 +246,43 @@ describe('App', () => {
 
     fireEvent.click(screen.getByText('はやい'));
     expect(localStorage.getItem('speechRate')).toBe('100%');
+  });
+
+  it('shows an answer column with data and blank fallback in all-phrases view', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ categories: [] }),
+    });
+    await act(async () => {
+      render(<App />);
+    });
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        return { ok: true, json: async () => ({ categories: [] }) };
+      }
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({
+            phrases: [
+              { id: 'p1', category: 'Cat1', phrase: '読み札A', level: '-', answer: '回答A' },
+              { id: 'p2', category: 'Cat1', phrase: '読み札B', level: '-', answer: '-' },
+            ],
+          }),
+        };
+      }
+      return { ok: false };
+    });
+
+    const allPhrasesLink = screen.getByText(/全札一覧を見る/i);
+    fireEvent.click(allPhrasesLink);
+
+    await waitFor(() => {
+      expect(screen.getByText('答え')).toBeInTheDocument();
+      expect(screen.getByText('回答A')).toBeInTheDocument();
+      expect(screen.getByText('読み札B').closest('tr')).not.toHaveTextContent('-');
+    });
   });
 
   it('updates document title when viewing all-phrases', async () => {


### PR DESCRIPTION
設計:
- 選定内容: タイム結果画面(renderResult)に答えがある場合のみ「答え」見出しと値を追加表示し、全札一覧テーブルにも「答え」列(ソート可能)を追加した。答えデータが無い(answerが未設定または"-")場合は既存どおり何も表示しない。
- 選定内容: 答え列のソートは既存のlevel列と同様に、未設定値("-"/未設定)を常に末尾に固定する専用比較ロジックを追加した。
- 選定内容: レビューで発覚したbackend/handler.jsのgetPhrase(読み上げ用フレーズ取得API)がDynamoDBのProjectionExpressionおよびレスポンス本文にanswerを含めておらず、結果画面の答え表示が本番で機能しない不整合を検出したため、合わせて修正した。
- 却下内容: answer判定ロジック("値があり、かつ\"-\"でない")を共通ヘルパー関数に切り出す案は見送った。既存コード(絵札印刷のgetEfudaText)でも同様のインラインパターンが使われており、今回の差分範囲を超える既存設計への手出しになるため。
- 理由: 既存の答えデータ(answerフィールド)はCSV/DynamoDBに既に存在していたが、UIで参照される箇所が限定的だったため活用されていなかった。

影響:
- 影響モジュール: frontend/src/App.jsx(renderResult、全札一覧テーブル、sortedPhrasesのソート処理)、backend/handler.js(getPhraseのProjectionExpressionとresponseBody)。
- 振る舞いの変更: 答えデータが存在するテーマでは、タイム結果画面と全札一覧に答えが表示されるようになる。答えデータが無いテーマでは表示内容に変化はない。

テスト:
- 追加済み: frontend/src/App.test.jsxに「結果画面に答えが表示される」「全札一覧に答え列が表示され、未設定時は空欄になる」の2件を追加。backend/handler.test.jsに「getPhraseがanswerフィールドを返す」を1件追加。テスト用のAudioモックがコンストラクタ引数経由のsrc設定に対応していなかった既存の不備も合わせて修正(これがないと読み上げ完了を待つテストが永久にハングする)。
- 未追加: getPhraseのGetCommand経路(idとcategoryを同時指定した場合)でのanswer返却は明示的なテストを追加していない(ProjectionExpressionの影響を受けない経路のため、既存実装で問題なく動作する)。