### PR TITLE
feat(frontend): 絵札印刷の枠線を太く・角丸にし用紙情報にリンクを追加

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -172,7 +172,8 @@ button:active:not(:disabled) {
   width: 91mm;
   height: 55mm;
   box-sizing: border-box;
-  border: 1mm solid #e44d26;
+  border: 5mm solid #e44d26;
+  border-radius: 4mm;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -720,7 +720,7 @@ function App() {
           <>
             <div className="no-print text-center mb-4">
               <p className="text-muted small mb-3">
-                用紙: エーワン マルチカード（マイクロミシン・厚口）A4・10面用<br />
+                用紙: <a href="https://www.a-one.co.jp/product/search/detail.php?id=51677" target="_blank" rel="noopener noreferrer">エーワン マルチカード（マイクロミシン・厚口）A4・10面用</a><br />
                 印刷ダイアログで「用紙サイズ: A4」「余白: なし」「拡大縮小: 実際のサイズ(100%)」「ヘッダーとフッター: オフ」に設定してください。
               </p>
               <button onClick={() => window.print()} className="btn btn-lg px-5 py-2 fw-bold rounded-pill shadow btn-karuta">

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -184,6 +184,11 @@ describe('App', () => {
       expect(screen.getByText('回答1')).toBeInTheDocument();
     });
 
+    // 用紙情報に商品ページへのリンクが設定されている
+    const paperLink = screen.getByRole('link', { name: /エーワン マルチカード/ });
+    expect(paperLink).toHaveAttribute('href', 'https://www.a-one.co.jp/product/search/detail.php?id=51677');
+    expect(paperLink).toHaveAttribute('target', '_blank');
+
     // 11枚 → 10面/ページなので2ページ生成される
     expect(document.querySelectorAll('.efuda-page').length).toBe(2);
 


### PR DESCRIPTION
設計:
- 選定内容: .efuda-cardのborderを1mm→5mmに変更しborder-radius: 4mmを追加。用紙情報テキストをa要素でラップしエーワン製品ページへリンク
- 却下内容: N/A
- 理由: ユーザー指示により切りやすさ・見栄えを向上、用紙の購入元を明示するため

影響:
- 影響モジュール: frontend/src/App.css, frontend/src/App.jsx（絵札印刷画面のみ）
- 振る舞いの変更: カード枠線が太くなり角丸になる。border厚が増えた分カード内テキスト表示領域がわずかに狭くなる。用紙情報のリンクは新しいタブで開く

テスト:
- 追加済み: 用紙情報リンクのhref/target属性を検証するテストをApp.test.jsxに追加
- 未追加: 実ブラウザでの目視確認（環境にブラウザ操作ツールがないため未実施）