### PR TITLE
fix(frontend): 絵札印刷カードの角丸を拡大し内側の角も丸くする

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -173,7 +173,7 @@ button:active:not(:disabled) {
   height: 55mm;
   box-sizing: border-box;
   border: 5mm solid #e44d26;
-  border-radius: 4mm;
+  border-radius: 9mm;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
設計:
- 選定内容: .efuda-card の border-radius を 4mm から 9mm に変更
- 却下内容: border-width(5mm)自体を下げる対応
- 理由: border-radius が border-width 以下だと内側の角丸が0になり角張って見えるため、 border-width(5mm)より大きい値にして外側・内側ともに丸みが出るようにした

影響:
- 影響モジュール: frontend/src/App.css の絵札印刷カードのスタイルのみ
- 振る舞いの変更: 見た目のみの変更で、印刷レイアウトやサイズ計算には影響しない

テスト:
- 追加済み: なし（CSSの数値変更のみのためユニットテスト対象外）
- 未追加: Playwrightでローカル起動し印刷画面のカード角を実機目視確認済み