### PR TITLE
fix(frontend): 絵札印刷のページ詰めとテストかるた削除

### DIFF
--- a/backend/phrases.csv
+++ b/backend/phrases.csv
@@ -1,6 +1,4 @@
 id,category,level,kana,phrase,phrase_en,answer
-1,テスト用,5,あ,アメンボ赤いな　あいうえお,"A red water strider — A, I, U, E, O.",-
-2,テスト用,100,い,犬も歩けば　棒に当たる,"If you go out, you may run into trouble.",-
 3,大ピンチずかん,77,え,エスカレーターが　ぎゃくだった,The escalator was going the opposite way.,-
 4,大ピンチずかん,20,あ,アイスが　とけてきた,The ice cream started melting.,-
 5,大ピンチずかん,4,へ,へんな　ひやけを　した,Made a strange face.,-

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -207,6 +207,14 @@ button:active:not(:disabled) {
   word-break: break-word;
 }
 
+.efuda-card-category {
+  position: absolute;
+  top: 3mm;
+  right: 3mm;
+  margin: 0;
+  font-size: 9px;
+}
+
 @media print {
   .no-print {
     display: none !important;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -83,15 +83,12 @@ function App() {
   const EFUDA_PER_PAGE = 10;
   const efudaPages = useMemo(() => {
     const pages = [];
-    selectedCategories.forEach(cat => {
-      const phrasesForCat = allPhrasesForCategory.filter(p => p.category === cat);
-      for (let i = 0; i < phrasesForCat.length; i += EFUDA_PER_PAGE) {
-        pages.push({ category: cat, items: phrasesForCat.slice(i, i + EFUDA_PER_PAGE) });
-      }
-    });
-    if (pages.length === 0) pages.push({ category: null, items: [] });
+    for (let i = 0; i < allPhrasesForCategory.length; i += EFUDA_PER_PAGE) {
+      pages.push({ items: allPhrasesForCategory.slice(i, i + EFUDA_PER_PAGE) });
+    }
+    if (pages.length === 0) pages.push({ items: [] });
     return pages;
-  }, [allPhrasesForCategory, selectedCategories]);
+  }, [allPhrasesForCategory]);
 
   const handleSort = (key) => {
     let direction = 'asc';
@@ -731,9 +728,6 @@ function App() {
             <div className="efuda-print-area">
               {efudaPages.map((page, pageIndex) => (
                 <div className="efuda-page" key={pageIndex}>
-                  {selectedCategories.length > 1 && (
-                    <p className="no-print text-muted small mb-2">{page.category}</p>
-                  )}
                   <div className="efuda-grid">
                     {Array.from({ length: EFUDA_PER_PAGE }).map((_, slotIndex) => {
                       const p = page.items[slotIndex];
@@ -741,6 +735,9 @@ function App() {
                         <div className="efuda-card" key={slotIndex}>
                           {p && (
                             <>
+                              {selectedCategories.length > 1 && (
+                                <p className="no-print text-muted small efuda-card-category">{p.category}</p>
+                              )}
                               <div className="efuda-card-kana">{p.kana}</div>
                               <div className="efuda-card-text">{getEfudaText(p)}</div>
                             </>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -196,7 +196,7 @@ describe('App', () => {
     expect(window.print).toHaveBeenCalled();
   });
 
-  it('groups printed efuda pages by category and labels each page when multiple categories are selected', async () => {
+  it('packs printed efuda cards across categories onto the same page without breaking per category', async () => {
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: ['Cat1', 'Cat2'] }) };
       // Both categories reuse id "p1" to also verify same-id phrases from
@@ -228,10 +228,61 @@ describe('App', () => {
     fireEvent.click(screen.getByText('絵札を印刷する'));
 
     await waitFor(() => {
-      // 各カテゴリが別ページになる（1枚ずつでも合算されず2ページ）
-      expect(document.querySelectorAll('.efuda-page').length).toBe(2);
+      // カテゴリ境界で改ページせず、1枚ずつでも詰めて1ページにまとまる
+      expect(document.querySelectorAll('.efuda-page').length).toBe(1);
       expect(screen.getByText('Cat1テキスト')).toBeInTheDocument();
       expect(screen.getByText('Cat2テキスト')).toBeInTheDocument();
+    });
+  });
+
+  it('fills a page across the category boundary instead of leaving trailing blanks', async () => {
+    const cat1Phrases = Array.from({ length: 7 }, (_, i) => ({
+      id: `a${i}`,
+      category: 'Cat1',
+      kana: 'あ',
+      phrase: `Cat1テキスト${i}`,
+      answer: '-',
+    }));
+    const cat2Phrases = Array.from({ length: 5 }, (_, i) => ({
+      id: `b${i}`,
+      category: 'Cat2',
+      kana: 'い',
+      phrase: `Cat2テキスト${i}`,
+      answer: '-',
+    }));
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: ['Cat1', 'Cat2'] }) };
+      if (url.includes('category=Cat1')) return { ok: true, json: async () => ({ phrases: cat1Phrases }) };
+      if (url.includes('category=Cat2')) return { ok: true, json: async () => ({ phrases: cat2Phrases }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Cat1/ })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Cat2/ })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Cat1/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Cat2/ }));
+    fireEvent.click(screen.getByText(/決定/));
+    fireEvent.click(screen.getByText('はい'));
+
+    await waitFor(() => screen.getByText('絵札を印刷する'));
+    fireEvent.click(screen.getByText('絵札を印刷する'));
+
+    await waitFor(() => {
+      // Cat1(7枚)+Cat2(5枚)=12枚 → 10面/ページなので2ページ生成される
+      const pages = document.querySelectorAll('.efuda-page');
+      expect(pages.length).toBe(2);
+      // 1ページ目はカテゴリ境界で途切れず10面すべて埋まる(空白カードなし)
+      expect(pages[0].querySelectorAll('.efuda-card-text').length).toBe(10);
+      // 2ページ目はCat2の残り2枚のみ
+      expect(pages[1].querySelectorAll('.efuda-card-text').length).toBe(2);
     });
   });
 


### PR DESCRIPTION
設計:
- 選定内容: 印刷ページ生成を、カテゴリ単位で分割せず全選択カテゴリを1つの連続リストにして10枚ごとに詰める方式へ変更。
- 却下内容: カテゴリ単位のページ構成を維持しつつ空白セルだけ詰める案（実装が複雑になるため不採用）。
- 理由: 複数カテゴリ選択時、各カテゴリの最終ページに余った空白セルが用紙を浪費していたため。

影響:
- 影響モジュール: frontend/src/App.jsx, frontend/src/App.css, frontend/src/App.test.jsx, backend/phrases.csv
- 振る舞いの変更: 印刷画面でカテゴリ境界を越えて10枚ずつ詰めてページを生成。複数カテゴリ選択時はページ単位のラベルをカード単位のカテゴリ表示に変更。あわせて不要なテスト用かるた(id 1, 2)をphrases.csvから削除。

テスト:
- 追加済み: カテゴリ境界をまたいで詰められ空白セルが残らないことを検証する単体テストを追加。既存のページ分割テストの期待値を新挙動に更新。
- 未追加: 実機プリンタでの印刷結果の目視確認。