### PR TITLE
feat: こども向け/エンジニア向けの区分選択機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ graph TD
 | :--- | :--- | :--- | :--- |
 | category | String | Partition Key | カテゴリ名 |
 | id | String | Sort Key | フレーズの一意識別子 |
+| group | String | - | 対象区分（`kids`: こども向け / `engineer`: エンジニア向け） |
 | phrase | String | - | 読み上げテキスト（日本語） |
 | phrase_en | String | - | 読み上げテキスト（英語） |
 | kana | String | - | フレーズの読み（かな） |
@@ -157,6 +158,7 @@ Amazon Polly で生成した音声データのキャッシュ。
    - `kana`: 読み（かな）
    - `phrase_en`: 英語テキスト（任意）
    - `level`: 難易度（数値または `-`）
+   - `group`: 対象区分（`kids`: こども向け / `engineer`: エンジニア向け）
 2. 変更を `main` ブランチにコミット＆プッシュします。
 3. GitHub Actions の CD ワークフローが自動的に実行され、DynamoDB のデータが更新されます。
    - 既存のアイテムの統計情報（読み上げ回数や平均時間）は維持されます。

--- a/backend/handler.js
+++ b/backend/handler.js
@@ -417,15 +417,25 @@ exports.getCategories = async (event) => {
   try {
     const scanParams = {
       TableName: process.env.TABLE_NAME,
-      ProjectionExpression: "category",
+      ProjectionExpression: "category, #grp",
+      ExpressionAttributeNames: {
+        "#grp": "group",
+      },
     };
     const scanResult = await docClient.send(new ScanCommand(scanParams));
     const items = scanResult.Items || [];
-    
-    let categories = [...new Set(items.map(item => item.category || "大ピンチずかん"))];
-    categories = categories.filter(cat => !!cat);
+
+    const categoryMap = new Map();
+    items.forEach(item => {
+      const name = item.category || "大ピンチずかん";
+      if (!categoryMap.has(name)) {
+        categoryMap.set(name, item.group === "engineer" ? "engineer" : "kids");
+      }
+    });
+
+    let categories = [...categoryMap.entries()].map(([name, group]) => ({ name, group }));
     if (categories.length === 0) {
-      categories = ["大ピンチずかん"];
+      categories = [{ name: "大ピンチずかん", group: "kids" }];
     }
 
     return {

--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -20,12 +20,12 @@ describe('getCategories', () => {
     process.env.TABLE_NAME = 'TestTable';
   });
 
-  it('should return categories', async () => {
+  it('should return categories with their group', async () => {
     ddbMock.on(ScanCommand).resolves({
       Items: [
-        { category: 'Category1' },
-        { category: 'Category2' },
-        { category: 'Category1' },
+        { category: 'Category1', group: 'kids' },
+        { category: 'Category2', group: 'engineer' },
+        { category: 'Category1', group: 'kids' },
       ],
     });
 
@@ -33,7 +33,28 @@ describe('getCategories', () => {
     const body = JSON.parse(response.body);
 
     expect(response.statusCode).toBe(200);
-    expect(body.categories).toEqual(['Category1', 'Category2']);
+    expect(body.categories).toEqual([
+      { name: 'Category1', group: 'kids' },
+      { name: 'Category2', group: 'engineer' },
+    ]);
+  });
+
+  it('should default group to kids when missing or unrecognized', async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        { category: 'Category1' },
+        { category: 'Category2', group: 'unknown' },
+      ],
+    });
+
+    const response = await getCategories({});
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body.categories).toEqual([
+      { name: 'Category1', group: 'kids' },
+      { name: 'Category2', group: 'kids' },
+    ]);
   });
 
   it('should return default category if no items', async () => {
@@ -45,7 +66,7 @@ describe('getCategories', () => {
     const body = JSON.parse(response.body);
 
     expect(response.statusCode).toBe(200);
-    expect(body.categories).toEqual(['大ピンチずかん']);
+    expect(body.categories).toEqual([{ name: '大ピンチずかん', group: 'kids' }]);
   });
 
   it('should handle errors', async () => {

--- a/backend/phrases.csv
+++ b/backend/phrases.csv
@@ -1,685 +1,685 @@
-id,category,level,kana,phrase,phrase_en,answer
-3,大ピンチずかん,77,え,エスカレーターが　ぎゃくだった,The escalator was going the opposite way.,-
-4,大ピンチずかん,20,あ,アイスが　とけてきた,The ice cream started melting.,-
-5,大ピンチずかん,4,へ,へんな　ひやけを　した,Made a strange face.,-
-6,大ピンチずかん,30,た,たんじょうびケーキが　たおれて　イチゴが　ころがった,The birthday cake fell over and the strawberries rolled away.,-
-7,大ピンチずかん,23,ご,ごはんつぶを　ふんだ,Stepped on a grain of rice.,-
-8,大ピンチずかん,21,お,おふろの　ごみが　すくえない,Can't scoop the debris out of the bathtub.,-
-9,大ピンチずかん,18,ふ,ふたが　ない,There is no lid.,-
-10,大ピンチずかん,6,て,テープの　はしが　みつからない,Can't find the end of the tape.,-
-11,大ピンチずかん,28,え,えだまめが　とんだ,The edamame flew away.,-
-12,大ピンチずかん,24,か,カップめんの　おゆが　たりない,Not enough hot water for the cup noodles.,-
-13,大ピンチずかん,68,う,うんてんちゅうの　くるまの　なかに　おおきな　クモが　いる,There is a big spider in the car while driving.,-
-14,大ピンチずかん,35,ゆ,ゆでたまごが　ボロボロ,The boiled egg is falling apart.,-
-15,大ピンチずかん,5,す,ストローが　とれない,Can't take out the straw.,-
-16,大ピンチずかん,27,う,「う」の　もじが　はんたいだった,The letter 'u' was backwards.,-
-17,大ピンチずかん,19,け,おちたけしゴムがみつからない,Can't find the dropped eraser.,-
-18,大ピンチずかん,17,し,しょうゆをいれすぎた,Poured too much soy sauce.,-
-19,大ピンチずかん,34,しゃ,シャワーがみつからない,Can't find the shower.,-
-20,大ピンチずかん,3,こ,こおりがしたにくっついた,The ice stuck to my tongue.,-
-21,大ピンチずかん,26,た,たんじょうびケーキがたおれそう,The birthday cake is about to fall.,-
-22,大ピンチずかん,22,じ,じゅうでんができていなかった,It wasn't charged.,-
-23,大ピンチずかん,14,し,シャボンえきをすった,Accidentally inhaled the bubble solution.,-
-24,大ピンチずかん,33,け,ケチャップがとんだ,Ketchup splattered.,-
-25,大ピンチずかん,31,ぽ,ポケットからすながたくさんでてきた,A lot of sand came out of the pocket.,-
-26,大ピンチずかん,25,せ,せんたくきのうしろにくつしたがおちた,A sock fell behind the washing machine.,-
-27,大ピンチずかん,90,ふ,フンをふんだ,Stepped on poop.,-
-28,大ピンチずかん,55,い,いおうとしていたことをわすれた,Forgot what I was about to say.,-
-29,大ピンチずかん,46,に,にくがきれない,Can't cut the meat.,-
-30,大ピンチずかん,39,た,たんじょうびケーキのろうそくがきえない,The birthday cake candles won't go out.,-
-31,大ピンチずかん,52,む,むかしのおにぎりがでてきた,An old rice ball appeared.,-
-32,大ピンチずかん,54,れ,れいとうこがあかない,The freezer won't open.,-
-33,大ピンチずかん,48,ふ,ふくのピラピラがきになる,The loose thread on my clothes is bothering me.,-
-34,大ピンチずかん,43,し,しゅくだいノートと　じゆうちょうをまちがえた,Confused the homework notebook with the sketchbook.,-
-35,大ピンチずかん,38,ふ,ふたがしまらない,The lid won't close.,-
-36,大ピンチずかん,32,め,めんつゆがすごくあまった,A lot of noodle dipping sauce was left over.,-
-37,大ピンチずかん,53,な,ながしのみずがスプーンではねた,The water in the sink splashed off the spoon.,-
-38,大ピンチずかん,49,べ,べんざをあけたまますわった,Sat down with the toilet seat up.,-
-39,大ピンチずかん,37,あ,アメリカンドッグがまわる,The corn dog is spinning.,-
-40,大ピンチずかん,76,ね,ねむれない,Can't sleep.,-
-41,大ピンチずかん,47,し,シャンプーがめにはいった,Got shampoo in my eyes.,-
-42,大ピンチずかん,51,ば,バッグのなかですいとうがもれた,The water bottle leaked inside the bag.,-
-43,大ピンチずかん,56,な,なまえがおもいだせない,Can't remember the name.,-
-44,大ピンチずかん,64,き,きんじょのおばさんが　ずっとなまえをまちがえている,The neighborhood lady has been getting my name wrong for a long time.,-
-45,大ピンチずかん,50,お,おゆがない,There is no hot water.,-
-46,大ピンチずかん,45,ど,ドアをあけられてさむい,Someone opened the door and it's cold.,-
-47,大ピンチずかん,40,せ,せんせいのメガネがとんだ,The teacher's glasses flew off.,-
-48,大ピンチずかん,36,ほ,ほねをとっていたら　ぐちゃぐちゃになった,It became a mess while I was trying to remove the bones.,-
-49,大ピンチずかん,29,ぎ,ぎゅうにゅうがこぼれた,The milk spilled.,-
-50,大ピンチずかん,96,か,かさがうらがえった,The umbrella turned inside out.,-
-51,大ピンチずかん,97,じ,じてんしゃがドミノだおし,The bicycles fell over like dominoes.,-
-52,大ピンチずかん,98,お,おもったよりみじかくなった,It became shorter than I thought.,-
-53,大ピンチずかん,99,ね,ネコがついてくる,A cat is following me.,-
-54,大ピンチずかん,100,ど,どしゃぶりなのにかさがない,It's pouring rain but I don't have an umbrella.,-
-55,大ピンチずかん,58,れ,れいとうこがしまらない,The freezer won't close.,-
-56,大ピンチずかん,59,さ,さようならのおじぎで　ランドセルのなかみがぜんぶでた,Everything fell out of my backpack when I bowed to say goodbye.,-
-57,大ピンチずかん,84,ま,まいご,I'm lost.,-
-58,大ピンチずかん,82,か,かいものがながい,Shopping is taking a long time.,-
-59,大ピンチずかん,81,じ,じてんしゃにハチがとまっている,A bee is sitting on the bicycle.,-
-60,大ピンチずかん,60,せ,せんせいに　おかあさんといってしまった,I accidentally called my teacher 'Mom'.,-
-61,大ピンチずかん,61,ぎ,ギターのなかにおかしがおちた,A snack fell inside the guitar.,-
-62,大ピンチずかん,62,ず,ズボンのゴムがきれた,The elastic in my pants snapped.,-
-63,大ピンチずかん,63,さ,さなぎからかえったカブトムシが　よなかにだっそうして　とびまわっている,The beetle that emerged from its pupa escaped at night and is flying around.,-
-64,大ピンチずかん,57,け,けしゴムにさした　えんぴつのしんが　けしたときにつく,The pencil lead stuck in the eraser leaves marks when I erase.,-
-65,大ピンチずかん,89,お,おきられない,Can't wake up.,-
-66,大ピンチずかん,91,で,かばしらに　じてんしゃで　つっこんだ,Crashed my bicycle into a mosquito swarm.,-
-67,大ピンチずかん,93,と,トイレがつまった,The toilet is clogged.,-
-68,大ピンチずかん,94,お,おかあさんがイライラしている,Mom is getting irritated.,-
-69,大ピンチずかん,95,お,プレゼントをわすれた,Forgot the present.,-
-70,大ピンチずかん,86,し,しんしつに　だれかいる,Someone is in the bedroom.,-
-71,大ピンチずかん,87,く,クモのすにかかった,Got caught in a spider web.,-
-72,大ピンチずかん,88,と,トイレにおおきなガがとまっている,A large moth is sitting in the toilet.,-
-73,大ピンチずかん,9,し,しゃっくりがとまらない,Can't stop hiccuping.,-
-74,大ピンチずかん,16,わ,わりばしがうまくわれない,Can't split the chopsticks properly.,-
-75,大ピンチずかん,11,ご,ゴミばこがやまもり,The trash can is overflowing.,-
-76,大ピンチずかん,70,お,おなかがすいてうごけない,So hungry I can't move.,-
-77,大ピンチずかん,67,ま,まちがえてシャワーがでた,The shower came on by mistake.,-
-78,大ピンチずかん,13,け,パンがくろこげ,The bread is burnt to a crisp.,-
-79,大ピンチずかん,10,け,けずりかすいれがはいってなかった,The pencil shavings container wasn't in.,-
-80,大ピンチずかん,71,ふ,ふとんのなかでおならがでた,Farted under the covers.,-
-81,大ピンチずかん,69,じ,じぶんのいえでトイレがつまった,The toilet at my own house is clogged.,-
-82,大ピンチずかん,8,あ,あたまにつけたわゴムがとれない,Can't remove the rubber band I put on my head.,-
-83,大ピンチずかん,12,や,ビニールぶくろがめくれない,Can't open the plastic bag.,-
-84,大ピンチずかん,15,し,しょくばんを　がんばってスライスしているうちに　ぺしゃんこになっていた,The bread got squashed while I was trying hard to slice it.,-
-85,大ピンチずかん,7,ぺ,ペンがしみてつくえについた,The pen leaked onto the desk.,-
-86,大ピンチずかん,80,や,やっぱりさむかった,It was cold after all.,-
-87,大ピンチずかん,74,と,トイレのかみがない,There is no toilet paper.,-
-88,大ピンチずかん,73,わ,ワサビいりだった,It had wasabi in it.,-
-89,大ピンチずかん,72,お,おべんとうをわすれた,Forgot my lunch box.,-
-90,大ピンチずかん,66,あ,あしがつちだらけ,Feet are covered in mud.,-
-91,大ピンチずかん,65,は,ハエがじぶんにばかりとまる,Flies only land on me.,-
-92,大ピンチずかん,83,い,イヌがすごくなめてくる,The dog is licking me a lot.,-
-93,大ピンチずかん,75,し,しらないひとのてをにぎっていた,Was holding a stranger's hand.,-
-94,大ピンチずかん,85,し,シロツメクサの　かんむりをよくみると　アブラムシだらけだった,"When I looked closely at the clover crown, it was full of aphids.",-
-95,大ピンチずかん,79,ば,バッグにアリがあつまってきた,Ants gathered on the bag.,-
-96,大ピンチずかん,78,し,しんしつの　てんじょうのもくめが　ひとのかおにみえてきた,The wood grain on the bedroom ceiling started to look like a person's face.,-
-97,大ピンチずかん,41,や,やすみじかんに　おいた　すいとうが　そのまま,The water bottle I left during recess is still there.,-
-98,大ピンチずかん,42,ご,ごはんが　たりない,Not enough food.,-
-99,大ピンチずかん,44,は,はなしを　きいてなかった,Wasn't listening.,-
-100,大ピンチずかん,2,の,のんだガムに　まだあじが　たくさんのこっていた,Swallowed the gum; it still had a lot of flavor left.,-
-101,大ピンチずかん,52,む,むかしの　おにぎりが　でてきた,An old rice ball appeared.,-
-102,国旗王,上級,し,人口密度が高い,High population density.,-
-103,国旗王,上級,ひ,一人当たりGDPが高い,High GDP per capita.,-
-104,国旗王,上級,し,首都 最東,Easternmost capital.,-
-105,国旗王,上級,し,首都が最北,Northernmost capital.,-
-106,国旗王,上級,は,排他的経済水域,Exclusive Economic Zone.,-
-107,国旗王,上級,く,軍事費が最小,Smallest military expenditure.,-
-108,国旗王,上級,へ,平均寿命が短い,Short average life expectancy.,-
-109,国旗王,初級,し,人口が多い,Large population.,-
-110,国旗王,初級,め,面積が最小,Smallest area.,-
-111,国旗王,初級,は,排他的経済水域が最小,Smallest Exclusive Economic Zone.,-
-112,国旗王,上級,さ,最高地点が高い,Highest point is high.,-
-113,国旗王,初級,こ,国内総生産GDPが低い,Low GDP.,-
-114,国旗王,初級,し,人口が少ない,Small population.,-
-115,国旗王,初級,せ,正式国名が長い,Long official country name.,-
-116,国旗王,上級,く,軍事費が大きい,Large military expenditure.,-
-117,国旗王,上級,さ,最高地点が低い,Highest point is low.,-
-118,国旗王,初級,こ,国内総生産GDPが高い,High GDP.,-
-119,国旗王,初級,せ,正式国名が短い,Short official country name.,-
-120,国旗王,初級,め,面積が大きい,Large area.,-
-121,国旗王,上級,へ,平均寿命が長い,Long average life expectancy.,-
-122,国旗王,初級,ひ,一人当たりGDPが低い,Low GDP per capita.,-
-123,国旗王,初級,し,人口密度が低い,Low population density.,-
-124,国旗王,初級,せ,正式国名 五十音順 アに近い,Official name closest to 'A' in Japanese syllabary.,-
-125,国旗王,初級,し,首都が最南,Southernmost capital.,-
-126,おばけかるた,-,ふ,ふでこぞうが　ひとふでがき,Fudekozo draws with a single stroke.,ふでこぞう
-127,おばけかるた,-,ね,ねこまたも　ねがおはかわいい,Even Nekomata looks cute when sleeping.,ねこまた
-128,おばけかるた,-,ち,ちょうちんぶらり　こっちへ　くるぞ,Chochin-burari is coming this way!,ちょうちんぶらり
-129,おばけかるた,-,た,たまごがわれて　てんぐがうまれた,An egg cracked and a Tengu was born.,てんぐ
-130,おばけかるた,-,け,けむくじゃらな　うでだ　まけるな！,"It's a hairy arm, don't lose!",けむくじゃらなうで
-131,おばけかるた,-,く,くずかごからくろいてが！！！　きゃっ！！！,A black hand from the wastebasket!!! Kya!!!,くろいて
-132,おばけかるた,-,あ,あめふりこぞうが　びちゃびちゃあるく,Amefuri-kozo walks with a squish-squish.,あめふりこぞう
-133,おばけかるた,-,ひ,ひとつめのくには　ひとつめだらけだってさ,They say the one-eyed country is full of one-eyes.,ひとつめ
-134,おばけかるた,-,ぬ,ぬらりとわらう　ぬっぺっぽう,Nureppon smiles eerily.,ぬっぺっぽう
-135,おばけかるた,-,つ,つきよにでていくつく　もがみ,Tsuku-mogami goes out on a moonlit night.,つくもがみ
-136,おばけかるた,-,そ,そろってあるく　ぞうりのおばけ,Zori ghosts walk in pairs.,ぞうりのおばけ
-137,おばけかるた,-,こ,こんばんは～　どろどろどろどろ～,Good evening~ Doro-doro-doro-doro~,ゆうれい
-138,おばけかるた,-,き,きゅうびのきつねは　ばけるめいじん,The nine-tailed fox is a master of disguise.,きゅうびのきつね
-139,おばけかるた,-,い,いったんもめんは　そらとべていいなあ,"Ittan-momen, it's nice to fly in the sky.",いったんもめん
-140,おばけかるた,-,は,はたらけはたらけ　おばけもはたらけ,"Work, work, ghosts also work.",おばけ
-141,おばけかるた,-,に,にっこりわらう　にかいのおんな,The woman on the second floor smiles.,にかいのおんな
-142,おばけかるた,-,て,てんぐのはながおれては　かわいそう,It would be pitiful if Tengu's nose broke.,てんぐ
-143,おばけかるた,-,せ,せんすだって　すてればばける,Even a fan will transform if you throw it away.,せんす
-144,おばけかるた,-,さ,さかさくびは　ぺろぺろなめる,Sakasa-kubi licks with a flick-flick.,さかさくび
-145,おばけかるた,-,か,かあさんかっぱ　とこどものかっぱ,Mother Kappa and baby Kappa.,かっぱ
-146,おばけかるた,-,う,うみぼうずのがっこう　せいとをぼしゅう,Umibozu's school is recruiting students.,うみぼうず
-147,おばけかるた,-,の,のんきなのぶすま　のんびりとんだ,Carefree Nobusuma flew leisurely.,のぶすま
-148,おばけかるた,-,な,なきなきかえった　ちいさなゆうれい,A small ghost returned crying.,ちいさなゆうれい
-149,おばけかるた,-,と,とらがねてたら　かみなりどしーん！！,"If a tiger sleeps, lightning strikes with a boom!!",かみなり
-150,おばけかるた,-,す,すりばちこぞうは　なにすってるの？,What is Suribachi-kozo grinding?,すりばちこぞう
-151,おばけかるた,-,し,しろくてみえない　ゆきのひのゆうれい,A white and invisible ghost on a snowy day.,ゆきのひのゆうれい
-152,おばけかるた,-,お,おにもおじいさんになる,Even an ogre grows old.,おに
-153,おばけかるた,-,え,えだをもやしたら　えんえんらがでたぞ,"When I burned a branch, Enenra came out!",えんえんら
-154,おばけかるた,-,る,るすばんしてるは　ぶるぶるひとり,"Staying home alone, trembling.",ゆうれい
-155,おばけかるた,-,り,りゅうがいねむり　そらからおちる,"A dragon sleeping, falling from the sky.",りゅう
-156,おばけかるた,-,む,むじなもばけたが　ちょっとむりだった,"Mujina tried to transform, but it was a bit impossible.",むじな
-157,おばけかるた,-,み,みこしにゅうどう　みかけよりよわい,"Mikoshi-Nyudo, weaker than he looks.",みこしにゅうどう
-158,おばけかるた,-,れ,れいぎただしい　ゆうれいもいる,There are polite ghosts too.,ゆうれい
-159,おばけかるた,-,ら,らしょうもんの　おにはらんぼうだ,The demon of Rashomon is wild.,らしょうもんのおに
-160,おばけかるた,-,め,めだまをとられた　ひとつめこぞう,A one-eyed monster whose eye was taken.,ひとつめこぞう
-161,おばけかるた,-,ま,まくらがえしは　まいばんうるさい,Makura-gaeshi is noisy every night.,まくらがえし
-162,おばけかるた,-,ろ,ろくろくねなかった　ろくろっくび,Rokurokubi who didn't sleep at all.,ろくろっくび
-163,おばけかるた,-,よ,よみちをこわがる　よわむしにゅうどう,A timid Nyudo who is scared of night roads.,よわむしにゅうどう
-164,おばけかるた,-,も,もりんじのかまは　たぬきがばけた,Morinji's kettle was a transformed raccoon dog.,たぬき
-165,おばけかるた,-,ほ,ほうきのおばけは　ほめてやろう,Let's praise the broom ghost.,ほうきのおばけ
-166,おばけかるた,-,を,「あしをけして　てをまえに」ゆうれいのおけいこ,"Delete legs, hands forward - a ghost's practice.",ゆうれい
-167,おばけかるた,-,わ,わ、にゅうどうだ　わぁーっこわい！,"Oh, it's a Nyudo! Ahh, scary!",にゅうどう
-168,おばけかるた,-,ゆ,ゆきおんな　おゆにはいってとけちゃった,Yuki-onna went into hot water and melted.,ゆきおんな
-169,おばけかるた,-,や,やなぎのしたで　ゆうれいけんか,Ghosts fighting under a willow tree.,ゆうれい
-170,おばけかるた,-,へ,へびよりこわい　ろくろっくび,"Rokurokubi, scarier than a snake.",ろくろっくび
-171,いろはかるた,-,ま,嘘から出たまこと,A lie can sometimes turn into the truth,でたらめに言ったことが、偶然にも事実になってしまうこと
-172,いろはかるた,-,こ,弘法にも筆の誤り,Even experts make mistakes,どんな名人でも失敗することがあるというたとえ
-173,いろはかるた,-,あ,得手に帆を揚げる,To take advantage of a good opportunity,物事を行うのに絶好の機会を得ること
-174,いろはかるた,-,あ,味なもの縁は異なもの,Romance works in mysterious ways,男女の仲は理屈では説明できないものだということ
-175,いろはかるた,-,ぞ,芋の煮えたも御存じない,Completely clueless,物事の様子がまったく分からない人をからかう言い方
-176,いろはかるた,-,て,文はやりたし書く手は持たぬ,Wanting to write a letter but lacking the skill,やりたい気持ちはあるが能力が伴わず困っていること
-177,いろはかるた,-,す,亭主の好きな赤烏帽子,One must go along with the head of the household,家長の好みには家族も従うべきだという考え
-178,いろはかるた,-,し,知らぬが仏,Ignorance is bliss,知らなければ悩まずにすむこともあるということ
-179,いろはかるた,-,は,背に腹はかえられぬ,Needs must when driven,大きな目的のためには多少の犠牲は仕方ないということ
-180,いろはかるた,-,げ,芸は身を助ける,A skill will always help you,身につけた技や芸が困ったときに役立つこと
-181,いろはかるた,-,の,喉元過ぎれば熱さを忘れる,"Once the pain is gone, the lesson is forgotten",苦しい経験をしても時間がたつと忘れてしまうこと
-182,いろはかるた,-,あ,頭隠して尻隠さず,Trying to hide something but failing,一部しか隠していないのに全部隠したつもりでいること
-183,いろはかるた,-,み,身から出た錆,You reap what you sow,自分のした悪い行いの結果で自分が苦しむこと
-184,いろはかるた,-,も,門前の小僧習わぬ経を読む,You learn things naturally by exposure,日頃見聞きしているうちに自然と身につくことがある
-185,いろはかるた,-,お,鬼に金棒,Adding strength to the strong,強いものがさらに力を得て一層強くなること
-186,いろはかるた,-,ま,負けるが勝ち,Sometimes losing leads to winning,一歩引いた方が結果的に有利になることがある
-187,いろはかるた,-,さ,三遍回って煙草にしょ,Take time and be careful,急がず慎重に行動することが大切だということ
-188,いろはかるた,-,め,目の上のたん瘤,A thorn in one’s side,自分にとって邪魔で目障りな存在のたとえ
-189,いろはかるた,-,ひ,貧乏暇なし,The poor have no leisure,貧しい人ほど仕事に追われ時間の余裕がないこと
-190,いろはかるた,-,く,臭い物に蓋をする,To cover up an inconvenient truth,都合の悪いことを一時的に隠そうとすること
-191,いろはかるた,-,や,安物買いの銭失い,Buying cheap ends up costing more,安い物を買うとかえって損をすること
-192,いろはかるた,-,き,聞いて極楽見て地獄,Hearing and seeing are very different,聞くのと実際に見るのとでは大きな違いがあること
-193,いろはかるた,-,ゆ,油断大敵,Carelessness is dangerous,油断すると失敗や災難を招くということ
-194,いろはかるた,-,い,犬も歩けば棒に当たる,Every action brings some result,行動すれば良くも悪くも何かが起こるということ
-195,いろはかるた,-,ら,楽あれば苦あり,Life has ups and downs,人生には楽しいことと苦しいことの両方がある
-196,いろはかるた,-,む,無理が通れば道理が引っ込む,"When force prevails, reason disappears",無茶がまかり通る世の中では道理が通らなくなる
-197,いろはかるた,-,と,年寄りの冷や水,An old person acting recklessly,年齢を考えず無理な振る舞いをすること
-198,いろはかるた,-,す,粋は身を食う,Showing off can ruin you,気取った振る舞いが身を滅ぼすことがある
-199,いろはかるた,-,き,京の夢大阪の夢,Dreams are fleeting and strange,夢というものはとりとめなく不思議なものだということ
-200,いろはかるた,-,へ,下手の長談義,The unskilled talk the longest,下手な人ほど話が長くなること
-201,いろはかるた,-,ろ,論より証拠,Proof is better than argument,理屈よりも実際の証拠が大切だということ
-202,いろはかるた,-,く,くたびれ儲け,All effort and no reward,苦労したわりに何の得もないこと
-203,いろはかるた,-,に,憎まれっ子世にはばかる,The disliked often survive well,憎まれるような人ほど世渡りがうまいこと
-204,いろはかるた,-,ち,塵も積もれば山となる,Many small things add up,小さなことでも積み重なれば大きな成果になる
-205,いろはかるた,-,こ,律義者の子だくさん,Honest people tend to have many children,律義な人は家庭を大切にし子どもが多くなるという考え
-206,いろはかるた,-,ぬ,盗人の昼寝,Even bad acts have consequences,どんな行いにも必ず報いがあるということ
-207,いろはかるた,-,は,花より団子,Practicality over appearance,見た目より実利を重んじること
-208,いろはかるた,-,る,瑠璃も玻璃も照らせば光る,True talent shines anywhere,才能のある人はどんな環境でも力を発揮する
-209,いろはかるた,-,な,泣きっ面に蜂,Misfortune never comes alone,不運なときにさらに不幸が重なること
-210,いろはかるた,-,あ,葦の髄から天井のぞく,Judging the whole from a tiny part,わずかな知識で全て分かったつもりになること
-211,いろはかるた,-,か,蛙の面に水,Completely unfazed,何をされても平然としていること
-212,いろはかるた,-,わ,破れ鍋に綴じ蓋,Every pot has its lid,どんな人にもふさわしい相手がいるということ
-213,いろはかるた,-,を,老いては子に従え,Let the younger generation lead,年を取ったら若い者の意見に従うのがよい
-214,いろはかるた,-,ね,念には念を入れよ,Double-check everything,十分注意した上でさらに注意を重ねること
-215,いろはかるた,-,た,旅は道連れ世は情け,Life is about helping each other,人は助け合って生きていくものだということ
-216,いろはかるた,-,れ,良薬は口に苦し,Good medicine tastes bitter,忠告は耳に痛いが自分のためになる
-217,いろはかるた,-,そ,総領の甚六,The eldest son is often naive,長男は大事に育てられ世間知らずになりがちだということ
-218,いろはかるた,-,つ,月とすっぽん,Like night and day,似ているようで実際は大きな違いがある
-219,いろはかるた（意味）,-,ま,でたらめに言ったことが、偶然にも事実になってしまうこと,A lie can sometimes turn into the truth,嘘から出たまこと
-220,いろはかるた（意味）,-,こ,どんな名人でも失敗することがあるというたとえ,Even experts make mistakes,弘法にも筆の誤り
-221,いろはかるた（意味）,-,あ,物事を行うのに絶好の機会を得ること,To take advantage of a good opportunity,得手に帆を揚げる
-222,いろはかるた（意味）,-,あ,男女の仲は理屈では説明できないものだということ,Romance works in mysterious ways,味なもの縁は異なもの
-223,いろはかるた（意味）,-,ぞ,物事の様子がまったく分からない人をからかう言い方,Completely clueless,芋の煮えたも御存じない
-224,いろはかるた（意味）,-,て,やりたい気持ちはあるが能力が伴わず困っていること,Wanting to write a letter but lacking the skill,文はやりたし書く手は持たぬ
-225,いろはかるた（意味）,-,す,家長の好みには家族も従うべきだという考え,One must go along with the head of the household,亭主の好きな赤烏帽子
-226,いろはかるた（意味）,-,し,知らなければ悩まずにすむこともあるということ,Ignorance is bliss,知らぬが仏
-227,いろはかるた（意味）,-,は,大きな目的のためには多少の犠牲は仕方ないということ,Needs must when driven,背に腹はかえられぬ
-228,いろはかるた（意味）,-,げ,身につけた技や芸が困ったときに役立つこと,A skill will always help you,芸は身を助ける
-229,いろはかるた（意味）,-,の,苦しい経験をしても時間がたつと忘れてしまうこと,"Once the pain is gone, the lesson is forgotten",喉元過ぎれば熱さを忘れる
-230,いろはかるた（意味）,-,あ,一部しか隠していないのに全部隠したつもりでいること,Trying to hide something but failing,頭隠して尻隠さず
-231,いろはかるた（意味）,-,み,自分のした悪い行いの結果で自分が苦しむこと,You reap what you sow,身から出た錆
-232,いろはかるた（意味）,-,も,日頃見聞きしているうちに自然と身につくことがある,You learn things naturally by exposure,門前の小僧習わぬ経を読む
-233,いろはかるた（意味）,-,お,強いものがさらに力を得て一層強くなること,Adding strength to the strong,鬼に金棒
-234,いろはかるた（意味）,-,ま,一歩引いた方が結果的に有利になることがある,Sometimes losing leads to winning,負けるが勝ち
-235,いろはかるた（意味）,-,さ,急がず慎重に行動することが大切だということ,Take time and be careful,三遍回って煙草にしょ
-236,いろはかるた（意味）,-,め,自分にとって邪魔で目障りな存在のたとえ,A thorn in one’s side,目の上のたん瘤
-237,いろはかるた（意味）,-,ひ,貧しい人ほど仕事に追われ時間の余裕がないこと,The poor have no leisure,貧乏暇なし
-238,いろはかるた（意味）,-,く,都合の悪いことを一時的に隠そうとすること,To cover up an inconvenient truth,臭い物に蓋をする
-239,いろはかるた（意味）,-,や,安い物を買うとかえって損をすること,Buying cheap ends up costing more,安物買いの銭失い
-240,いろはかるた（意味）,-,き,聞くのと実際に見るのとでは大きな違いがあること,Hearing and seeing are very different,聞いて極楽見て地獄
-241,いろはかるた（意味）,-,ゆ,油断すると失敗や災難を招くということ,Carelessness is dangerous,油断大敵
-242,いろはかるた（意味）,-,い,行動すれば良くも悪くも何かが起こるということ,Every action brings some result,犬も歩けば棒に当たる
-243,いろはかるた（意味）,-,ら,人生には楽しいことと苦しいことの両方がある,Life has ups and downs,楽あれば苦あり
-244,いろはかるた（意味）,-,む,無茶がまかり通る世の中では道理が通らなくなる,"When force prevails, reason disappears",無理が通れば道理が引っ込む
-245,いろはかるた（意味）,-,と,年齢を考えず無理な振る舞いをすること,An old person acting recklessly,年寄りの冷や水
-246,いろはかるた（意味）,-,す,気取った振る舞いが身を滅ぼすことがある,Showing off can ruin you,粋は身を食う
-247,いろはかるた（意味）,-,き,夢というものはとりとめなく不思議なものだということ,Dreams are fleeting and strange,京の夢大阪の夢
-248,いろはかるた（意味）,-,へ,下手な人ほど話が長くなること,The unskilled talk the longest,下手の長談義
-249,いろはかるた（意味）,-,ろ,理屈よりも実際の証拠が大切だということ,Proof is better than argument,論より証拠
-250,いろはかるた（意味）,-,く,苦労したわりに何の得もないこと,All effort and no reward,くたびれ儲け
-251,いろはかるた（意味）,-,に,憎まれるような人ほど世渡りがうまいこと,The disliked often survive well,憎まれっ子世にはばかる
-252,いろはかるた（意味）,-,ち,小さなことでも積み重なれば大きな成果になる,Many small things add up,塵も積もれば山となる
-253,いろはかるた（意味）,-,こ,律義な人は家庭を大切にし子どもが多くなるという考え,Honest people tend to have many children,律義者の子だくさん
-254,いろはかるた（意味）,-,ぬ,どんな行いにも必ず報いがあるということ,Even bad acts have consequences,盗人の昼寝
-255,いろはかるた（意味）,-,は,見た目より実利を重んじること,Practicality over appearance,花より団子
-256,いろはかるた（意味）,-,る,才能のある人はどんな環境でも力を発揮する,True talent shines anywhere,瑠璃も玻璃も照らせば光る
-257,いろはかるた（意味）,-,な,不運なときにさらに不幸が重なること,Misfortune never comes alone,泣きっ面に蜂
-258,いろはかるた（意味）,-,あ,わずかな知識で全て分かったつもりになること,Judging the whole from a tiny part,葦の髄から天井のぞく
-259,いろはかるた（意味）,-,か,何をされても平然としていること,Completely unfazed,蛙の面に水
-260,いろはかるた（意味）,-,わ,どんな人にもふさわしい相手がいるということ,Every pot has its lid,破れ鍋に綴じ蓋
-261,いろはかるた（意味）,-,を,年を取ったら若い者の意見に従うのがよい,Let the younger generation lead,老いては子に従え
-262,いろはかるた（意味）,-,ね,十分注意した上でさらに注意を重ねること,Double-check everything,念には念を入れよ
-263,いろはかるた（意味）,-,た,人は助け合って生きていくものだということ,Life is about helping each other,旅は道連れ世は情け
-264,いろはかるた（意味）,-,れ,忠告は耳に痛いが自分のためになる,Good medicine tastes bitter,良薬は口に苦し
-265,いろはかるた（意味）,-,そ,長男は大事に育てられ世間知らずになりがちだということ,The eldest son is often naive,総領の甚六
-266,いろはかるた（意味）,-,つ,似ているようで実際は大きな違いがある,Like night and day,月とすっぽん
-267,百人一首,-,あ,あきのたの かりほのいおの とまをあらみ わがころもでは つゆにぬれつつ,"In the autumn field, in the temporary hut's rough rush-mats, my sleeves are getting wet with dew.",-
-268,百人一首,-,あ,あきかぜに たなびくくもの たえまより もれいづるつきの かげのさやけさ,"Through the rifts in the clouds trailing in the autumn wind, how clear the moonlight leaks out.",-
-269,百人一首,-,あ,あしびきの やまどりのをの しだりをの ながながしよを ひとりかもねむ,"Must I sleep alone through the long, long night, like the long, trailing tail of the mountain pheasant?",-
-270,百人一首,-,あ,あまのはら ふりさけみれば かすがなる みかさのやまに いでしつきかも,"When I look out over the plain of heaven, is that the same moon that rose over Mount Mikasa in Kasuga?",-
-271,百人一首,-,あ,あわれとも いうべきひとは おもほえで みのいたずらに なりぬべきかな,"Since there is no one who might feel pity for me, I suppose I shall just pass away in vain.",-
-272,百人一首,-,い,いまはただ おもひたえなむ とばかりを ひとづてならで いうよしもがな,Now I just want to give up my love; if only I could tell you this directly and not through others.,-
-273,百人一首,-,い,いまこむと いいしばかりに ながつきの ありあけのつきを まちいでつるかな,"Just because you said 'I'll come soon', I have waited until the morning moon of the long month appeared.",-
-274,百人一首,-,い,いろはにほへど ちりぬるを わがよたれぞ つねならむ,"Though flowers are fragrant, they will fall; in our world, who can remain forever?",-
-275,百人一首,-,い,いのちながくは かたみにあはず ひとりして ものおもふよぞ ながかりける,"If I live long, we might not meet again; the night I spend alone in thought is so very long.",-
-276,百人一首,-,い,いにしへの ならのみやこの やへざくら けふここのへに にほひぬるかな,The eight-layered cherry blossoms of the ancient capital of Nara are fragrantly blooming today in the imperial palace.,-
-277,百人一首,-,う,うかりける ひとをはつせの やまおろしよ はげしかれとは いのらぬものを,"O mountain wind of Hatsuse, I did not pray for you to be so harsh, though she is cold to me.",-
-278,百人一首,-,う,うらみわび ほさぬそでだに あるものを こひにくちなむ なこそをしけれ,"I resent her and am weary; my sleeves never dry, and I fear my reputation will rot away in this love.",-
-279,百人一首,-,え,えにしあらば あはむとぞおもふ いざさらば わがなとひとは わすれざらなむ,"If there is fate, I believe we shall meet; now farewell, and may you not forget my name.",-
-280,百人一首,-,お,おおえやま いくののみちの とおければ まだふみもみず あまのはしだて,The road to Ikuno over Mount Oe is so far that I have seen neither a letter nor Amanohashidate.,-
-281,百人一首,-,お,おくやまに もみぢふみわけ なくしかの こゑきくときぞ あきはかなしき,"When I hear the voice of the stag crying as he steps through the maple leaves deep in the mountains, autumn is truly sad.",-
-282,百人一首,-,か,かささぎの わたせるはしに おくしもの しろきをみれば よぞふけにける,"When I see the white frost on the bridge the magpies are said to have spread, I know the night has deepened.",-
-283,百人一首,-,か,かぜをいたみ いはうつなみの おのれのみ くだけてものを おもふころかな,"Like the waves breaking against the rocks in the fierce wind, I alone am broken as I think of my love.",-
-284,百人一首,-,き,きみがため はるののにいでて わかなつむ わがころもでに ゆきはふりつつ,"For your sake, I went out to the spring fields to pick young greens, while snow fell on my sleeves.",-
-285,百人一首,-,き,きみがため をしからざりし いのちさへ ながくもがなと おもひけるかな,"For your sake, I did not value my life, but now I wish it would be long.",-
-286,百人一首,-,く,くさもきも いろかはれども わたつみの なみのはなにぞ あきなかりける,"Though the colors of plants and trees change, there is no autumn in the flowers of the sea waves.",-
-287,百人一首,-,く,くれなゐに みづくくるとは ききしかど あきぞこのはに まじりけるかな,"I heard that the water is dyed crimson, but it seems autumn has mixed into the leaves.",-
-288,百人一首,-,こ,こころあてに をらばやをらむ はつしもの おきまどはせる しらぎくのはな,"If I were to pick them at random, I might pick the white chrysanthemums that the first frost has confused.",-
-289,百人一首,-,こ,このたびは ぬさもとりあへず たむけやま もみぢのにしき かみのまにまに,"At this time, I could not even bring an offering; let the gods take the brocade of maple leaves on Mount Tamuke.",-
-290,百人一首,-,さ,さびしさに やどをたちいでて ながむれば いづこもおなじ あきのゆふぐれ,"In my loneliness, I leave my house and look out; everywhere it is the same autumn evening.",-
-291,百人一首,-,し,しのぶれど いろにいでにけり わがこひは ものやおもふと ひとのとふまで,"Though I try to hide it, my love shows in my face, until people ask if I am lost in thought.",-
-292,百人一首,-,す,すみのえの きしによるなみ よるさへや ゆめのかよひぢ ひとめよくらむ,"Like the waves approaching the shore of Suminoe, even at night do you avoid people's eyes on the dream path?",-
-293,百人一首,-,せ,せをはやみ いはにせかるる たきがはの われてもすゑに あはむとぞおもふ,"Like the river current split by a rock in the rapids, though divided, I know we shall meet in the end.",-
-294,百人一首,-,そ,そらしらぬ ゆきふみわけて いでつるは ひとつのえだに つるをたづねて,"I went out treading through the snow I didn't know, seeking a vine on a single branch.",-
-295,百人一首,-,た,たごのうらに うちいでてみれば しろたへの ふじのたかねに ゆきはふりつつ,"When I go out to the shore of Tago and look, snow is falling on the white peak of Mount Fuji.",-
-296,百人一首,-,ち,ちはやぶる かみよもきかず たつたがは からくれなゐに みづくくるとは,"Never heard of even in the age of the mighty gods, that the Tatsuta River is dyed in deep crimson.",-
-297,百人一首,-,つ,つくばねの みねよりおつる みなのがは こひぞつもりて ふちとなりぬる,"Like the Minano River falling from the peak of Tsukubane, my love has accumulated and become a deep pool.",-
-298,百人一首,-,て,てふことも いまはむかしに なりぬれば たがためにかは なにかうらみむ,"Since even that has become a thing of the past, for whose sake should I hold any resentment?",-
-299,百人一首,-,と,ともしびを かきたつるまも なつかしき いづれのよひに みえぬまにまに,"Even while trimming the lamp, I miss you; on which evening did I not see you?",-
-300,百人一首,-,な,ながからむ こころもしらず くろかみの みだれてけさは ものをこそおもへ,"Uncertain of how long his heart will stay,my black hair lies in disarray this morning and so, I am lost in troubled thoughts.",-
-301,百人一首,-,に,にしきなる ふくろにいれて いはざかり いづれのやまを こえぬとぞおもふ,I put it in a brocade bag; I wonder which mountain it crossed in its peak of silence.,-
-302,百人一首,-,ぬ,ぬさもとりあへず たむけやま もみぢのにしき かみのまにまに,I could not even bring an offering; let the gods take the brocade of maple leaves on Mount Tamuke.,-
-303,百人一首,-,ね,ねがはくは はなのしたにて はるしなむ そのきさらぎの もちづきのころ,"My wish is to die in spring under the flowers, around the time of the full moon in the second month.",-
-304,百人一首,-,の,のちのよを おもへばかろし ほととぎす あかつきかけて なきつるものを,"Thinking of the afterlife makes it seem light, while the cuckoo cries toward the dawn.",-
-305,百人一首,-,は,はるすぎて なつきにけらし しろたへの ころもほすてふ あまのかぐやま,Spring has passed and summer seems to have come; white robes are said to be dried on the heavenly Mount Kagu.,-
-306,百人一首,-,ひ,ひさかたの ひかりのどけき はるのひに しづこころなく はなのちるらむ,"On this spring day when the light is so calm, why do the cherry blossoms scatter with such unquiet hearts?",-
-307,百人一首,-,ふ,ふくからに あきのくさきの しをるれば むべやまかぜを あらしといふらむ,"Since the autumn plants and trees wither as soon as it blows, it is no wonder the mountain wind is called a storm.",-
-308,百人一首,-,へ,へにける いくよをかさね たまづさの ふみをひらけば こひぞつもりぬる,"As I open the letter after many passing nights, my love has truly accumulated.",-
-309,百人一首,-,ほ,ほととぎす なきつるかたを ながむれば ただありあけの つきぞのこれる,"When I look toward where the cuckoo cried, only the morning moon remains.",-
-310,百人一首,-,ま,まつとしき たかしのはまの あまごろも ぬれにぞぬれし いろはかはらず,"Waiting on the beach of Takashi, the fisher's robe got soaked and soaked, but its color remained unchanged.",-
-311,百人一首,-,み,みかのはら わきてながるる いづみがは いつみきとてか こひしかるらむ,"Like the Izumi River flowing through the plain of Mika, when did I see you that I should love you so?",-
-312,百人一首,-,む,むらさめの つゆもまだひぬ まきのはに きりたちのぼる あきのゆふぐれ,"Before the dew of the passing shower has dried on the fir leaves, the mist rises on an autumn evening.",-
-313,百人一首,-,め,めぐりあひて みしやそれとも わかぬまに くもがくれにし よはのつきかな,"Meeting by chance, before I could even tell if it was you, you were hidden by clouds like the midnight moon.",-
-314,百人一首,-,も,ももしきや ふるきのきばの しのぶにも なほあまりある むかしなりけり,"In the palace, even the ferns on the old eaves make me yearn for the past more than I can bear.",-
-315,百人一首,-,や,やすらはで ねなましものを さよふけて かたぶくまでの つきをみしかな,I should have gone to sleep without waiting; I watched the moon until it began to sink late at night.,-
-316,百人一首,-,ゆ,ゆらのとを わたるふなびと かぢをたえ ゆくへもしらぬ こひのみちかな,"Like a mariner crossing the Yura Strait with a lost oar, I know not where the path of my love leads.",-
-317,百人一首,-,よ,よをこめて とりのそらねは はかるとも よにあふさかの せきはゆるさじ,"Though you try to deceive with a bird's false cry in the dead of night, the gate of Osaka shall not let you pass.",-
-318,百人一首,-,ら,らいしやうの いのちのはてを しらぬまに けふをかぎりと おもひけるかな,"Not knowing the end of my life in the next world, I thought today would be the limit.",-
-319,百人一首,-,り,りくかぜの さむきにたへて みちのくの しのぶもぢずり たれゆゑにけむ,"Enduring the cold land wind, for whose sake was the tangled print of Michinoku's Shinobu?",-
-320,百人一首,-,る,るりのつぼ いづれのひとも すむらむと こころをかけし いろはみえず,"In the lapis lazuli jar where everyone might live, I cannot see the colors I set my heart on.",-
-321,百人一首,-,れ,れいよりも こころをつくせ さくらばな ちりぬるのちも にほひをこそ,"Exert your heart more than usual, cherry blossoms; even after you fall, leave your fragrance.",-
-322,百人一首,-,ろ,ろばたにて こまをつなぎて みるほどに はなぞちりける さくらかな,"While tethering my horse by the roadside, the cherry blossoms were scattering.",-
-323,百人一首,-,わ,わたのはら やそしまかけて こぎいでぬと ひとにはつげよ あまのつりぶね,"Tell the people that I have rowed out over the wide sea toward the many islands, O fisher's boat.",-
-324,百人一首,-,を,をぐらやま みねのもみぢば こころあらば いまひとたびの みゆきまたなむ,"O maple leaves on the peak of Mount Ogura, if you have a heart, wait for one more imperial visit.",-
-325,百人一首,-,ん,んにゃくにしゅう つねのことばを うたにして こころをつたふ みちぞたふとき,"Turning ordinary words into songs to convey the heart, the path is truly noble.",-
-326,大ピンチずかん,92,た,たからものいれが　あかない,I can't open treasure box.,-
-327,大ピンチずかん,1,が,がむを　のんだ,I swallowed gum.,-
-400,しょうがっこうかるた,-,あ,あさきたら あいさつしよう げんきよく,"When morning comes, greet cheerfully.",-
-401,しょうがっこうかるた,-,い,いねむりは たいちょうくずす はじまりだ,Dozing off is the start of feeling unwell.,-
-402,しょうがっこうかるた,-,う,うんどうで からだをきたえ よくねよう,Exercise your body and sleep well.,-
-403,しょうがっこうかるた,-,え,えがおでね すごせばみんな うれしいよ,"If you spend time smiling, everyone is happy.",-
-404,しょうがっこうかるた,-,お,おはようと げんきなこえで あいさつだ,Say good morning with a cheerful voice.,-
-405,しょうがっこうかるた,-,か,かさをさし あめのひだって たのしいよ,Even rainy days can be fun with an umbrella.,-
-406,しょうがっこうかるた,-,き,きちんとね つかったあとは かたづけよう,"After using things, tidy them properly.",-
-407,しょうがっこうかるた,-,く,くつぬいで そろえておけば きもちいい,Take off and line up your shoes neatly.,-
-408,しょうがっこうかるた,-,け,けいさんは あせらずゆっくり かくにんだ,Do calculations calmly and check carefully.,-
-409,しょうがっこうかるた,-,こ,こころには あんぜんまもる やくそくだ,Keep safety rules in your heart.,-
-410,しょうがっこうかるた,-,さ,さくらさく にゅうがくきせつ はるがきた,Cherry blossoms bloom—spring and school begin.,-
-411,しょうがっこうかるた,-,し,しゃべらずに どうろをあるこう あぶないよ,Walk quietly on roads—it’s dangerous otherwise.,-
-412,しょうがっこうかるた,-,す,すきなもの ちゃんとえらんで たいせつに,Choose what you like and value it.,-
-413,しょうがっこうかるた,-,せ,せいりして つかえばいつも きもちいい,Keep things organized and feel good.,-
-414,しょうがっこうかるた,-,そ,そうじして みんなできれいに しようね,Let’s all clean and make it neat.,-
-415,しょうがっこうかるた,-,た,たのしいね みんなであそぶと えがおさく,Playing together brings smiles.,-
-416,しょうがっこうかるた,-,ち,ちいさくても ルールまもれば りっぱだよ,Even small acts matter if you follow rules.,-
-417,しょうがっこうかるた,-,つ,つかうもの たいせつにして ながくつかう,Take care of things and use them long.,-
-418,しょうがっこうかるた,-,て,てをあらい きれいにすれば びょうきよぼう,Wash your hands to prevent illness.,-
-419,しょうがっこうかるた,-,と,ともだちと なかよくすごす がっこうだ,School is for getting along with friends.,-
-420,しょうがっこうかるた,-,な,なかよくね けんかしないで すごそうよ,Let’s get along without fighting.,-
-421,しょうがっこうかるた,-,に,にこにこと えがおであいさつ きもちいい,Smiling greetings feel good.,-
-422,しょうがっこうかるた,-,ぬ,ぬいだくつ そろえておけば きれいだね,Neatly arranged shoes look nice.,-
-423,しょうがっこうかるた,-,ね,ねるまえに あしたのじゅんび しておこう,Prepare for tomorrow before sleeping.,-
-424,しょうがっこうかるた,-,の,のこさずに きゅうしょくたべて げんきだよ,Eat your lunch fully to stay healthy.,-
-425,しょうがっこうかるた,-,は,はやおきで こころもからだも げんきだよ,Waking early keeps you healthy.,-
-426,しょうがっこうかるた,-,ひ,ひとりでも できることから がんばろう,"Do what you can, even alone.",-
-427,しょうがっこうかるた,-,ふ,ふざけずに じゅぎょううけよう しっかりと,Take class seriously without fooling around.,-
-428,しょうがっこうかるた,-,へ,へやのなか きれいにすれば きもちいい,A clean room feels nice.,-
-429,しょうがっこうかるた,-,ほ,ほんをよみ こころをそだて かしこくね,Read books to grow your mind.,-
-430,しょうがっこうかるた,-,ま,まいにちを たいせつにして すごそうね,Cherish each day.,-
-431,しょうがっこうかるた,-,み,みんなでね ちからをあわせ がんばろう,Let’s work together.,-
-432,しょうがっこうかるた,-,む,むりしない じぶんのペースで すすもうね,Go at your own pace.,-
-433,しょうがっこうかるた,-,め,めあてもち がくしゅうすれば ちからつく,Study with goals to improve.,-
-434,しょうがっこうかるた,-,も,ものはね たいせつにして つかおうね,Take care of your belongings.,-
-435,しょうがっこうかるた,-,や,やくそくを まもればみんな しんらいだ,Keeping promises builds trust.,-
-436,しょうがっこうかるた,-,ゆ,ゆっくりと あせらずいこう だいじょうぶ,"Take it slow, no need to rush.",-
-437,しょうがっこうかるた,-,よ,よるふかし しないでねむろう はやめにね,"Don’t stay up late, sleep early.",-
-438,しょうがっこうかるた,-,ら,らくがきは してはいけない たいせつに,Don’t scribble—respect things.,-
-439,しょうがっこうかるた,-,り,りゆうある こうどうすれば せいちょうだ,Act with purpose to grow.,-
-440,しょうがっこうかるた,-,る,ルールまもり みんながたのしく すごせるよ,Follow rules so everyone enjoys.,-
-441,しょうがっこうかるた,-,れ,れいぎよく あいさつできる いいこだね,Polite greetings are great.,-
-442,しょうがっこうかるた,-,ろ,ろうかでは はしらずあるこう あんぜんに,Walk in hallways safely.,-
-443,しょうがっこうかるた,-,わ,わすれもの しないようにね かくにんだ,Check so you don’t forget things.,-
-444,しょうがっこうかるた,-,を,しゅくだいを きちんとやろう わすれずに,Do your homework properly without forgetting.,-
-445,しょうがっこうかるた,-,ん,さんかんび パパやママは みてるかな,"On open school day, I wonder if mom and dad are watching.",-
-1001,HTTPステータスコードかるた,-,2,要求は成功しました,The request succeeded.,200 OK
-1002,HTTPステータスコードかるた,-,2,新しいリソースが作成されました,A new resource has been created.,201 Created
-1003,HTTPステータスコードかるた,-,2,処理は成功したが返す内容がない,The request succeeded but there is no content to return.,204 No Content
-1004,HTTPステータスコードかるた,-,3,リソースが恒久的に移動した,The resource has permanently moved.,301 Moved Permanently
-1005,HTTPステータスコードかるた,-,3,リソースが一時的に移動した,The resource has temporarily moved.,302 Found
-1006,HTTPステータスコードかるた,-,3,キャッシュされた内容が更新されていない,The cached content has not changed.,304 Not Modified
-1007,HTTPステータスコードかるた,-,4,リクエストの形式が正しくない,The request is malformed.,400 Bad Request
-1008,HTTPステータスコードかるた,-,4,認証が必要です,Authentication is required.,401 Unauthorized
-1009,HTTPステータスコードかるた,-,4,認証は済んでいるが権限がありません,"Authenticated, but not authorized to access this resource.",403 Forbidden
-1010,HTTPステータスコードかるた,-,4,リソースが見つかりません,The requested resource was not found.,404 Not Found
-1011,HTTPステータスコードかるた,-,4,許可されていないHTTPメソッドが使われた,The HTTP method used is not allowed.,405 Method Not Allowed
-1012,HTTPステータスコードかるた,-,4,リクエストが時間内に完了しなかった,The request timed out.,408 Request Timeout
-1013,HTTPステータスコードかるた,-,4,リソースの状態が競合している,The request conflicts with the current state of the resource.,409 Conflict
-1014,HTTPステータスコードかるた,-,4,リソースは存在したが今は削除された,The resource existed but has since been deleted.,410 Gone
-1015,HTTPステータスコードかるた,-,4,送信データが大きすぎる,The request payload is too large.,413 Payload Too Large
-1016,HTTPステータスコードかるた,-,4,対応していない形式のデータが送られた,The media type of the request is not supported.,415 Unsupported Media Type
-1017,HTTPステータスコードかるた,-,4,構文は正しいが内容を処理できない,The request is well-formed but cannot be processed.,422 Unprocessable Entity
-1018,HTTPステータスコードかるた,-,4,短時間にリクエストを送りすぎた,Too many requests were sent in a short time.,429 Too Many Requests
-1019,HTTPステータスコードかるた,-,5,サーバー内部で予期しないエラーが発生した,An unexpected error occurred on the server.,500 Internal Server Error
-1020,HTTPステータスコードかるた,-,5,サーバーがその機能に対応していない,The server does not support the requested functionality.,501 Not Implemented
-1021,HTTPステータスコードかるた,-,5,上流サーバーから不正な応答を受け取った,Received an invalid response from an upstream server.,502 Bad Gateway
-1022,HTTPステータスコードかるた,-,5,サーバーが一時的に利用できない,The server is temporarily unavailable.,503 Service Unavailable
-1023,HTTPステータスコードかるた,-,5,上流サーバーからの応答が時間内に来なかった,Did not receive a timely response from an upstream server.,504 Gateway Timeout
-1101,Linuxコマンドかるた,-,L,ディレクトリ一覧を表示する,Display a list of directory contents.,ls
-1102,Linuxコマンドかるた,-,P,現在のディレクトリを表示する,Display the current directory.,pwd
-1103,Linuxコマンドかるた,-,C,ディレクトリを移動する,Change the current directory.,cd
-1104,Linuxコマンドかるた,-,M,新しいディレクトリを作成する,Create a new directory.,mkdir
-1105,Linuxコマンドかるた,-,R,空のディレクトリを削除する,Remove an empty directory.,rmdir
-1106,Linuxコマンドかるた,-,R,ファイルを削除する,Delete a file.,rm
-1107,Linuxコマンドかるた,-,C,ファイルをコピーする,Copy a file.,cp
-1108,Linuxコマンドかるた,-,M,ファイルを移動する、または名前を変更する,Move or rename a file.,mv
-1109,Linuxコマンドかるた,-,T,空のファイルを作成する、タイムスタンプを更新する,Create an empty file or update its timestamp.,touch
-1110,Linuxコマンドかるた,-,C,ファイルの内容を表示する,Display the contents of a file.,cat
-1111,Linuxコマンドかるた,-,F,ファイルを検索する,Search for files.,find
-1112,Linuxコマンドかるた,-,G,ファイルの中から文字列を検索する,Search for a string within files.,grep
-1113,Linuxコマンドかるた,-,C,ファイルの権限を変更する,Change file permissions.,chmod
-1114,Linuxコマンドかるた,-,C,ファイルの所有者を変更する,Change file ownership.,chown
-1115,Linuxコマンドかるた,-,P,実行中のプロセスを表示する,Display running processes.,ps
-1116,Linuxコマンドかるた,-,K,プロセスを終了させる,Terminate a process.,kill
-1117,Linuxコマンドかるた,-,T,システムのリソース使用状況をリアルタイムで表示する,Display real-time system resource usage.,top
-1118,Linuxコマンドかるた,-,D,ディスクの空き容量を表示する,Display free disk space.,df
-1119,Linuxコマンドかるた,-,D,ファイルやディレクトリのサイズを表示する,Display the size of files or directories.,du
-1120,Linuxコマンドかるた,-,T,複数のファイルをひとつにまとめて圧縮・展開する,Archive or extract multiple files.,tar
-1121,Linuxコマンドかるた,-,S,別のサーバーにリモートでログインする,Log in to a remote server.,ssh
-1122,Linuxコマンドかるた,-,S,サーバー間でファイルを安全にコピーする,Securely copy files between servers.,scp
-1123,Linuxコマンドかるた,-,C,URLを指定してデータを送受信する,Transfer data to or from a URL.,curl
-1124,Linuxコマンドかるた,-,W,URLからファイルをダウンロードする,Download a file from a URL.,wget
-1125,Linuxコマンドかるた,-,M,コマンドの使い方を調べる,Look up how to use a command.,man
-1126,Linuxコマンドかるた,-,H,これまでに実行したコマンドの履歴を表示する,Display the history of executed commands.,history
-1127,Linuxコマンドかるた,-,E,文字列を画面に出力する,Print a string to the screen.,echo
-1128,Linuxコマンドかるた,-,L,ファイルの内容をスクロールしながら表示する,View a file's contents one screen at a time.,less
-1129,Linuxコマンドかるた,-,H,ファイルの先頭部分を表示する,Display the beginning of a file.,head
-1130,Linuxコマンドかるた,-,T,ファイルの末尾部分を表示する,Display the end of a file.,tail
-1131,Linuxコマンドかるた,-,S,行を並び替える,Sort lines of text.,sort
-1132,Linuxコマンドかるた,-,U,重複する行を取り除く,Remove duplicate adjacent lines.,uniq
-1133,Linuxコマンドかるた,-,W,行数や単語数、文字数を数える,"Count lines, words, and characters.",wc
-1134,Linuxコマンドかるた,-,L,ファイルのリンクを作成する,Create a link to a file.,ln
-1135,Linuxコマンドかるた,-,A,コマンドに別名をつける,Define a shortcut name for a command.,alias
-1136,Linuxコマンドかるた,-,E,環境変数を設定する,Set an environment variable.,export
-1137,Linuxコマンドかるた,-,S,管理者権限でコマンドを実行する,Run a command with administrator privileges.,sudo
-1138,Linuxコマンドかるた,-,W,コマンドの実行ファイルの場所を調べる,Find the location of a command's executable.,which
-1139,Linuxコマンドかるた,-,W,現在ログインしているユーザー名を表示する,Display the current logged-in user name.,whoami
-1140,Linuxコマンドかるた,-,H,コンピュータのホスト名を表示する,Display the computer's host name.,hostname
-1201,Gitかるた,-,I,新しいリポジトリを作成する,Create a new repository.,git init
-1202,Gitかるた,-,C,既存のリポジトリを複製する,Clone an existing repository.,git clone
-1203,Gitかるた,-,A,変更をステージングする,Stage changes.,git add
-1204,Gitかるた,-,C,変更をコミットする,Commit changes.,git commit
-1205,Gitかるた,-,P,ローカルの変更をリモートに送る,Push local changes to a remote.,git push
-1206,Gitかるた,-,P,リモートの変更を取得して取り込む,Fetch and merge changes from a remote.,git pull
-1207,Gitかるた,-,F,リモートの変更情報だけを取得する,Fetch changes from a remote without merging.,git fetch
-1208,Gitかるた,-,S,作業ディレクトリの状態を確認する,Check the status of the working directory.,git status
-1209,Gitかるた,-,D,変更の差分を確認する,Show changes between commits or the working directory.,git diff
-1210,Gitかるた,-,L,コミットの履歴を表示する,Show commit history.,git log
-1211,Gitかるた,-,B,ブランチを作成・一覧表示する,Create or list branches.,git branch
-1212,Gitかるた,-,C,ブランチやファイルの状態を切り替える,Switch branches or restore files.,git checkout
-1213,Gitかるた,-,S,ブランチを切り替える,Switch branches.,git switch
-1214,Gitかるた,-,M,別のブランチの変更を取り込む,Merge changes from another branch.,git merge
-1215,Gitかるた,-,R,コミットの履歴を別のベースに付け替える,Reapply commits on top of another base.,git rebase
-1216,Gitかるた,-,S,作業内容を一時退避する,Temporarily shelve changes.,git stash
-1217,Gitかるた,-,R,コミットやステージングの状態を戻す,Undo commits or staged changes.,git reset
-1218,Gitかるた,-,R,過去のコミットを打ち消す新しいコミットを作る,Create a new commit that undoes a past commit.,git revert
-1219,Gitかるた,-,T,コミットに目印となるタグを付ける,Mark a commit with a tag.,git tag
-1220,Gitかるた,-,R,リモートリポジトリの情報を管理する,Manage remote repository information.,git remote
-1221,Gitかるた,-,C,Gitの設定を変更する,Change Git configuration.,git config
-1222,Gitかるた,-,C,特定のコミットだけを取り込む,Apply a specific commit onto the current branch.,git cherry-pick
-1223,Gitかるた,-,B,各行を最後に変更した人を調べる,Find out who last modified each line.,git blame
-1224,Gitかるた,-,S,コミットの詳細な内容を表示する,Show the details of a commit.,git show
-1225,Gitかるた,-,R,ファイルを削除してその変更を記録する,Delete a file and stage the removal.,git rm
-1301,SQLかるた,-,S,取得する列を指定する,Specify which columns to retrieve.,SELECT
-1302,SQLかるた,-,F,データを取得するテーブルを指定する,Specify the table to retrieve data from.,FROM
-1303,SQLかるた,-,W,条件に一致するデータを取得する,Retrieve data that matches a condition.,WHERE
-1304,SQLかるた,-,G,指定した列の値でグループ化する,Group rows by the values of specified columns.,GROUP BY
-1305,SQLかるた,-,H,グループ化した後の結果に条件をつける,Filter results after grouping.,HAVING
-1306,SQLかるた,-,O,結果を並び替える,Sort the results.,ORDER BY
-1307,SQLかるた,-,L,取得する件数を制限する,Limit the number of rows returned.,LIMIT
-1308,SQLかるた,-,I,一致する行だけを複数テーブルから結合する,"Join tables, returning only matching rows.",INNER JOIN
-1309,SQLかるた,-,L,左側のテーブルを基準に結合する,"Join tables, keeping all rows from the left table.",LEFT JOIN
-1310,SQLかるた,-,R,右側のテーブルを基準に結合する,"Join tables, keeping all rows from the right table.",RIGHT JOIN
-1311,SQLかるた,-,F,両方のテーブルの行をすべて結合する,"Join tables, keeping all rows from both tables.",FULL OUTER JOIN
-1312,SQLかるた,-,U,複数の検索結果を縦に結合する,Combine the results of multiple queries.,UNION
-1313,SQLかるた,-,D,重複を除外する,Exclude duplicate rows.,DISTINCT
-1314,SQLかるた,-,I,新しい行を追加する,Insert a new row.,INSERT INTO
-1315,SQLかるた,-,U,既存の行を更新する,Update existing rows.,UPDATE
-1316,SQLかるた,-,D,行を削除する,Delete rows.,DELETE
-1317,SQLかるた,-,C,新しいテーブルを作成する,Create a new table.,CREATE TABLE
-1318,SQLかるた,-,A,テーブルの構造を変更する,Modify a table's structure.,ALTER TABLE
-1319,SQLかるた,-,D,テーブルを削除する,Delete a table.,DROP TABLE
-1320,SQLかるた,-,P,行を一意に識別する列を指定する,Designate a column that uniquely identifies each row.,PRIMARY KEY
-1321,SQLかるた,-,F,他のテーブルの行を参照する制約,A constraint that references a row in another table.,FOREIGN KEY
-1322,SQLかるた,-,N,値が存在しないことを表す,Represents the absence of a value.,NULL
-1323,SQLかるた,-,B,指定した範囲内のデータを取得する,Retrieve data within a specified range.,BETWEEN
-1324,SQLかるた,-,L,文字列のパターンに一致するか調べる,Check whether a string matches a pattern.,LIKE
-1325,SQLかるた,-,I,複数の値のいずれかに一致するか調べる,Check whether a value matches any in a list.,IN
-1326,SQLかるた,-,C,行数を数える,Count the number of rows.,COUNT
-1327,SQLかるた,-,S,値の合計を求める,Calculate the sum of values.,SUM
-1328,SQLかるた,-,A,値の平均を求める,Calculate the average of values.,AVG
-1329,SQLかるた,-,A,列やテーブルに別名をつける,Give a column or table an alias.,AS
-1330,SQLかるた,-,C,条件によって異なる値を返す,Return different values depending on a condition.,CASE WHEN
-1331,SQLかるた,-,C,変更をデータベースに確定する,Commit changes to the database.,COMMIT
-1332,SQLかるた,-,R,変更を取り消して元に戻す,Undo changes and revert to the previous state.,ROLLBACK
-1401,AWSかるた,-,L,サーバレスでコードを実行する,Run code without managing servers.,Lambda
-1402,AWSかるた,-,S,オブジェクトストレージ,Object storage.,S3
-1403,AWSかるた,-,D,NoSQLデータベース,A NoSQL database.,DynamoDB
-1404,AWSかるた,-,E,仮想サーバーを提供する,Provides virtual servers.,EC2
-1405,AWSかるた,-,R,マネージドなリレーショナルデータベース,A managed relational database.,RDS
-1406,AWSかるた,-,V,仮想的なネットワーク環境を作る,Create an isolated virtual network.,VPC
-1407,AWSかるた,-,I,ユーザーや権限を管理する,Manage users and permissions.,IAM
-1408,AWSかるた,-,C,コンテンツ配信網(CDN)サービス,A content delivery network (CDN) service.,CloudFront
-1409,AWSかるた,-,R,DNSサービス,A DNS service.,Route 53
-1410,AWSかるた,-,A,APIの作成・公開・管理を行う,"Create, publish, and manage APIs.",API Gateway
-1411,AWSかるた,-,S,メッセージを溜めておくキューサービス,A queue service for storing messages.,SQS
-1412,AWSかるた,-,S,メッセージを配信する通知サービス,A notification service for delivering messages.,SNS
-1413,AWSかるた,-,C,リソースの監視やログ収集を行う,Monitor resources and collect logs.,CloudWatch
-1414,AWSかるた,-,C,インフラをコードで構築・管理する,Provision and manage infrastructure as code.,CloudFormation
-1415,AWSかるた,-,E,コンテナを管理・実行するサービス,A service for managing and running containers.,ECS
-1416,AWSかるた,-,E,マネージドなKubernetesサービス,A managed Kubernetes service.,EKS
-1417,AWSかるた,-,F,サーバー管理が不要なコンテナ実行環境,A serverless container runtime that needs no server management.,Fargate
-1418,AWSかるた,-,E,アプリケーションのデプロイを簡単にする,Simplifies application deployment.,Elastic Beanstalk
-1419,AWSかるた,-,A,負荷に応じてサーバー台数を自動調整する,Automatically adjusts server count based on load.,Auto Scaling
-1420,AWSかるた,-,E,通信を複数サーバーに振り分ける,Distributes traffic across multiple servers.,Elastic Load Balancing
-1421,AWSかるた,-,G,データを抽出・変換・ロードするETLサービス,"An ETL service for extracting, transforming, and loading data.",Glue
-1422,AWSかるた,-,A,S3のデータをSQLで分析する,Analyze data in S3 using SQL.,Athena
-1423,AWSかるた,-,K,大量のストリーミングデータを処理する,Process large volumes of streaming data.,Kinesis
-1424,AWSかるた,-,S,複数のサービスをワークフローでつなぐ,Coordinate multiple services into a workflow.,Step Functions
-1425,AWSかるた,-,C,ユーザーの認証や認可を管理する,Manage user authentication and authorization.,Cognito
-1426,AWSかるた,-,S,パスワードなどの機密情報を管理する,Manage secrets such as passwords.,Secrets Manager
-1427,AWSかるた,-,C,ビルドからデプロイまでを自動化する,Automate the process from build to deployment.,CodePipeline
-1428,AWSかるた,-,E,EC2にアタッチするブロックストレージ,Block storage attached to EC2 instances.,EBS
-1429,AWSかるた,-,A,高い性能を持つマネージドリレーショナルDB,A high-performance managed relational database.,Aurora
-1430,AWSかるた,-,R,大規模なデータウェアハウス,A large-scale data warehouse.,Redshift
-1501,Javaかるた,-,N,Null参照時に発生する例外,An exception thrown when dereferencing a null reference.,NullPointerException
-1502,Javaかるた,-,I,入出力で発生する例外,An exception thrown for input/output failures.,IOException
-1503,Javaかるた,-,H,キーと値を保持するコレクション,A collection that holds key-value pairs.,HashMap
-1504,Javaかるた,-,A,配列の範囲外にアクセスした時の例外,An exception thrown when accessing an array out of bounds.,ArrayIndexOutOfBoundsException
-1505,Javaかるた,-,C,指定したクラスが見つからない時の例外,An exception thrown when a specified class cannot be found.,ClassNotFoundException
-1506,Javaかるた,-,N,文字列を数値に変換できない時の例外,An exception thrown when a string cannot be converted to a number.,NumberFormatException
-1507,Javaかるた,-,I,不正な引数が渡された時の例外,An exception thrown when an invalid argument is passed.,IllegalArgumentException
-1508,Javaかるた,-,I,オブジェクトの状態が不正な時の例外,An exception thrown when an object is in an invalid state.,IllegalStateException
-1509,Javaかるた,-,A,0で割るなど算術エラー時の例外,An exception thrown for arithmetic errors such as division by zero.,ArithmeticException
-1510,Javaかるた,-,C,ループ中にコレクションを変更した時の例外,An exception thrown when a collection is modified during iteration.,ConcurrentModificationException
-1511,Javaかるた,-,O,メモリ不足で発生するエラー,An error thrown when the JVM runs out of memory.,OutOfMemoryError
-1512,Javaかるた,-,S,再帰呼び出しが深すぎて発生するエラー,An error thrown when recursive calls go too deep.,StackOverflowError
-1513,Javaかるた,-,A,可変長の配列のようなコレクション,A resizable array-like collection.,ArrayList
-1514,Javaかるた,-,L,要素を連結して保持するリスト,A list that holds elements as a linked sequence.,LinkedList
-1515,Javaかるた,-,H,重複を許さないコレクション,A collection that does not allow duplicate elements.,HashSet
-1516,Javaかるた,-,T,キーで自動的に並び替えられるマップ,A map that is automatically sorted by its keys.,TreeMap
-1517,Javaかるた,-,S,文字列を効率的に組み立てるクラス,A class for efficiently building strings.,StringBuilder
-1518,Javaかるた,-,O,値が存在しないかもしれないことを表すクラス,A class representing a value that may or may not be present.,Optional
-1519,Javaかるた,-,S,コレクションを関数的に処理するAPI,An API for processing collections in a functional style.,Stream
-1520,Javaかるた,-,I,メソッドの仕様だけを定義する型,A type that defines only method signatures.,Interface
-1521,Javaかるた,-,A,一部だけ実装したクラス,A class that is only partially implemented.,Abstract Class
-1522,Javaかるた,-,G,型を汎用的に扱う仕組み,A mechanism for handling types generically.,Generics
-1523,Javaかるた,-,T,例外処理を記述する構文,Syntax for handling exceptions.,try-catch-finally
-1524,Javaかるた,-,S,複数スレッドからの同時アクセスを制御する,Controls concurrent access from multiple threads.,synchronized
-1525,Javaかるた,-,T,並行して処理を実行する単位,A unit of execution that runs concurrently.,Thread
-1526,Javaかるた,-,O,親クラスのメソッドを子クラスで上書きする,Overrides a parent class's method in a subclass.,Override
-1527,Javaかるた,-,E,オブジェクトの等価性を判定する仕組み,A mechanism for determining object equality.,equals/hashCode
-1528,Javaかるた,-,F,値や継承を変更不可にするキーワード,A keyword that makes a value or inheritance unchangeable.,final
-1529,Javaかるた,-,S,インスタンスに依存しないメンバーを定義するキーワード,A keyword for defining members that don't depend on an instance.,static
-1601,コードレビューかるた,-,D,同じコードが複数箇所に存在する,The same code exists in multiple places.,DRY原則
-1602,コードレビューかるた,-,か,変数名から役割が分からない,It's unclear what a variable does from its name.,可読性
-1603,コードレビューかるた,-,た,1つのメソッドが長すぎる,A single method is too long.,単一責任の原則
-1604,コードレビューかるた,-,ま,意味のわからない数値が直接書かれている,An unexplained number is hard-coded directly in the code.,マジックナンバー
-1605,コードレビューかるた,-,ね,条件分岐が何重にも入れ子になっている,Conditional branches are nested many levels deep.,ネストが深い
-1606,コードレビューかるた,-,め,変数名やクラス名のつけ方が統一されていない,Variable and class naming is inconsistent.,命名規則違反
-1607,コードレビューかるた,-,て,重要な処理にテストが書かれていない,Critical logic has no tests.,テストカバレッジ不足
-1608,コードレビューかるた,-,は,設定値がコード中に直接埋め込まれている,Configuration values are embedded directly in the code.,ハードコーディング
-1609,コードレビューかるた,-,れ,catchした例外を何もせず無視している,A caught exception is silently ignored.,例外の握りつぶし
-1610,コードレビューかるた,-,ぐ,どこからでも書き換えられる変数を多用している,Overuse of variables that can be modified from anywhere.,グローバル変数の濫用
-1611,コードレビューかるた,-,こ,複雑な処理の意図が説明されていない,The intent behind complex logic is not explained.,コメント不足
-1612,コードレビューかるた,-,じ,同じロジックが何箇所にもコピーされている,The same logic is copy-pasted in many places.,重複コード
-1613,コードレビューかるた,-,そ,条件を満たしたらすぐに関数を抜けず深く入れ子にしている,"Doesn't exit early when a condition is met, leading to deep nesting.",早期return
-1614,コードレビューかるた,-,ふ,名前から想像できない値の変更を行う関数,A function that changes values in ways its name doesn't suggest.,副作用のある関数
-1615,コードレビューかるた,-,み,クラス同士が内部実装に強く依存している,Classes depend heavily on each other's internal implementation.,密結合
-1616,コードレビューかるた,-,で,呼び出されない不要なコードが残っている,Unused code that is never called remains in the codebase.,デッドコード
-1617,コードレビューかるた,-,S,ユーザー入力をそのままSQLに組み込んでいる,User input is embedded directly into SQL without sanitization.,SQLインジェクション脆弱性
-1618,コードレビューかるた,-,ふ,使われていないモジュールが読み込まれている,Unused modules are imported.,不要なimport
-1619,コードレビューかるた,-,ろ,エラー発生時に原因を追えるログがない,There are no logs to trace the cause when an error occurs.,ログ出力不足
-1620,コードレビューかるた,-,ば,入力値の検証が行われていない,Input values are not validated.,バリデーション漏れ
-1621,コードレビューかるた,-,れ,並行処理の実行順序によって結果が変わる不具合,A bug where the result depends on the timing of concurrent execution.,レースコンディション
-1622,コードレビューかるた,-,か,将来使うかもしれない機能を先に作り込んでいる,Building functionality preemptively for hypothetical future use.,過剰な抽象化
-1701,セキュリティ大ピンチ,10,は,アカウント全部　同じパスワードだった,I used the same password for every account.,パスワードリスト攻撃
-1702,セキュリティ大ピンチ,15,ふ,いそいで振り込め　メールを信じた,I trusted an urgent payment email.,フィッシング
-1703,セキュリティ大ピンチ,12,ま,USBを拾って　そのまま挿した,I plugged in a USB drive I found.,マルウェア
-1704,セキュリティ大ピンチ,40,し,APIキーを　GitHubで公開した,I exposed an API key on GitHub.,シークレット管理
-1705,セキュリティ大ピンチ,15,ふ,おなじログイン画面だと　思い込んだ,I assumed the login page was genuine.,フィッシングサイト
-1706,セキュリティ大ピンチ,20,て,開発用パスワードを　本番でも使った,I used a development password in production.,デフォルトパスワード
-1707,セキュリティ大ピンチ,25,し,きょうもパッチを　後回しにした,I postponed installing security patches again.,脆弱性
-1708,セキュリティ大ピンチ,25,ら,暗号化されても　バックアップがない,Everything was encrypted and I had no backup.,ランサムウェア
-1709,セキュリティ大ピンチ,40,え,検索欄から　データベースが壊れた,The database broke through the search box.,SQLインジェクション
-1710,セキュリティ大ピンチ,40,く,コメントを書いたら　勝手に画面が動いた,A comment caused unexpected script execution.,XSS
-1711,セキュリティ大ピンチ,45,し,サイトを見ただけで　退会していた,I was logged out or unsubscribed just by visiting a page.,CSRF
-1712,セキュリティ大ピンチ,35,に,知らない人まで　管理画面に入れた,Unauthorized users reached the admin screen.,認可不備
-1713,セキュリティ大ピンチ,20,あ,すでに退職した人が　まだログインしていた,A former employee could still log in.,アカウント管理
-1714,セキュリティ大ピンチ,30,さ,全員を管理者に　してしまった,I gave everyone administrator privileges.,最小権限の原則
-1715,セキュリティ大ピンチ,15,て,そのままHTTPで　ログインした,I logged in over HTTP.,TLS
-1716,セキュリティ大ピンチ,20,か,だれが操作したか　分からない,Nobody knew who performed the operation.,監査ログ
-1717,セキュリティ大ピンチ,35,せ,社内だから安全と　思い込んでいた,I assumed the internal network was safe.,ゼロトラスト
-1718,セキュリティ大ピンチ,40,あ,つうしんの異常に　誰も気付かなかった,Nobody noticed the suspicious traffic.,IDS
-1719,セキュリティ大ピンチ,45,あ,敵は見つけたのに　止められなかった,We detected the attack but couldn't stop it.,IPS
-1720,セキュリティ大ピンチ,40,え,取りつかれても　誰も気付かなかった,The endpoint was compromised without anyone noticing.,EDR
-1721,セキュリティ大ピンチ,20,せ,長いこと更新を　していなかった,The server hadn't been updated for a long time.,セキュリティパッチ
-1722,セキュリティ大ピンチ,15,た,認証が　パスワードだけだった,Only a password protected the account.,多要素認証
-1723,セキュリティ大ピンチ,35,せ,ぬすまれたCookieで　ログインされた,Someone logged in using my stolen cookie.,セッションハイジャック
-1724,セキュリティ大ピンチ,20,あ,ねだんより　個人情報を守れ,Personal data was stored without protection.,暗号化
-1725,セキュリティ大ピンチ,15,て,残っていた初期設定で　入られた,Someone logged in with default credentials.,デフォルト認証情報
-1726,セキュリティ大ピンチ,20,と,アクセスが急に　100万件来た,A million requests suddenly flooded the server.,DoS攻撃
-1727,セキュリティ大ピンチ,35,こ,秘密鍵を　メールで送ってしまった,I emailed a private key.,公開鍵暗号方式
-1728,セキュリティ大ピンチ,35,せ,古い設定をコピーしたら　穴だらけだった,I copied an insecure server configuration.,セキュア設定
-1729,セキュリティ大ピンチ,30,し,へいきだろうで　本番公開した,I released it to production assuming it was safe.,脆弱性診断
-1730,セキュリティ大ピンチ,15,さ,ほんとうに開いてよかった？　その添付ファイル,Should I really have opened that attachment?,サンドボックス
-1731,セキュリティ大ピンチ,70,え,まさか社内サーバが　外から操作された,The internal server was manipulated from outside.,SSRF
-1732,セキュリティ大ピンチ,80,え,見せるはずのない　サーバのファイルが見えた,Internal server files became visible.,XXE
-1733,セキュリティ大ピンチ,70,お,無害な入力のはずが　コマンドが動いた,A harmless input executed a command.,OSコマンドインジェクション
-1734,セキュリティ大ピンチ,85,し,メンバーなのに　管理者になっていた,A normal user became an administrator.,JWT
-1735,セキュリティ大ピンチ,65,お,もれたトークンで　勝手に操作された,A leaked token was used for unauthorized access.,OAuth
-1736,セキュリティ大ピンチ,55,に,やっぱり開発環境だからと　認証を外した,I disabled authentication because it was only a development environment.,認証
-1737,セキュリティ大ピンチ,60,に,ユーザー画面だけで　権限チェックしていた,Authorization was checked only on the client side.,認可
-1801,Webアプリ大ピンチ,10,き,更新したのに昨日の画面のままだった,The page still showed yesterday's version after deployment.,キャッシュ
-1802,Webアプリ大ピンチ,15,せ,ログインしたのにすぐログアウトされた,I was logged out right after logging in.,セッション
-1803,Webアプリ大ピンチ,20,と,注文ボタンを連打したら二重登録された,Clicking the order button repeatedly created duplicate records.,トランザクション
-1804,Webアプリ大ピンチ,15,く,Cookieを消したらログインできるようになった,Deleting cookies fixed the login problem.,Cookie
-1805,Webアプリ大ピンチ,20,H,404しか返ってこない,Everything returned a 404 error.,HTTPステータスコード
-1806,Webアプリ大ピンチ,25,り,POSTしたのに画面が別ページへ飛んだ,"After POST, I was sent to another page.",リダイレクト
-1807,Webアプリ大ピンチ,25,ふ,画面遷移したら入力内容が消えなかった,The input remained after changing pages.,フォワード
-1808,Webアプリ大ピンチ,20,さ,画面は開くのにデータが表示されない,The page loads but no data appears.,Servlet
-1809,Webアプリ大ピンチ,25,J,JSPを直したのに画面が変わらない,I edited a JSP but nothing changed.,JSP
-1810,Webアプリ大ピンチ,30,E,HTMLの中にJavaだらけで読めない,The JSP is full of Java code and unreadable.,EL式
-1811,Webアプリ大ピンチ,30,J,同じ処理を何度もJSPに書いてしまった,I duplicated the same logic across JSPs.,JSTL
-1812,Webアプリ大ピンチ,35,え,DBにはあるのに画面には表示されない,The data exists in the database but isn't shown.,MVC
-1813,Webアプリ大ピンチ,35,J,SQLは成功したのに画面が更新されない,The SQL succeeded but the screen didn't update.,JDBC
-1814,Webアプリ大ピンチ,20,S,SQLを書き換えたら全部落ちた,Changing one SQL query broke everything.,SQL
-1815,Webアプリ大ピンチ,45,い,検索だけやたら遅い,Only searches are extremely slow.,インデックス
-1816,Webアプリ大ピンチ,40,こ,接続数がいっぱいでDBにつながらない,The database refused more connections.,コネクションプール
-1817,Webアプリ大ピンチ,20,M,データベースが起動していなかった,The database server wasn't running.,MySQL
-1818,Webアプリ大ピンチ,30,P,再起動したら直った,Restarting the server fixed it.,Payara
-1819,Webアプリ大ピンチ,25,わ,デプロイしたのに反映されない,I deployed it but nothing changed.,WAR
-1820,Webアプリ大ピンチ,35,G,依存ライブラリを追加したのに読み込まれない,The dependency wasn't picked up after adding it.,Gradle
-1821,Webアプリ大ピンチ,35,い,昨日までビルドできたのに今日は失敗する,Yesterday's build worked but today's doesn't.,依存関係
-1822,Webアプリ大ピンチ,20,び,ソースは変えていないのに実行できない,"I changed nothing, but it no longer runs.",ビルド
-1823,Webアプリ大ピンチ,20,J,ボタンを押しても何も起きない,Clicking the button does nothing.,JavaScript
-1824,Webアプリ大ピンチ,25,D,要素が見つからないと言われた,The browser says the element can't be found.,DOM
-1825,Webアプリ大ピンチ,15,し,画面レイアウトがぐちゃぐちゃになった,The page layout completely broke.,CSS
-1826,Webアプリ大ピンチ,30,J,APIの返却結果が読めない,I can't parse the API response.,JSON
-1827,Webアプリ大ピンチ,30,A,画面はあるのにデータだけ取れない,The page loads but no data comes back.,AJAX
-1828,Webアプリ大ピンチ,35,ば,入力したのに保存できない,The form won't save my input.,バリデーション
-1829,Webアプリ大ピンチ,35,れ,エラー画面しか出ない,Only an error page is displayed.,例外処理
-1830,Webアプリ大ピンチ,20,ろ,何が起きたのか全然分からない,I have no idea what happened.,ログ
-1831,Webアプリ大ピンチ,35,す,エラーは出たけど原因が読めない,I see an error but can't identify the cause.,スタックトレース
-1832,Webアプリ大ピンチ,20,で,デバッグしたら動いてしまう,The bug disappears during debugging.,デバッグ
-1833,Webアプリ大ピンチ,30,も,文字が全部「???」になった,All the text turned into question marks.,文字コード
-1834,Webアプリ大ピンチ,25,U,日本語だけ文字化けした,Only Japanese characters are garbled.,UTF-8
-1835,Webアプリ大ピンチ,20,G,最新コードを取ったら動かなくなった,Pulling the latest code broke everything.,Git
-1836,Webアプリ大ピンチ,40,ま,同じファイルを編集して取り込めない,I can't merge because we edited the same file.,マージコンフリクト
-1837,Webアプリ大ピンチ,40,C,ブラウザからだけAPIが呼べない,The API works elsewhere but not from the browser.,CORS
-1838,Webアプリ大ピンチ,45,N,SQLを1件取得するたびにSQLが増えていく,One query turns into hundreds of queries.,N+1問題
-1839,Webアプリ大ピンチ,40,ら,他の人が更新して保存できなかった,Someone else updated the record first.,楽観ロック
-1840,Webアプリ大ピンチ,35,に,ログイン状態なのに403になった,I'm logged in but received a 403.,認可
-1901,Windowsショートカット,10,C,コピーしたつもりが　できていなかった,I thought I copied it but it wasn't copied.,Ctrl+C
-1902,Windowsショートカット,10,V,貼り付けたいのに　右クリックできない,I want to paste but can't use the mouse.,Ctrl+V
-1903,Windowsショートカット,10,X,別の場所へ　移動したい,I want to move it somewhere else.,Ctrl+X
-1904,Windowsショートカット,10,Z,間違えて消してしまった,I accidentally deleted it.,Ctrl+Z
-1905,Windowsショートカット,15,Y,戻しすぎて　やっぱり元に戻したい,I undid too much.,Ctrl+Y
-1906,Windowsショートカット,10,A,全部まとめて選びたい,I want to select everything.,Ctrl+A
-1907,Windowsショートカット,15,F,探したい文字が　見つからない,I can't find the text I'm looking for.,Ctrl+F
-1908,Windowsショートカット,10,S,保存する前に　落ちそうだ,The application might crash before I save.,Ctrl+S
-1909,Windowsショートカット,15,P,印刷したい,I want to print this.,Ctrl+P
-1910,Windowsショートカット,20,T,新しいタブを　開きたい,I want to open a new tab.,Ctrl+T
-1911,Windowsショートカット,25,T,閉じたタブを　戻したい,I want to reopen the tab I just closed.,Ctrl+Shift+T
-1912,Windowsショートカット,15,R,更新したい,I want to refresh the page.,Ctrl+R
-1913,Windowsショートカット,20,T,隣のタブへ　移動したい,I want to move to the next tab.,Ctrl+Tab
-1914,Windowsショートカット,20,T,開きすぎて　目的の画面が見つからない,I have too many windows open.,Alt+Tab
-1915,Windowsショートカット,15,D,デスクトップを　一瞬だけ見たい,I need to see the desktop quickly.,Windows+D
-1916,Windowsショートカット,20,E,エクスプローラーを　開きたい,I need File Explorer.,Windows+E
-1917,Windowsショートカット,20,L,席を離れるので　すぐロックしたい,I'm leaving my desk and want to lock my PC.,Windows+L
-1918,Windowsショートカット,20,I,設定画面を　開きたい,I need to open Settings.,Windows+I
-1919,Windowsショートカット,20,S,アプリやファイルを　すぐ探したい,I need to search for an app or file.,Windows+S
-1920,Windowsショートカット,15,F,ファイル名を　変更したい,I want to rename a file.,F2
-1921,Windowsショートカット,10,F,画面を　更新したい,I want to refresh the screen.,F5
-1922,Windowsショートカット,10,F,ヘルプを　開きたい,I need help.,F1
-1923,Windowsショートカット,25,F,終了ボタンが　押せない,I need to close the current application.,Alt+F4
-1924,Windowsショートカット,30,E,固まったアプリを　調べたい,I need Task Manager.,Ctrl+Shift+Esc
-1925,Windowsショートカット,20,D,ログイン画面に　戻りたい,I need the Windows security screen.,Ctrl+Alt+Delete
-1926,Windowsショートカット,25,+,文字が小さすぎて　見えない,The text is too small to read.,Windows++
-1927,Windowsショートカット,25,-,画面が大きすぎて　見づらい,Everything is zoomed in too much.,Windows+-
-1928,Windowsショートカット,30,P,画面を　そのまま保存したい,I want to save a screenshot.,Windows+PrintScreen
-1929,Windowsショートカット,20,S,画面の一部だけ　切り取りたい,I only need part of the screen.,Windows+Shift+S
-1930,Windowsショートカット,25,.,絵文字を　入力したい,I want to insert an emoji.,Windows+.
-1931,Windowsショートカット,30,V,さっきコピーしたものを　もう一度使いたい,I need something I copied earlier.,Windows+V
-1932,Windowsショートカット,35,S,日本語入力に　切り替わらない,I can't switch the input language.,Alt+Shift
-1933,Windowsショートカット,35,`,かな入力に　なってしまった,I accidentally switched input modes.,Alt+`
-1934,Windowsショートカット,30,D,同じ操作を　何度も繰り返している,I'm repeating the same action over and over.,Ctrl+D
-1935,Windowsショートカット,35,F,右クリックメニューを　開きたい,I need the context menu without a mouse.,Shift+F10
+id,category,level,kana,phrase,phrase_en,answer,group
+3,大ピンチずかん,77,え,エスカレーターが　ぎゃくだった,The escalator was going the opposite way.,-,kids
+4,大ピンチずかん,20,あ,アイスが　とけてきた,The ice cream started melting.,-,kids
+5,大ピンチずかん,4,へ,へんな　ひやけを　した,Made a strange face.,-,kids
+6,大ピンチずかん,30,た,たんじょうびケーキが　たおれて　イチゴが　ころがった,The birthday cake fell over and the strawberries rolled away.,-,kids
+7,大ピンチずかん,23,ご,ごはんつぶを　ふんだ,Stepped on a grain of rice.,-,kids
+8,大ピンチずかん,21,お,おふろの　ごみが　すくえない,Can't scoop the debris out of the bathtub.,-,kids
+9,大ピンチずかん,18,ふ,ふたが　ない,There is no lid.,-,kids
+10,大ピンチずかん,6,て,テープの　はしが　みつからない,Can't find the end of the tape.,-,kids
+11,大ピンチずかん,28,え,えだまめが　とんだ,The edamame flew away.,-,kids
+12,大ピンチずかん,24,か,カップめんの　おゆが　たりない,Not enough hot water for the cup noodles.,-,kids
+13,大ピンチずかん,68,う,うんてんちゅうの　くるまの　なかに　おおきな　クモが　いる,There is a big spider in the car while driving.,-,kids
+14,大ピンチずかん,35,ゆ,ゆでたまごが　ボロボロ,The boiled egg is falling apart.,-,kids
+15,大ピンチずかん,5,す,ストローが　とれない,Can't take out the straw.,-,kids
+16,大ピンチずかん,27,う,「う」の　もじが　はんたいだった,The letter 'u' was backwards.,-,kids
+17,大ピンチずかん,19,け,おちたけしゴムがみつからない,Can't find the dropped eraser.,-,kids
+18,大ピンチずかん,17,し,しょうゆをいれすぎた,Poured too much soy sauce.,-,kids
+19,大ピンチずかん,34,しゃ,シャワーがみつからない,Can't find the shower.,-,kids
+20,大ピンチずかん,3,こ,こおりがしたにくっついた,The ice stuck to my tongue.,-,kids
+21,大ピンチずかん,26,た,たんじょうびケーキがたおれそう,The birthday cake is about to fall.,-,kids
+22,大ピンチずかん,22,じ,じゅうでんができていなかった,It wasn't charged.,-,kids
+23,大ピンチずかん,14,し,シャボンえきをすった,Accidentally inhaled the bubble solution.,-,kids
+24,大ピンチずかん,33,け,ケチャップがとんだ,Ketchup splattered.,-,kids
+25,大ピンチずかん,31,ぽ,ポケットからすながたくさんでてきた,A lot of sand came out of the pocket.,-,kids
+26,大ピンチずかん,25,せ,せんたくきのうしろにくつしたがおちた,A sock fell behind the washing machine.,-,kids
+27,大ピンチずかん,90,ふ,フンをふんだ,Stepped on poop.,-,kids
+28,大ピンチずかん,55,い,いおうとしていたことをわすれた,Forgot what I was about to say.,-,kids
+29,大ピンチずかん,46,に,にくがきれない,Can't cut the meat.,-,kids
+30,大ピンチずかん,39,た,たんじょうびケーキのろうそくがきえない,The birthday cake candles won't go out.,-,kids
+31,大ピンチずかん,52,む,むかしのおにぎりがでてきた,An old rice ball appeared.,-,kids
+32,大ピンチずかん,54,れ,れいとうこがあかない,The freezer won't open.,-,kids
+33,大ピンチずかん,48,ふ,ふくのピラピラがきになる,The loose thread on my clothes is bothering me.,-,kids
+34,大ピンチずかん,43,し,しゅくだいノートと　じゆうちょうをまちがえた,Confused the homework notebook with the sketchbook.,-,kids
+35,大ピンチずかん,38,ふ,ふたがしまらない,The lid won't close.,-,kids
+36,大ピンチずかん,32,め,めんつゆがすごくあまった,A lot of noodle dipping sauce was left over.,-,kids
+37,大ピンチずかん,53,な,ながしのみずがスプーンではねた,The water in the sink splashed off the spoon.,-,kids
+38,大ピンチずかん,49,べ,べんざをあけたまますわった,Sat down with the toilet seat up.,-,kids
+39,大ピンチずかん,37,あ,アメリカンドッグがまわる,The corn dog is spinning.,-,kids
+40,大ピンチずかん,76,ね,ねむれない,Can't sleep.,-,kids
+41,大ピンチずかん,47,し,シャンプーがめにはいった,Got shampoo in my eyes.,-,kids
+42,大ピンチずかん,51,ば,バッグのなかですいとうがもれた,The water bottle leaked inside the bag.,-,kids
+43,大ピンチずかん,56,な,なまえがおもいだせない,Can't remember the name.,-,kids
+44,大ピンチずかん,64,き,きんじょのおばさんが　ずっとなまえをまちがえている,The neighborhood lady has been getting my name wrong for a long time.,-,kids
+45,大ピンチずかん,50,お,おゆがない,There is no hot water.,-,kids
+46,大ピンチずかん,45,ど,ドアをあけられてさむい,Someone opened the door and it's cold.,-,kids
+47,大ピンチずかん,40,せ,せんせいのメガネがとんだ,The teacher's glasses flew off.,-,kids
+48,大ピンチずかん,36,ほ,ほねをとっていたら　ぐちゃぐちゃになった,It became a mess while I was trying to remove the bones.,-,kids
+49,大ピンチずかん,29,ぎ,ぎゅうにゅうがこぼれた,The milk spilled.,-,kids
+50,大ピンチずかん,96,か,かさがうらがえった,The umbrella turned inside out.,-,kids
+51,大ピンチずかん,97,じ,じてんしゃがドミノだおし,The bicycles fell over like dominoes.,-,kids
+52,大ピンチずかん,98,お,おもったよりみじかくなった,It became shorter than I thought.,-,kids
+53,大ピンチずかん,99,ね,ネコがついてくる,A cat is following me.,-,kids
+54,大ピンチずかん,100,ど,どしゃぶりなのにかさがない,It's pouring rain but I don't have an umbrella.,-,kids
+55,大ピンチずかん,58,れ,れいとうこがしまらない,The freezer won't close.,-,kids
+56,大ピンチずかん,59,さ,さようならのおじぎで　ランドセルのなかみがぜんぶでた,Everything fell out of my backpack when I bowed to say goodbye.,-,kids
+57,大ピンチずかん,84,ま,まいご,I'm lost.,-,kids
+58,大ピンチずかん,82,か,かいものがながい,Shopping is taking a long time.,-,kids
+59,大ピンチずかん,81,じ,じてんしゃにハチがとまっている,A bee is sitting on the bicycle.,-,kids
+60,大ピンチずかん,60,せ,せんせいに　おかあさんといってしまった,I accidentally called my teacher 'Mom'.,-,kids
+61,大ピンチずかん,61,ぎ,ギターのなかにおかしがおちた,A snack fell inside the guitar.,-,kids
+62,大ピンチずかん,62,ず,ズボンのゴムがきれた,The elastic in my pants snapped.,-,kids
+63,大ピンチずかん,63,さ,さなぎからかえったカブトムシが　よなかにだっそうして　とびまわっている,The beetle that emerged from its pupa escaped at night and is flying around.,-,kids
+64,大ピンチずかん,57,け,けしゴムにさした　えんぴつのしんが　けしたときにつく,The pencil lead stuck in the eraser leaves marks when I erase.,-,kids
+65,大ピンチずかん,89,お,おきられない,Can't wake up.,-,kids
+66,大ピンチずかん,91,で,かばしらに　じてんしゃで　つっこんだ,Crashed my bicycle into a mosquito swarm.,-,kids
+67,大ピンチずかん,93,と,トイレがつまった,The toilet is clogged.,-,kids
+68,大ピンチずかん,94,お,おかあさんがイライラしている,Mom is getting irritated.,-,kids
+69,大ピンチずかん,95,お,プレゼントをわすれた,Forgot the present.,-,kids
+70,大ピンチずかん,86,し,しんしつに　だれかいる,Someone is in the bedroom.,-,kids
+71,大ピンチずかん,87,く,クモのすにかかった,Got caught in a spider web.,-,kids
+72,大ピンチずかん,88,と,トイレにおおきなガがとまっている,A large moth is sitting in the toilet.,-,kids
+73,大ピンチずかん,9,し,しゃっくりがとまらない,Can't stop hiccuping.,-,kids
+74,大ピンチずかん,16,わ,わりばしがうまくわれない,Can't split the chopsticks properly.,-,kids
+75,大ピンチずかん,11,ご,ゴミばこがやまもり,The trash can is overflowing.,-,kids
+76,大ピンチずかん,70,お,おなかがすいてうごけない,So hungry I can't move.,-,kids
+77,大ピンチずかん,67,ま,まちがえてシャワーがでた,The shower came on by mistake.,-,kids
+78,大ピンチずかん,13,け,パンがくろこげ,The bread is burnt to a crisp.,-,kids
+79,大ピンチずかん,10,け,けずりかすいれがはいってなかった,The pencil shavings container wasn't in.,-,kids
+80,大ピンチずかん,71,ふ,ふとんのなかでおならがでた,Farted under the covers.,-,kids
+81,大ピンチずかん,69,じ,じぶんのいえでトイレがつまった,The toilet at my own house is clogged.,-,kids
+82,大ピンチずかん,8,あ,あたまにつけたわゴムがとれない,Can't remove the rubber band I put on my head.,-,kids
+83,大ピンチずかん,12,や,ビニールぶくろがめくれない,Can't open the plastic bag.,-,kids
+84,大ピンチずかん,15,し,しょくばんを　がんばってスライスしているうちに　ぺしゃんこになっていた,The bread got squashed while I was trying hard to slice it.,-,kids
+85,大ピンチずかん,7,ぺ,ペンがしみてつくえについた,The pen leaked onto the desk.,-,kids
+86,大ピンチずかん,80,や,やっぱりさむかった,It was cold after all.,-,kids
+87,大ピンチずかん,74,と,トイレのかみがない,There is no toilet paper.,-,kids
+88,大ピンチずかん,73,わ,ワサビいりだった,It had wasabi in it.,-,kids
+89,大ピンチずかん,72,お,おべんとうをわすれた,Forgot my lunch box.,-,kids
+90,大ピンチずかん,66,あ,あしがつちだらけ,Feet are covered in mud.,-,kids
+91,大ピンチずかん,65,は,ハエがじぶんにばかりとまる,Flies only land on me.,-,kids
+92,大ピンチずかん,83,い,イヌがすごくなめてくる,The dog is licking me a lot.,-,kids
+93,大ピンチずかん,75,し,しらないひとのてをにぎっていた,Was holding a stranger's hand.,-,kids
+94,大ピンチずかん,85,し,シロツメクサの　かんむりをよくみると　アブラムシだらけだった,"When I looked closely at the clover crown, it was full of aphids.",-,kids
+95,大ピンチずかん,79,ば,バッグにアリがあつまってきた,Ants gathered on the bag.,-,kids
+96,大ピンチずかん,78,し,しんしつの　てんじょうのもくめが　ひとのかおにみえてきた,The wood grain on the bedroom ceiling started to look like a person's face.,-,kids
+97,大ピンチずかん,41,や,やすみじかんに　おいた　すいとうが　そのまま,The water bottle I left during recess is still there.,-,kids
+98,大ピンチずかん,42,ご,ごはんが　たりない,Not enough food.,-,kids
+99,大ピンチずかん,44,は,はなしを　きいてなかった,Wasn't listening.,-,kids
+100,大ピンチずかん,2,の,のんだガムに　まだあじが　たくさんのこっていた,Swallowed the gum; it still had a lot of flavor left.,-,kids
+101,大ピンチずかん,52,む,むかしの　おにぎりが　でてきた,An old rice ball appeared.,-,kids
+102,国旗王,上級,し,人口密度が高い,High population density.,-,kids
+103,国旗王,上級,ひ,一人当たりGDPが高い,High GDP per capita.,-,kids
+104,国旗王,上級,し,首都 最東,Easternmost capital.,-,kids
+105,国旗王,上級,し,首都が最北,Northernmost capital.,-,kids
+106,国旗王,上級,は,排他的経済水域,Exclusive Economic Zone.,-,kids
+107,国旗王,上級,く,軍事費が最小,Smallest military expenditure.,-,kids
+108,国旗王,上級,へ,平均寿命が短い,Short average life expectancy.,-,kids
+109,国旗王,初級,し,人口が多い,Large population.,-,kids
+110,国旗王,初級,め,面積が最小,Smallest area.,-,kids
+111,国旗王,初級,は,排他的経済水域が最小,Smallest Exclusive Economic Zone.,-,kids
+112,国旗王,上級,さ,最高地点が高い,Highest point is high.,-,kids
+113,国旗王,初級,こ,国内総生産GDPが低い,Low GDP.,-,kids
+114,国旗王,初級,し,人口が少ない,Small population.,-,kids
+115,国旗王,初級,せ,正式国名が長い,Long official country name.,-,kids
+116,国旗王,上級,く,軍事費が大きい,Large military expenditure.,-,kids
+117,国旗王,上級,さ,最高地点が低い,Highest point is low.,-,kids
+118,国旗王,初級,こ,国内総生産GDPが高い,High GDP.,-,kids
+119,国旗王,初級,せ,正式国名が短い,Short official country name.,-,kids
+120,国旗王,初級,め,面積が大きい,Large area.,-,kids
+121,国旗王,上級,へ,平均寿命が長い,Long average life expectancy.,-,kids
+122,国旗王,初級,ひ,一人当たりGDPが低い,Low GDP per capita.,-,kids
+123,国旗王,初級,し,人口密度が低い,Low population density.,-,kids
+124,国旗王,初級,せ,正式国名 五十音順 アに近い,Official name closest to 'A' in Japanese syllabary.,-,kids
+125,国旗王,初級,し,首都が最南,Southernmost capital.,-,kids
+126,おばけかるた,-,ふ,ふでこぞうが　ひとふでがき,Fudekozo draws with a single stroke.,ふでこぞう,kids
+127,おばけかるた,-,ね,ねこまたも　ねがおはかわいい,Even Nekomata looks cute when sleeping.,ねこまた,kids
+128,おばけかるた,-,ち,ちょうちんぶらり　こっちへ　くるぞ,Chochin-burari is coming this way!,ちょうちんぶらり,kids
+129,おばけかるた,-,た,たまごがわれて　てんぐがうまれた,An egg cracked and a Tengu was born.,てんぐ,kids
+130,おばけかるた,-,け,けむくじゃらな　うでだ　まけるな！,"It's a hairy arm, don't lose!",けむくじゃらなうで,kids
+131,おばけかるた,-,く,くずかごからくろいてが！！！　きゃっ！！！,A black hand from the wastebasket!!! Kya!!!,くろいて,kids
+132,おばけかるた,-,あ,あめふりこぞうが　びちゃびちゃあるく,Amefuri-kozo walks with a squish-squish.,あめふりこぞう,kids
+133,おばけかるた,-,ひ,ひとつめのくには　ひとつめだらけだってさ,They say the one-eyed country is full of one-eyes.,ひとつめ,kids
+134,おばけかるた,-,ぬ,ぬらりとわらう　ぬっぺっぽう,Nureppon smiles eerily.,ぬっぺっぽう,kids
+135,おばけかるた,-,つ,つきよにでていくつく　もがみ,Tsuku-mogami goes out on a moonlit night.,つくもがみ,kids
+136,おばけかるた,-,そ,そろってあるく　ぞうりのおばけ,Zori ghosts walk in pairs.,ぞうりのおばけ,kids
+137,おばけかるた,-,こ,こんばんは～　どろどろどろどろ～,Good evening~ Doro-doro-doro-doro~,ゆうれい,kids
+138,おばけかるた,-,き,きゅうびのきつねは　ばけるめいじん,The nine-tailed fox is a master of disguise.,きゅうびのきつね,kids
+139,おばけかるた,-,い,いったんもめんは　そらとべていいなあ,"Ittan-momen, it's nice to fly in the sky.",いったんもめん,kids
+140,おばけかるた,-,は,はたらけはたらけ　おばけもはたらけ,"Work, work, ghosts also work.",おばけ,kids
+141,おばけかるた,-,に,にっこりわらう　にかいのおんな,The woman on the second floor smiles.,にかいのおんな,kids
+142,おばけかるた,-,て,てんぐのはながおれては　かわいそう,It would be pitiful if Tengu's nose broke.,てんぐ,kids
+143,おばけかるた,-,せ,せんすだって　すてればばける,Even a fan will transform if you throw it away.,せんす,kids
+144,おばけかるた,-,さ,さかさくびは　ぺろぺろなめる,Sakasa-kubi licks with a flick-flick.,さかさくび,kids
+145,おばけかるた,-,か,かあさんかっぱ　とこどものかっぱ,Mother Kappa and baby Kappa.,かっぱ,kids
+146,おばけかるた,-,う,うみぼうずのがっこう　せいとをぼしゅう,Umibozu's school is recruiting students.,うみぼうず,kids
+147,おばけかるた,-,の,のんきなのぶすま　のんびりとんだ,Carefree Nobusuma flew leisurely.,のぶすま,kids
+148,おばけかるた,-,な,なきなきかえった　ちいさなゆうれい,A small ghost returned crying.,ちいさなゆうれい,kids
+149,おばけかるた,-,と,とらがねてたら　かみなりどしーん！！,"If a tiger sleeps, lightning strikes with a boom!!",かみなり,kids
+150,おばけかるた,-,す,すりばちこぞうは　なにすってるの？,What is Suribachi-kozo grinding?,すりばちこぞう,kids
+151,おばけかるた,-,し,しろくてみえない　ゆきのひのゆうれい,A white and invisible ghost on a snowy day.,ゆきのひのゆうれい,kids
+152,おばけかるた,-,お,おにもおじいさんになる,Even an ogre grows old.,おに,kids
+153,おばけかるた,-,え,えだをもやしたら　えんえんらがでたぞ,"When I burned a branch, Enenra came out!",えんえんら,kids
+154,おばけかるた,-,る,るすばんしてるは　ぶるぶるひとり,"Staying home alone, trembling.",ゆうれい,kids
+155,おばけかるた,-,り,りゅうがいねむり　そらからおちる,"A dragon sleeping, falling from the sky.",りゅう,kids
+156,おばけかるた,-,む,むじなもばけたが　ちょっとむりだった,"Mujina tried to transform, but it was a bit impossible.",むじな,kids
+157,おばけかるた,-,み,みこしにゅうどう　みかけよりよわい,"Mikoshi-Nyudo, weaker than he looks.",みこしにゅうどう,kids
+158,おばけかるた,-,れ,れいぎただしい　ゆうれいもいる,There are polite ghosts too.,ゆうれい,kids
+159,おばけかるた,-,ら,らしょうもんの　おにはらんぼうだ,The demon of Rashomon is wild.,らしょうもんのおに,kids
+160,おばけかるた,-,め,めだまをとられた　ひとつめこぞう,A one-eyed monster whose eye was taken.,ひとつめこぞう,kids
+161,おばけかるた,-,ま,まくらがえしは　まいばんうるさい,Makura-gaeshi is noisy every night.,まくらがえし,kids
+162,おばけかるた,-,ろ,ろくろくねなかった　ろくろっくび,Rokurokubi who didn't sleep at all.,ろくろっくび,kids
+163,おばけかるた,-,よ,よみちをこわがる　よわむしにゅうどう,A timid Nyudo who is scared of night roads.,よわむしにゅうどう,kids
+164,おばけかるた,-,も,もりんじのかまは　たぬきがばけた,Morinji's kettle was a transformed raccoon dog.,たぬき,kids
+165,おばけかるた,-,ほ,ほうきのおばけは　ほめてやろう,Let's praise the broom ghost.,ほうきのおばけ,kids
+166,おばけかるた,-,を,「あしをけして　てをまえに」ゆうれいのおけいこ,"Delete legs, hands forward - a ghost's practice.",ゆうれい,kids
+167,おばけかるた,-,わ,わ、にゅうどうだ　わぁーっこわい！,"Oh, it's a Nyudo! Ahh, scary!",にゅうどう,kids
+168,おばけかるた,-,ゆ,ゆきおんな　おゆにはいってとけちゃった,Yuki-onna went into hot water and melted.,ゆきおんな,kids
+169,おばけかるた,-,や,やなぎのしたで　ゆうれいけんか,Ghosts fighting under a willow tree.,ゆうれい,kids
+170,おばけかるた,-,へ,へびよりこわい　ろくろっくび,"Rokurokubi, scarier than a snake.",ろくろっくび,kids
+171,いろはかるた,-,ま,嘘から出たまこと,A lie can sometimes turn into the truth,でたらめに言ったことが、偶然にも事実になってしまうこと,kids
+172,いろはかるた,-,こ,弘法にも筆の誤り,Even experts make mistakes,どんな名人でも失敗することがあるというたとえ,kids
+173,いろはかるた,-,あ,得手に帆を揚げる,To take advantage of a good opportunity,物事を行うのに絶好の機会を得ること,kids
+174,いろはかるた,-,あ,味なもの縁は異なもの,Romance works in mysterious ways,男女の仲は理屈では説明できないものだということ,kids
+175,いろはかるた,-,ぞ,芋の煮えたも御存じない,Completely clueless,物事の様子がまったく分からない人をからかう言い方,kids
+176,いろはかるた,-,て,文はやりたし書く手は持たぬ,Wanting to write a letter but lacking the skill,やりたい気持ちはあるが能力が伴わず困っていること,kids
+177,いろはかるた,-,す,亭主の好きな赤烏帽子,One must go along with the head of the household,家長の好みには家族も従うべきだという考え,kids
+178,いろはかるた,-,し,知らぬが仏,Ignorance is bliss,知らなければ悩まずにすむこともあるということ,kids
+179,いろはかるた,-,は,背に腹はかえられぬ,Needs must when driven,大きな目的のためには多少の犠牲は仕方ないということ,kids
+180,いろはかるた,-,げ,芸は身を助ける,A skill will always help you,身につけた技や芸が困ったときに役立つこと,kids
+181,いろはかるた,-,の,喉元過ぎれば熱さを忘れる,"Once the pain is gone, the lesson is forgotten",苦しい経験をしても時間がたつと忘れてしまうこと,kids
+182,いろはかるた,-,あ,頭隠して尻隠さず,Trying to hide something but failing,一部しか隠していないのに全部隠したつもりでいること,kids
+183,いろはかるた,-,み,身から出た錆,You reap what you sow,自分のした悪い行いの結果で自分が苦しむこと,kids
+184,いろはかるた,-,も,門前の小僧習わぬ経を読む,You learn things naturally by exposure,日頃見聞きしているうちに自然と身につくことがある,kids
+185,いろはかるた,-,お,鬼に金棒,Adding strength to the strong,強いものがさらに力を得て一層強くなること,kids
+186,いろはかるた,-,ま,負けるが勝ち,Sometimes losing leads to winning,一歩引いた方が結果的に有利になることがある,kids
+187,いろはかるた,-,さ,三遍回って煙草にしょ,Take time and be careful,急がず慎重に行動することが大切だということ,kids
+188,いろはかるた,-,め,目の上のたん瘤,A thorn in one’s side,自分にとって邪魔で目障りな存在のたとえ,kids
+189,いろはかるた,-,ひ,貧乏暇なし,The poor have no leisure,貧しい人ほど仕事に追われ時間の余裕がないこと,kids
+190,いろはかるた,-,く,臭い物に蓋をする,To cover up an inconvenient truth,都合の悪いことを一時的に隠そうとすること,kids
+191,いろはかるた,-,や,安物買いの銭失い,Buying cheap ends up costing more,安い物を買うとかえって損をすること,kids
+192,いろはかるた,-,き,聞いて極楽見て地獄,Hearing and seeing are very different,聞くのと実際に見るのとでは大きな違いがあること,kids
+193,いろはかるた,-,ゆ,油断大敵,Carelessness is dangerous,油断すると失敗や災難を招くということ,kids
+194,いろはかるた,-,い,犬も歩けば棒に当たる,Every action brings some result,行動すれば良くも悪くも何かが起こるということ,kids
+195,いろはかるた,-,ら,楽あれば苦あり,Life has ups and downs,人生には楽しいことと苦しいことの両方がある,kids
+196,いろはかるた,-,む,無理が通れば道理が引っ込む,"When force prevails, reason disappears",無茶がまかり通る世の中では道理が通らなくなる,kids
+197,いろはかるた,-,と,年寄りの冷や水,An old person acting recklessly,年齢を考えず無理な振る舞いをすること,kids
+198,いろはかるた,-,す,粋は身を食う,Showing off can ruin you,気取った振る舞いが身を滅ぼすことがある,kids
+199,いろはかるた,-,き,京の夢大阪の夢,Dreams are fleeting and strange,夢というものはとりとめなく不思議なものだということ,kids
+200,いろはかるた,-,へ,下手の長談義,The unskilled talk the longest,下手な人ほど話が長くなること,kids
+201,いろはかるた,-,ろ,論より証拠,Proof is better than argument,理屈よりも実際の証拠が大切だということ,kids
+202,いろはかるた,-,く,くたびれ儲け,All effort and no reward,苦労したわりに何の得もないこと,kids
+203,いろはかるた,-,に,憎まれっ子世にはばかる,The disliked often survive well,憎まれるような人ほど世渡りがうまいこと,kids
+204,いろはかるた,-,ち,塵も積もれば山となる,Many small things add up,小さなことでも積み重なれば大きな成果になる,kids
+205,いろはかるた,-,こ,律義者の子だくさん,Honest people tend to have many children,律義な人は家庭を大切にし子どもが多くなるという考え,kids
+206,いろはかるた,-,ぬ,盗人の昼寝,Even bad acts have consequences,どんな行いにも必ず報いがあるということ,kids
+207,いろはかるた,-,は,花より団子,Practicality over appearance,見た目より実利を重んじること,kids
+208,いろはかるた,-,る,瑠璃も玻璃も照らせば光る,True talent shines anywhere,才能のある人はどんな環境でも力を発揮する,kids
+209,いろはかるた,-,な,泣きっ面に蜂,Misfortune never comes alone,不運なときにさらに不幸が重なること,kids
+210,いろはかるた,-,あ,葦の髄から天井のぞく,Judging the whole from a tiny part,わずかな知識で全て分かったつもりになること,kids
+211,いろはかるた,-,か,蛙の面に水,Completely unfazed,何をされても平然としていること,kids
+212,いろはかるた,-,わ,破れ鍋に綴じ蓋,Every pot has its lid,どんな人にもふさわしい相手がいるということ,kids
+213,いろはかるた,-,を,老いては子に従え,Let the younger generation lead,年を取ったら若い者の意見に従うのがよい,kids
+214,いろはかるた,-,ね,念には念を入れよ,Double-check everything,十分注意した上でさらに注意を重ねること,kids
+215,いろはかるた,-,た,旅は道連れ世は情け,Life is about helping each other,人は助け合って生きていくものだということ,kids
+216,いろはかるた,-,れ,良薬は口に苦し,Good medicine tastes bitter,忠告は耳に痛いが自分のためになる,kids
+217,いろはかるた,-,そ,総領の甚六,The eldest son is often naive,長男は大事に育てられ世間知らずになりがちだということ,kids
+218,いろはかるた,-,つ,月とすっぽん,Like night and day,似ているようで実際は大きな違いがある,kids
+219,いろはかるた（意味）,-,ま,でたらめに言ったことが、偶然にも事実になってしまうこと,A lie can sometimes turn into the truth,嘘から出たまこと,kids
+220,いろはかるた（意味）,-,こ,どんな名人でも失敗することがあるというたとえ,Even experts make mistakes,弘法にも筆の誤り,kids
+221,いろはかるた（意味）,-,あ,物事を行うのに絶好の機会を得ること,To take advantage of a good opportunity,得手に帆を揚げる,kids
+222,いろはかるた（意味）,-,あ,男女の仲は理屈では説明できないものだということ,Romance works in mysterious ways,味なもの縁は異なもの,kids
+223,いろはかるた（意味）,-,ぞ,物事の様子がまったく分からない人をからかう言い方,Completely clueless,芋の煮えたも御存じない,kids
+224,いろはかるた（意味）,-,て,やりたい気持ちはあるが能力が伴わず困っていること,Wanting to write a letter but lacking the skill,文はやりたし書く手は持たぬ,kids
+225,いろはかるた（意味）,-,す,家長の好みには家族も従うべきだという考え,One must go along with the head of the household,亭主の好きな赤烏帽子,kids
+226,いろはかるた（意味）,-,し,知らなければ悩まずにすむこともあるということ,Ignorance is bliss,知らぬが仏,kids
+227,いろはかるた（意味）,-,は,大きな目的のためには多少の犠牲は仕方ないということ,Needs must when driven,背に腹はかえられぬ,kids
+228,いろはかるた（意味）,-,げ,身につけた技や芸が困ったときに役立つこと,A skill will always help you,芸は身を助ける,kids
+229,いろはかるた（意味）,-,の,苦しい経験をしても時間がたつと忘れてしまうこと,"Once the pain is gone, the lesson is forgotten",喉元過ぎれば熱さを忘れる,kids
+230,いろはかるた（意味）,-,あ,一部しか隠していないのに全部隠したつもりでいること,Trying to hide something but failing,頭隠して尻隠さず,kids
+231,いろはかるた（意味）,-,み,自分のした悪い行いの結果で自分が苦しむこと,You reap what you sow,身から出た錆,kids
+232,いろはかるた（意味）,-,も,日頃見聞きしているうちに自然と身につくことがある,You learn things naturally by exposure,門前の小僧習わぬ経を読む,kids
+233,いろはかるた（意味）,-,お,強いものがさらに力を得て一層強くなること,Adding strength to the strong,鬼に金棒,kids
+234,いろはかるた（意味）,-,ま,一歩引いた方が結果的に有利になることがある,Sometimes losing leads to winning,負けるが勝ち,kids
+235,いろはかるた（意味）,-,さ,急がず慎重に行動することが大切だということ,Take time and be careful,三遍回って煙草にしょ,kids
+236,いろはかるた（意味）,-,め,自分にとって邪魔で目障りな存在のたとえ,A thorn in one’s side,目の上のたん瘤,kids
+237,いろはかるた（意味）,-,ひ,貧しい人ほど仕事に追われ時間の余裕がないこと,The poor have no leisure,貧乏暇なし,kids
+238,いろはかるた（意味）,-,く,都合の悪いことを一時的に隠そうとすること,To cover up an inconvenient truth,臭い物に蓋をする,kids
+239,いろはかるた（意味）,-,や,安い物を買うとかえって損をすること,Buying cheap ends up costing more,安物買いの銭失い,kids
+240,いろはかるた（意味）,-,き,聞くのと実際に見るのとでは大きな違いがあること,Hearing and seeing are very different,聞いて極楽見て地獄,kids
+241,いろはかるた（意味）,-,ゆ,油断すると失敗や災難を招くということ,Carelessness is dangerous,油断大敵,kids
+242,いろはかるた（意味）,-,い,行動すれば良くも悪くも何かが起こるということ,Every action brings some result,犬も歩けば棒に当たる,kids
+243,いろはかるた（意味）,-,ら,人生には楽しいことと苦しいことの両方がある,Life has ups and downs,楽あれば苦あり,kids
+244,いろはかるた（意味）,-,む,無茶がまかり通る世の中では道理が通らなくなる,"When force prevails, reason disappears",無理が通れば道理が引っ込む,kids
+245,いろはかるた（意味）,-,と,年齢を考えず無理な振る舞いをすること,An old person acting recklessly,年寄りの冷や水,kids
+246,いろはかるた（意味）,-,す,気取った振る舞いが身を滅ぼすことがある,Showing off can ruin you,粋は身を食う,kids
+247,いろはかるた（意味）,-,き,夢というものはとりとめなく不思議なものだということ,Dreams are fleeting and strange,京の夢大阪の夢,kids
+248,いろはかるた（意味）,-,へ,下手な人ほど話が長くなること,The unskilled talk the longest,下手の長談義,kids
+249,いろはかるた（意味）,-,ろ,理屈よりも実際の証拠が大切だということ,Proof is better than argument,論より証拠,kids
+250,いろはかるた（意味）,-,く,苦労したわりに何の得もないこと,All effort and no reward,くたびれ儲け,kids
+251,いろはかるた（意味）,-,に,憎まれるような人ほど世渡りがうまいこと,The disliked often survive well,憎まれっ子世にはばかる,kids
+252,いろはかるた（意味）,-,ち,小さなことでも積み重なれば大きな成果になる,Many small things add up,塵も積もれば山となる,kids
+253,いろはかるた（意味）,-,こ,律義な人は家庭を大切にし子どもが多くなるという考え,Honest people tend to have many children,律義者の子だくさん,kids
+254,いろはかるた（意味）,-,ぬ,どんな行いにも必ず報いがあるということ,Even bad acts have consequences,盗人の昼寝,kids
+255,いろはかるた（意味）,-,は,見た目より実利を重んじること,Practicality over appearance,花より団子,kids
+256,いろはかるた（意味）,-,る,才能のある人はどんな環境でも力を発揮する,True talent shines anywhere,瑠璃も玻璃も照らせば光る,kids
+257,いろはかるた（意味）,-,な,不運なときにさらに不幸が重なること,Misfortune never comes alone,泣きっ面に蜂,kids
+258,いろはかるた（意味）,-,あ,わずかな知識で全て分かったつもりになること,Judging the whole from a tiny part,葦の髄から天井のぞく,kids
+259,いろはかるた（意味）,-,か,何をされても平然としていること,Completely unfazed,蛙の面に水,kids
+260,いろはかるた（意味）,-,わ,どんな人にもふさわしい相手がいるということ,Every pot has its lid,破れ鍋に綴じ蓋,kids
+261,いろはかるた（意味）,-,を,年を取ったら若い者の意見に従うのがよい,Let the younger generation lead,老いては子に従え,kids
+262,いろはかるた（意味）,-,ね,十分注意した上でさらに注意を重ねること,Double-check everything,念には念を入れよ,kids
+263,いろはかるた（意味）,-,た,人は助け合って生きていくものだということ,Life is about helping each other,旅は道連れ世は情け,kids
+264,いろはかるた（意味）,-,れ,忠告は耳に痛いが自分のためになる,Good medicine tastes bitter,良薬は口に苦し,kids
+265,いろはかるた（意味）,-,そ,長男は大事に育てられ世間知らずになりがちだということ,The eldest son is often naive,総領の甚六,kids
+266,いろはかるた（意味）,-,つ,似ているようで実際は大きな違いがある,Like night and day,月とすっぽん,kids
+267,百人一首,-,あ,あきのたの かりほのいおの とまをあらみ わがころもでは つゆにぬれつつ,"In the autumn field, in the temporary hut's rough rush-mats, my sleeves are getting wet with dew.",-,kids
+268,百人一首,-,あ,あきかぜに たなびくくもの たえまより もれいづるつきの かげのさやけさ,"Through the rifts in the clouds trailing in the autumn wind, how clear the moonlight leaks out.",-,kids
+269,百人一首,-,あ,あしびきの やまどりのをの しだりをの ながながしよを ひとりかもねむ,"Must I sleep alone through the long, long night, like the long, trailing tail of the mountain pheasant?",-,kids
+270,百人一首,-,あ,あまのはら ふりさけみれば かすがなる みかさのやまに いでしつきかも,"When I look out over the plain of heaven, is that the same moon that rose over Mount Mikasa in Kasuga?",-,kids
+271,百人一首,-,あ,あわれとも いうべきひとは おもほえで みのいたずらに なりぬべきかな,"Since there is no one who might feel pity for me, I suppose I shall just pass away in vain.",-,kids
+272,百人一首,-,い,いまはただ おもひたえなむ とばかりを ひとづてならで いうよしもがな,Now I just want to give up my love; if only I could tell you this directly and not through others.,-,kids
+273,百人一首,-,い,いまこむと いいしばかりに ながつきの ありあけのつきを まちいでつるかな,"Just because you said 'I'll come soon', I have waited until the morning moon of the long month appeared.",-,kids
+274,百人一首,-,い,いろはにほへど ちりぬるを わがよたれぞ つねならむ,"Though flowers are fragrant, they will fall; in our world, who can remain forever?",-,kids
+275,百人一首,-,い,いのちながくは かたみにあはず ひとりして ものおもふよぞ ながかりける,"If I live long, we might not meet again; the night I spend alone in thought is so very long.",-,kids
+276,百人一首,-,い,いにしへの ならのみやこの やへざくら けふここのへに にほひぬるかな,The eight-layered cherry blossoms of the ancient capital of Nara are fragrantly blooming today in the imperial palace.,-,kids
+277,百人一首,-,う,うかりける ひとをはつせの やまおろしよ はげしかれとは いのらぬものを,"O mountain wind of Hatsuse, I did not pray for you to be so harsh, though she is cold to me.",-,kids
+278,百人一首,-,う,うらみわび ほさぬそでだに あるものを こひにくちなむ なこそをしけれ,"I resent her and am weary; my sleeves never dry, and I fear my reputation will rot away in this love.",-,kids
+279,百人一首,-,え,えにしあらば あはむとぞおもふ いざさらば わがなとひとは わすれざらなむ,"If there is fate, I believe we shall meet; now farewell, and may you not forget my name.",-,kids
+280,百人一首,-,お,おおえやま いくののみちの とおければ まだふみもみず あまのはしだて,The road to Ikuno over Mount Oe is so far that I have seen neither a letter nor Amanohashidate.,-,kids
+281,百人一首,-,お,おくやまに もみぢふみわけ なくしかの こゑきくときぞ あきはかなしき,"When I hear the voice of the stag crying as he steps through the maple leaves deep in the mountains, autumn is truly sad.",-,kids
+282,百人一首,-,か,かささぎの わたせるはしに おくしもの しろきをみれば よぞふけにける,"When I see the white frost on the bridge the magpies are said to have spread, I know the night has deepened.",-,kids
+283,百人一首,-,か,かぜをいたみ いはうつなみの おのれのみ くだけてものを おもふころかな,"Like the waves breaking against the rocks in the fierce wind, I alone am broken as I think of my love.",-,kids
+284,百人一首,-,き,きみがため はるののにいでて わかなつむ わがころもでに ゆきはふりつつ,"For your sake, I went out to the spring fields to pick young greens, while snow fell on my sleeves.",-,kids
+285,百人一首,-,き,きみがため をしからざりし いのちさへ ながくもがなと おもひけるかな,"For your sake, I did not value my life, but now I wish it would be long.",-,kids
+286,百人一首,-,く,くさもきも いろかはれども わたつみの なみのはなにぞ あきなかりける,"Though the colors of plants and trees change, there is no autumn in the flowers of the sea waves.",-,kids
+287,百人一首,-,く,くれなゐに みづくくるとは ききしかど あきぞこのはに まじりけるかな,"I heard that the water is dyed crimson, but it seems autumn has mixed into the leaves.",-,kids
+288,百人一首,-,こ,こころあてに をらばやをらむ はつしもの おきまどはせる しらぎくのはな,"If I were to pick them at random, I might pick the white chrysanthemums that the first frost has confused.",-,kids
+289,百人一首,-,こ,このたびは ぬさもとりあへず たむけやま もみぢのにしき かみのまにまに,"At this time, I could not even bring an offering; let the gods take the brocade of maple leaves on Mount Tamuke.",-,kids
+290,百人一首,-,さ,さびしさに やどをたちいでて ながむれば いづこもおなじ あきのゆふぐれ,"In my loneliness, I leave my house and look out; everywhere it is the same autumn evening.",-,kids
+291,百人一首,-,し,しのぶれど いろにいでにけり わがこひは ものやおもふと ひとのとふまで,"Though I try to hide it, my love shows in my face, until people ask if I am lost in thought.",-,kids
+292,百人一首,-,す,すみのえの きしによるなみ よるさへや ゆめのかよひぢ ひとめよくらむ,"Like the waves approaching the shore of Suminoe, even at night do you avoid people's eyes on the dream path?",-,kids
+293,百人一首,-,せ,せをはやみ いはにせかるる たきがはの われてもすゑに あはむとぞおもふ,"Like the river current split by a rock in the rapids, though divided, I know we shall meet in the end.",-,kids
+294,百人一首,-,そ,そらしらぬ ゆきふみわけて いでつるは ひとつのえだに つるをたづねて,"I went out treading through the snow I didn't know, seeking a vine on a single branch.",-,kids
+295,百人一首,-,た,たごのうらに うちいでてみれば しろたへの ふじのたかねに ゆきはふりつつ,"When I go out to the shore of Tago and look, snow is falling on the white peak of Mount Fuji.",-,kids
+296,百人一首,-,ち,ちはやぶる かみよもきかず たつたがは からくれなゐに みづくくるとは,"Never heard of even in the age of the mighty gods, that the Tatsuta River is dyed in deep crimson.",-,kids
+297,百人一首,-,つ,つくばねの みねよりおつる みなのがは こひぞつもりて ふちとなりぬる,"Like the Minano River falling from the peak of Tsukubane, my love has accumulated and become a deep pool.",-,kids
+298,百人一首,-,て,てふことも いまはむかしに なりぬれば たがためにかは なにかうらみむ,"Since even that has become a thing of the past, for whose sake should I hold any resentment?",-,kids
+299,百人一首,-,と,ともしびを かきたつるまも なつかしき いづれのよひに みえぬまにまに,"Even while trimming the lamp, I miss you; on which evening did I not see you?",-,kids
+300,百人一首,-,な,ながからむ こころもしらず くろかみの みだれてけさは ものをこそおもへ,"Uncertain of how long his heart will stay,my black hair lies in disarray this morning and so, I am lost in troubled thoughts.",-,kids
+301,百人一首,-,に,にしきなる ふくろにいれて いはざかり いづれのやまを こえぬとぞおもふ,I put it in a brocade bag; I wonder which mountain it crossed in its peak of silence.,-,kids
+302,百人一首,-,ぬ,ぬさもとりあへず たむけやま もみぢのにしき かみのまにまに,I could not even bring an offering; let the gods take the brocade of maple leaves on Mount Tamuke.,-,kids
+303,百人一首,-,ね,ねがはくは はなのしたにて はるしなむ そのきさらぎの もちづきのころ,"My wish is to die in spring under the flowers, around the time of the full moon in the second month.",-,kids
+304,百人一首,-,の,のちのよを おもへばかろし ほととぎす あかつきかけて なきつるものを,"Thinking of the afterlife makes it seem light, while the cuckoo cries toward the dawn.",-,kids
+305,百人一首,-,は,はるすぎて なつきにけらし しろたへの ころもほすてふ あまのかぐやま,Spring has passed and summer seems to have come; white robes are said to be dried on the heavenly Mount Kagu.,-,kids
+306,百人一首,-,ひ,ひさかたの ひかりのどけき はるのひに しづこころなく はなのちるらむ,"On this spring day when the light is so calm, why do the cherry blossoms scatter with such unquiet hearts?",-,kids
+307,百人一首,-,ふ,ふくからに あきのくさきの しをるれば むべやまかぜを あらしといふらむ,"Since the autumn plants and trees wither as soon as it blows, it is no wonder the mountain wind is called a storm.",-,kids
+308,百人一首,-,へ,へにける いくよをかさね たまづさの ふみをひらけば こひぞつもりぬる,"As I open the letter after many passing nights, my love has truly accumulated.",-,kids
+309,百人一首,-,ほ,ほととぎす なきつるかたを ながむれば ただありあけの つきぞのこれる,"When I look toward where the cuckoo cried, only the morning moon remains.",-,kids
+310,百人一首,-,ま,まつとしき たかしのはまの あまごろも ぬれにぞぬれし いろはかはらず,"Waiting on the beach of Takashi, the fisher's robe got soaked and soaked, but its color remained unchanged.",-,kids
+311,百人一首,-,み,みかのはら わきてながるる いづみがは いつみきとてか こひしかるらむ,"Like the Izumi River flowing through the plain of Mika, when did I see you that I should love you so?",-,kids
+312,百人一首,-,む,むらさめの つゆもまだひぬ まきのはに きりたちのぼる あきのゆふぐれ,"Before the dew of the passing shower has dried on the fir leaves, the mist rises on an autumn evening.",-,kids
+313,百人一首,-,め,めぐりあひて みしやそれとも わかぬまに くもがくれにし よはのつきかな,"Meeting by chance, before I could even tell if it was you, you were hidden by clouds like the midnight moon.",-,kids
+314,百人一首,-,も,ももしきや ふるきのきばの しのぶにも なほあまりある むかしなりけり,"In the palace, even the ferns on the old eaves make me yearn for the past more than I can bear.",-,kids
+315,百人一首,-,や,やすらはで ねなましものを さよふけて かたぶくまでの つきをみしかな,I should have gone to sleep without waiting; I watched the moon until it began to sink late at night.,-,kids
+316,百人一首,-,ゆ,ゆらのとを わたるふなびと かぢをたえ ゆくへもしらぬ こひのみちかな,"Like a mariner crossing the Yura Strait with a lost oar, I know not where the path of my love leads.",-,kids
+317,百人一首,-,よ,よをこめて とりのそらねは はかるとも よにあふさかの せきはゆるさじ,"Though you try to deceive with a bird's false cry in the dead of night, the gate of Osaka shall not let you pass.",-,kids
+318,百人一首,-,ら,らいしやうの いのちのはてを しらぬまに けふをかぎりと おもひけるかな,"Not knowing the end of my life in the next world, I thought today would be the limit.",-,kids
+319,百人一首,-,り,りくかぜの さむきにたへて みちのくの しのぶもぢずり たれゆゑにけむ,"Enduring the cold land wind, for whose sake was the tangled print of Michinoku's Shinobu?",-,kids
+320,百人一首,-,る,るりのつぼ いづれのひとも すむらむと こころをかけし いろはみえず,"In the lapis lazuli jar where everyone might live, I cannot see the colors I set my heart on.",-,kids
+321,百人一首,-,れ,れいよりも こころをつくせ さくらばな ちりぬるのちも にほひをこそ,"Exert your heart more than usual, cherry blossoms; even after you fall, leave your fragrance.",-,kids
+322,百人一首,-,ろ,ろばたにて こまをつなぎて みるほどに はなぞちりける さくらかな,"While tethering my horse by the roadside, the cherry blossoms were scattering.",-,kids
+323,百人一首,-,わ,わたのはら やそしまかけて こぎいでぬと ひとにはつげよ あまのつりぶね,"Tell the people that I have rowed out over the wide sea toward the many islands, O fisher's boat.",-,kids
+324,百人一首,-,を,をぐらやま みねのもみぢば こころあらば いまひとたびの みゆきまたなむ,"O maple leaves on the peak of Mount Ogura, if you have a heart, wait for one more imperial visit.",-,kids
+325,百人一首,-,ん,んにゃくにしゅう つねのことばを うたにして こころをつたふ みちぞたふとき,"Turning ordinary words into songs to convey the heart, the path is truly noble.",-,kids
+326,大ピンチずかん,92,た,たからものいれが　あかない,I can't open treasure box.,-,kids
+327,大ピンチずかん,1,が,がむを　のんだ,I swallowed gum.,-,kids
+400,しょうがっこうかるた,-,あ,あさきたら あいさつしよう げんきよく,"When morning comes, greet cheerfully.",-,kids
+401,しょうがっこうかるた,-,い,いねむりは たいちょうくずす はじまりだ,Dozing off is the start of feeling unwell.,-,kids
+402,しょうがっこうかるた,-,う,うんどうで からだをきたえ よくねよう,Exercise your body and sleep well.,-,kids
+403,しょうがっこうかるた,-,え,えがおでね すごせばみんな うれしいよ,"If you spend time smiling, everyone is happy.",-,kids
+404,しょうがっこうかるた,-,お,おはようと げんきなこえで あいさつだ,Say good morning with a cheerful voice.,-,kids
+405,しょうがっこうかるた,-,か,かさをさし あめのひだって たのしいよ,Even rainy days can be fun with an umbrella.,-,kids
+406,しょうがっこうかるた,-,き,きちんとね つかったあとは かたづけよう,"After using things, tidy them properly.",-,kids
+407,しょうがっこうかるた,-,く,くつぬいで そろえておけば きもちいい,Take off and line up your shoes neatly.,-,kids
+408,しょうがっこうかるた,-,け,けいさんは あせらずゆっくり かくにんだ,Do calculations calmly and check carefully.,-,kids
+409,しょうがっこうかるた,-,こ,こころには あんぜんまもる やくそくだ,Keep safety rules in your heart.,-,kids
+410,しょうがっこうかるた,-,さ,さくらさく にゅうがくきせつ はるがきた,Cherry blossoms bloom—spring and school begin.,-,kids
+411,しょうがっこうかるた,-,し,しゃべらずに どうろをあるこう あぶないよ,Walk quietly on roads—it’s dangerous otherwise.,-,kids
+412,しょうがっこうかるた,-,す,すきなもの ちゃんとえらんで たいせつに,Choose what you like and value it.,-,kids
+413,しょうがっこうかるた,-,せ,せいりして つかえばいつも きもちいい,Keep things organized and feel good.,-,kids
+414,しょうがっこうかるた,-,そ,そうじして みんなできれいに しようね,Let’s all clean and make it neat.,-,kids
+415,しょうがっこうかるた,-,た,たのしいね みんなであそぶと えがおさく,Playing together brings smiles.,-,kids
+416,しょうがっこうかるた,-,ち,ちいさくても ルールまもれば りっぱだよ,Even small acts matter if you follow rules.,-,kids
+417,しょうがっこうかるた,-,つ,つかうもの たいせつにして ながくつかう,Take care of things and use them long.,-,kids
+418,しょうがっこうかるた,-,て,てをあらい きれいにすれば びょうきよぼう,Wash your hands to prevent illness.,-,kids
+419,しょうがっこうかるた,-,と,ともだちと なかよくすごす がっこうだ,School is for getting along with friends.,-,kids
+420,しょうがっこうかるた,-,な,なかよくね けんかしないで すごそうよ,Let’s get along without fighting.,-,kids
+421,しょうがっこうかるた,-,に,にこにこと えがおであいさつ きもちいい,Smiling greetings feel good.,-,kids
+422,しょうがっこうかるた,-,ぬ,ぬいだくつ そろえておけば きれいだね,Neatly arranged shoes look nice.,-,kids
+423,しょうがっこうかるた,-,ね,ねるまえに あしたのじゅんび しておこう,Prepare for tomorrow before sleeping.,-,kids
+424,しょうがっこうかるた,-,の,のこさずに きゅうしょくたべて げんきだよ,Eat your lunch fully to stay healthy.,-,kids
+425,しょうがっこうかるた,-,は,はやおきで こころもからだも げんきだよ,Waking early keeps you healthy.,-,kids
+426,しょうがっこうかるた,-,ひ,ひとりでも できることから がんばろう,"Do what you can, even alone.",-,kids
+427,しょうがっこうかるた,-,ふ,ふざけずに じゅぎょううけよう しっかりと,Take class seriously without fooling around.,-,kids
+428,しょうがっこうかるた,-,へ,へやのなか きれいにすれば きもちいい,A clean room feels nice.,-,kids
+429,しょうがっこうかるた,-,ほ,ほんをよみ こころをそだて かしこくね,Read books to grow your mind.,-,kids
+430,しょうがっこうかるた,-,ま,まいにちを たいせつにして すごそうね,Cherish each day.,-,kids
+431,しょうがっこうかるた,-,み,みんなでね ちからをあわせ がんばろう,Let’s work together.,-,kids
+432,しょうがっこうかるた,-,む,むりしない じぶんのペースで すすもうね,Go at your own pace.,-,kids
+433,しょうがっこうかるた,-,め,めあてもち がくしゅうすれば ちからつく,Study with goals to improve.,-,kids
+434,しょうがっこうかるた,-,も,ものはね たいせつにして つかおうね,Take care of your belongings.,-,kids
+435,しょうがっこうかるた,-,や,やくそくを まもればみんな しんらいだ,Keeping promises builds trust.,-,kids
+436,しょうがっこうかるた,-,ゆ,ゆっくりと あせらずいこう だいじょうぶ,"Take it slow, no need to rush.",-,kids
+437,しょうがっこうかるた,-,よ,よるふかし しないでねむろう はやめにね,"Don’t stay up late, sleep early.",-,kids
+438,しょうがっこうかるた,-,ら,らくがきは してはいけない たいせつに,Don’t scribble—respect things.,-,kids
+439,しょうがっこうかるた,-,り,りゆうある こうどうすれば せいちょうだ,Act with purpose to grow.,-,kids
+440,しょうがっこうかるた,-,る,ルールまもり みんながたのしく すごせるよ,Follow rules so everyone enjoys.,-,kids
+441,しょうがっこうかるた,-,れ,れいぎよく あいさつできる いいこだね,Polite greetings are great.,-,kids
+442,しょうがっこうかるた,-,ろ,ろうかでは はしらずあるこう あんぜんに,Walk in hallways safely.,-,kids
+443,しょうがっこうかるた,-,わ,わすれもの しないようにね かくにんだ,Check so you don’t forget things.,-,kids
+444,しょうがっこうかるた,-,を,しゅくだいを きちんとやろう わすれずに,Do your homework properly without forgetting.,-,kids
+445,しょうがっこうかるた,-,ん,さんかんび パパやママは みてるかな,"On open school day, I wonder if mom and dad are watching.",-,kids
+1001,HTTPステータスコード,-,2,要求は成功しました,The request succeeded.,200 OK,engineer
+1002,HTTPステータスコード,-,2,新しいリソースが作成されました,A new resource has been created.,201 Created,engineer
+1003,HTTPステータスコード,-,2,処理は成功したが返す内容がない,The request succeeded but there is no content to return.,204 No Content,engineer
+1004,HTTPステータスコード,-,3,リソースが恒久的に移動した,The resource has permanently moved.,301 Moved Permanently,engineer
+1005,HTTPステータスコード,-,3,リソースが一時的に移動した,The resource has temporarily moved.,302 Found,engineer
+1006,HTTPステータスコード,-,3,キャッシュされた内容が更新されていない,The cached content has not changed.,304 Not Modified,engineer
+1007,HTTPステータスコード,-,4,リクエストの形式が正しくない,The request is malformed.,400 Bad Request,engineer
+1008,HTTPステータスコード,-,4,認証が必要です,Authentication is required.,401 Unauthorized,engineer
+1009,HTTPステータスコード,-,4,認証は済んでいるが権限がありません,"Authenticated, but not authorized to access this resource.",403 Forbidden,engineer
+1010,HTTPステータスコード,-,4,リソースが見つかりません,The requested resource was not found.,404 Not Found,engineer
+1011,HTTPステータスコード,-,4,許可されていないHTTPメソッドが使われた,The HTTP method used is not allowed.,405 Method Not Allowed,engineer
+1012,HTTPステータスコード,-,4,リクエストが時間内に完了しなかった,The request timed out.,408 Request Timeout,engineer
+1013,HTTPステータスコード,-,4,リソースの状態が競合している,The request conflicts with the current state of the resource.,409 Conflict,engineer
+1014,HTTPステータスコード,-,4,リソースは存在したが今は削除された,The resource existed but has since been deleted.,410 Gone,engineer
+1015,HTTPステータスコード,-,4,送信データが大きすぎる,The request payload is too large.,413 Payload Too Large,engineer
+1016,HTTPステータスコード,-,4,対応していない形式のデータが送られた,The media type of the request is not supported.,415 Unsupported Media Type,engineer
+1017,HTTPステータスコード,-,4,構文は正しいが内容を処理できない,The request is well-formed but cannot be processed.,422 Unprocessable Entity,engineer
+1018,HTTPステータスコード,-,4,短時間にリクエストを送りすぎた,Too many requests were sent in a short time.,429 Too Many Requests,engineer
+1019,HTTPステータスコード,-,5,サーバー内部で予期しないエラーが発生した,An unexpected error occurred on the server.,500 Internal Server Error,engineer
+1020,HTTPステータスコード,-,5,サーバーがその機能に対応していない,The server does not support the requested functionality.,501 Not Implemented,engineer
+1021,HTTPステータスコード,-,5,上流サーバーから不正な応答を受け取った,Received an invalid response from an upstream server.,502 Bad Gateway,engineer
+1022,HTTPステータスコード,-,5,サーバーが一時的に利用できない,The server is temporarily unavailable.,503 Service Unavailable,engineer
+1023,HTTPステータスコード,-,5,上流サーバーからの応答が時間内に来なかった,Did not receive a timely response from an upstream server.,504 Gateway Timeout,engineer
+1101,Linuxコマンドかるた,-,L,ディレクトリ一覧を表示する,Display a list of directory contents.,ls,engineer
+1102,Linuxコマンドかるた,-,P,現在のディレクトリを表示する,Display the current directory.,pwd,engineer
+1103,Linuxコマンドかるた,-,C,ディレクトリを移動する,Change the current directory.,cd,engineer
+1104,Linuxコマンドかるた,-,M,新しいディレクトリを作成する,Create a new directory.,mkdir,engineer
+1105,Linuxコマンドかるた,-,R,空のディレクトリを削除する,Remove an empty directory.,rmdir,engineer
+1106,Linuxコマンドかるた,-,R,ファイルを削除する,Delete a file.,rm,engineer
+1107,Linuxコマンドかるた,-,C,ファイルをコピーする,Copy a file.,cp,engineer
+1108,Linuxコマンドかるた,-,M,ファイルを移動する、または名前を変更する,Move or rename a file.,mv,engineer
+1109,Linuxコマンドかるた,-,T,空のファイルを作成する、タイムスタンプを更新する,Create an empty file or update its timestamp.,touch,engineer
+1110,Linuxコマンドかるた,-,C,ファイルの内容を表示する,Display the contents of a file.,cat,engineer
+1111,Linuxコマンドかるた,-,F,ファイルを検索する,Search for files.,find,engineer
+1112,Linuxコマンドかるた,-,G,ファイルの中から文字列を検索する,Search for a string within files.,grep,engineer
+1113,Linuxコマンドかるた,-,C,ファイルの権限を変更する,Change file permissions.,chmod,engineer
+1114,Linuxコマンドかるた,-,C,ファイルの所有者を変更する,Change file ownership.,chown,engineer
+1115,Linuxコマンドかるた,-,P,実行中のプロセスを表示する,Display running processes.,ps,engineer
+1116,Linuxコマンドかるた,-,K,プロセスを終了させる,Terminate a process.,kill,engineer
+1117,Linuxコマンドかるた,-,T,システムのリソース使用状況をリアルタイムで表示する,Display real-time system resource usage.,top,engineer
+1118,Linuxコマンドかるた,-,D,ディスクの空き容量を表示する,Display free disk space.,df,engineer
+1119,Linuxコマンドかるた,-,D,ファイルやディレクトリのサイズを表示する,Display the size of files or directories.,du,engineer
+1120,Linuxコマンドかるた,-,T,複数のファイルをひとつにまとめて圧縮・展開する,Archive or extract multiple files.,tar,engineer
+1121,Linuxコマンドかるた,-,S,別のサーバーにリモートでログインする,Log in to a remote server.,ssh,engineer
+1122,Linuxコマンドかるた,-,S,サーバー間でファイルを安全にコピーする,Securely copy files between servers.,scp,engineer
+1123,Linuxコマンドかるた,-,C,URLを指定してデータを送受信する,Transfer data to or from a URL.,curl,engineer
+1124,Linuxコマンドかるた,-,W,URLからファイルをダウンロードする,Download a file from a URL.,wget,engineer
+1125,Linuxコマンドかるた,-,M,コマンドの使い方を調べる,Look up how to use a command.,man,engineer
+1126,Linuxコマンドかるた,-,H,これまでに実行したコマンドの履歴を表示する,Display the history of executed commands.,history,engineer
+1127,Linuxコマンドかるた,-,E,文字列を画面に出力する,Print a string to the screen.,echo,engineer
+1128,Linuxコマンドかるた,-,L,ファイルの内容をスクロールしながら表示する,View a file's contents one screen at a time.,less,engineer
+1129,Linuxコマンドかるた,-,H,ファイルの先頭部分を表示する,Display the beginning of a file.,head,engineer
+1130,Linuxコマンドかるた,-,T,ファイルの末尾部分を表示する,Display the end of a file.,tail,engineer
+1131,Linuxコマンドかるた,-,S,行を並び替える,Sort lines of text.,sort,engineer
+1132,Linuxコマンドかるた,-,U,重複する行を取り除く,Remove duplicate adjacent lines.,uniq,engineer
+1133,Linuxコマンドかるた,-,W,行数や単語数、文字数を数える,"Count lines, words, and characters.",wc,engineer
+1134,Linuxコマンドかるた,-,L,ファイルのリンクを作成する,Create a link to a file.,ln,engineer
+1135,Linuxコマンドかるた,-,A,コマンドに別名をつける,Define a shortcut name for a command.,alias,engineer
+1136,Linuxコマンドかるた,-,E,環境変数を設定する,Set an environment variable.,export,engineer
+1137,Linuxコマンドかるた,-,S,管理者権限でコマンドを実行する,Run a command with administrator privileges.,sudo,engineer
+1138,Linuxコマンドかるた,-,W,コマンドの実行ファイルの場所を調べる,Find the location of a command's executable.,which,engineer
+1139,Linuxコマンドかるた,-,W,現在ログインしているユーザー名を表示する,Display the current logged-in user name.,whoami,engineer
+1140,Linuxコマンドかるた,-,H,コンピュータのホスト名を表示する,Display the computer's host name.,hostname,engineer
+1201,Gitかるた,-,I,新しいリポジトリを作成する,Create a new repository.,git init,engineer
+1202,Gitかるた,-,C,既存のリポジトリを複製する,Clone an existing repository.,git clone,engineer
+1203,Gitかるた,-,A,変更をステージングする,Stage changes.,git add,engineer
+1204,Gitかるた,-,C,変更をコミットする,Commit changes.,git commit,engineer
+1205,Gitかるた,-,P,ローカルの変更をリモートに送る,Push local changes to a remote.,git push,engineer
+1206,Gitかるた,-,P,リモートの変更を取得して取り込む,Fetch and merge changes from a remote.,git pull,engineer
+1207,Gitかるた,-,F,リモートの変更情報だけを取得する,Fetch changes from a remote without merging.,git fetch,engineer
+1208,Gitかるた,-,S,作業ディレクトリの状態を確認する,Check the status of the working directory.,git status,engineer
+1209,Gitかるた,-,D,変更の差分を確認する,Show changes between commits or the working directory.,git diff,engineer
+1210,Gitかるた,-,L,コミットの履歴を表示する,Show commit history.,git log,engineer
+1211,Gitかるた,-,B,ブランチを作成・一覧表示する,Create or list branches.,git branch,engineer
+1212,Gitかるた,-,C,ブランチやファイルの状態を切り替える,Switch branches or restore files.,git checkout,engineer
+1213,Gitかるた,-,S,ブランチを切り替える,Switch branches.,git switch,engineer
+1214,Gitかるた,-,M,別のブランチの変更を取り込む,Merge changes from another branch.,git merge,engineer
+1215,Gitかるた,-,R,コミットの履歴を別のベースに付け替える,Reapply commits on top of another base.,git rebase,engineer
+1216,Gitかるた,-,S,作業内容を一時退避する,Temporarily shelve changes.,git stash,engineer
+1217,Gitかるた,-,R,コミットやステージングの状態を戻す,Undo commits or staged changes.,git reset,engineer
+1218,Gitかるた,-,R,過去のコミットを打ち消す新しいコミットを作る,Create a new commit that undoes a past commit.,git revert,engineer
+1219,Gitかるた,-,T,コミットに目印となるタグを付ける,Mark a commit with a tag.,git tag,engineer
+1220,Gitかるた,-,R,リモートリポジトリの情報を管理する,Manage remote repository information.,git remote,engineer
+1221,Gitかるた,-,C,Gitの設定を変更する,Change Git configuration.,git config,engineer
+1222,Gitかるた,-,C,特定のコミットだけを取り込む,Apply a specific commit onto the current branch.,git cherry-pick,engineer
+1223,Gitかるた,-,B,各行を最後に変更した人を調べる,Find out who last modified each line.,git blame,engineer
+1224,Gitかるた,-,S,コミットの詳細な内容を表示する,Show the details of a commit.,git show,engineer
+1225,Gitかるた,-,R,ファイルを削除してその変更を記録する,Delete a file and stage the removal.,git rm,engineer
+1301,SQLかるた,-,S,取得する列を指定する,Specify which columns to retrieve.,SELECT,engineer
+1302,SQLかるた,-,F,データを取得するテーブルを指定する,Specify the table to retrieve data from.,FROM,engineer
+1303,SQLかるた,-,W,条件に一致するデータを取得する,Retrieve data that matches a condition.,WHERE,engineer
+1304,SQLかるた,-,G,指定した列の値でグループ化する,Group rows by the values of specified columns.,GROUP BY,engineer
+1305,SQLかるた,-,H,グループ化した後の結果に条件をつける,Filter results after grouping.,HAVING,engineer
+1306,SQLかるた,-,O,結果を並び替える,Sort the results.,ORDER BY,engineer
+1307,SQLかるた,-,L,取得する件数を制限する,Limit the number of rows returned.,LIMIT,engineer
+1308,SQLかるた,-,I,一致する行だけを複数テーブルから結合する,"Join tables, returning only matching rows.",INNER JOIN,engineer
+1309,SQLかるた,-,L,左側のテーブルを基準に結合する,"Join tables, keeping all rows from the left table.",LEFT JOIN,engineer
+1310,SQLかるた,-,R,右側のテーブルを基準に結合する,"Join tables, keeping all rows from the right table.",RIGHT JOIN,engineer
+1311,SQLかるた,-,F,両方のテーブルの行をすべて結合する,"Join tables, keeping all rows from both tables.",FULL OUTER JOIN,engineer
+1312,SQLかるた,-,U,複数の検索結果を縦に結合する,Combine the results of multiple queries.,UNION,engineer
+1313,SQLかるた,-,D,重複を除外する,Exclude duplicate rows.,DISTINCT,engineer
+1314,SQLかるた,-,I,新しい行を追加する,Insert a new row.,INSERT INTO,engineer
+1315,SQLかるた,-,U,既存の行を更新する,Update existing rows.,UPDATE,engineer
+1316,SQLかるた,-,D,行を削除する,Delete rows.,DELETE,engineer
+1317,SQLかるた,-,C,新しいテーブルを作成する,Create a new table.,CREATE TABLE,engineer
+1318,SQLかるた,-,A,テーブルの構造を変更する,Modify a table's structure.,ALTER TABLE,engineer
+1319,SQLかるた,-,D,テーブルを削除する,Delete a table.,DROP TABLE,engineer
+1320,SQLかるた,-,P,行を一意に識別する列を指定する,Designate a column that uniquely identifies each row.,PRIMARY KEY,engineer
+1321,SQLかるた,-,F,他のテーブルの行を参照する制約,A constraint that references a row in another table.,FOREIGN KEY,engineer
+1322,SQLかるた,-,N,値が存在しないことを表す,Represents the absence of a value.,NULL,engineer
+1323,SQLかるた,-,B,指定した範囲内のデータを取得する,Retrieve data within a specified range.,BETWEEN,engineer
+1324,SQLかるた,-,L,文字列のパターンに一致するか調べる,Check whether a string matches a pattern.,LIKE,engineer
+1325,SQLかるた,-,I,複数の値のいずれかに一致するか調べる,Check whether a value matches any in a list.,IN,engineer
+1326,SQLかるた,-,C,行数を数える,Count the number of rows.,COUNT,engineer
+1327,SQLかるた,-,S,値の合計を求める,Calculate the sum of values.,SUM,engineer
+1328,SQLかるた,-,A,値の平均を求める,Calculate the average of values.,AVG,engineer
+1329,SQLかるた,-,A,列やテーブルに別名をつける,Give a column or table an alias.,AS,engineer
+1330,SQLかるた,-,C,条件によって異なる値を返す,Return different values depending on a condition.,CASE WHEN,engineer
+1331,SQLかるた,-,C,変更をデータベースに確定する,Commit changes to the database.,COMMIT,engineer
+1332,SQLかるた,-,R,変更を取り消して元に戻す,Undo changes and revert to the previous state.,ROLLBACK,engineer
+1401,AWSかるた,-,L,サーバレスでコードを実行する,Run code without managing servers.,Lambda,engineer
+1402,AWSかるた,-,S,オブジェクトストレージ,Object storage.,S3,engineer
+1403,AWSかるた,-,D,NoSQLデータベース,A NoSQL database.,DynamoDB,engineer
+1404,AWSかるた,-,E,仮想サーバーを提供する,Provides virtual servers.,EC2,engineer
+1405,AWSかるた,-,R,マネージドなリレーショナルデータベース,A managed relational database.,RDS,engineer
+1406,AWSかるた,-,V,仮想的なネットワーク環境を作る,Create an isolated virtual network.,VPC,engineer
+1407,AWSかるた,-,I,ユーザーや権限を管理する,Manage users and permissions.,IAM,engineer
+1408,AWSかるた,-,C,コンテンツ配信網(CDN)サービス,A content delivery network (CDN) service.,CloudFront,engineer
+1409,AWSかるた,-,R,DNSサービス,A DNS service.,Route 53,engineer
+1410,AWSかるた,-,A,APIの作成・公開・管理を行う,"Create, publish, and manage APIs.",API Gateway,engineer
+1411,AWSかるた,-,S,メッセージを溜めておくキューサービス,A queue service for storing messages.,SQS,engineer
+1412,AWSかるた,-,S,メッセージを配信する通知サービス,A notification service for delivering messages.,SNS,engineer
+1413,AWSかるた,-,C,リソースの監視やログ収集を行う,Monitor resources and collect logs.,CloudWatch,engineer
+1414,AWSかるた,-,C,インフラをコードで構築・管理する,Provision and manage infrastructure as code.,CloudFormation,engineer
+1415,AWSかるた,-,E,コンテナを管理・実行するサービス,A service for managing and running containers.,ECS,engineer
+1416,AWSかるた,-,E,マネージドなKubernetesサービス,A managed Kubernetes service.,EKS,engineer
+1417,AWSかるた,-,F,サーバー管理が不要なコンテナ実行環境,A serverless container runtime that needs no server management.,Fargate,engineer
+1418,AWSかるた,-,E,アプリケーションのデプロイを簡単にする,Simplifies application deployment.,Elastic Beanstalk,engineer
+1419,AWSかるた,-,A,負荷に応じてサーバー台数を自動調整する,Automatically adjusts server count based on load.,Auto Scaling,engineer
+1420,AWSかるた,-,E,通信を複数サーバーに振り分ける,Distributes traffic across multiple servers.,Elastic Load Balancing,engineer
+1421,AWSかるた,-,G,データを抽出・変換・ロードするETLサービス,"An ETL service for extracting, transforming, and loading data.",Glue,engineer
+1422,AWSかるた,-,A,S3のデータをSQLで分析する,Analyze data in S3 using SQL.,Athena,engineer
+1423,AWSかるた,-,K,大量のストリーミングデータを処理する,Process large volumes of streaming data.,Kinesis,engineer
+1424,AWSかるた,-,S,複数のサービスをワークフローでつなぐ,Coordinate multiple services into a workflow.,Step Functions,engineer
+1425,AWSかるた,-,C,ユーザーの認証や認可を管理する,Manage user authentication and authorization.,Cognito,engineer
+1426,AWSかるた,-,S,パスワードなどの機密情報を管理する,Manage secrets such as passwords.,Secrets Manager,engineer
+1427,AWSかるた,-,C,ビルドからデプロイまでを自動化する,Automate the process from build to deployment.,CodePipeline,engineer
+1428,AWSかるた,-,E,EC2にアタッチするブロックストレージ,Block storage attached to EC2 instances.,EBS,engineer
+1429,AWSかるた,-,A,高い性能を持つマネージドリレーショナルDB,A high-performance managed relational database.,Aurora,engineer
+1430,AWSかるた,-,R,大規模なデータウェアハウス,A large-scale data warehouse.,Redshift,engineer
+1501,Javaかるた,-,N,Null参照時に発生する例外,An exception thrown when dereferencing a null reference.,NullPointerException,engineer
+1502,Javaかるた,-,I,入出力で発生する例外,An exception thrown for input/output failures.,IOException,engineer
+1503,Javaかるた,-,H,キーと値を保持するコレクション,A collection that holds key-value pairs.,HashMap,engineer
+1504,Javaかるた,-,A,配列の範囲外にアクセスした時の例外,An exception thrown when accessing an array out of bounds.,ArrayIndexOutOfBoundsException,engineer
+1505,Javaかるた,-,C,指定したクラスが見つからない時の例外,An exception thrown when a specified class cannot be found.,ClassNotFoundException,engineer
+1506,Javaかるた,-,N,文字列を数値に変換できない時の例外,An exception thrown when a string cannot be converted to a number.,NumberFormatException,engineer
+1507,Javaかるた,-,I,不正な引数が渡された時の例外,An exception thrown when an invalid argument is passed.,IllegalArgumentException,engineer
+1508,Javaかるた,-,I,オブジェクトの状態が不正な時の例外,An exception thrown when an object is in an invalid state.,IllegalStateException,engineer
+1509,Javaかるた,-,A,0で割るなど算術エラー時の例外,An exception thrown for arithmetic errors such as division by zero.,ArithmeticException,engineer
+1510,Javaかるた,-,C,ループ中にコレクションを変更した時の例外,An exception thrown when a collection is modified during iteration.,ConcurrentModificationException,engineer
+1511,Javaかるた,-,O,メモリ不足で発生するエラー,An error thrown when the JVM runs out of memory.,OutOfMemoryError,engineer
+1512,Javaかるた,-,S,再帰呼び出しが深すぎて発生するエラー,An error thrown when recursive calls go too deep.,StackOverflowError,engineer
+1513,Javaかるた,-,A,可変長の配列のようなコレクション,A resizable array-like collection.,ArrayList,engineer
+1514,Javaかるた,-,L,要素を連結して保持するリスト,A list that holds elements as a linked sequence.,LinkedList,engineer
+1515,Javaかるた,-,H,重複を許さないコレクション,A collection that does not allow duplicate elements.,HashSet,engineer
+1516,Javaかるた,-,T,キーで自動的に並び替えられるマップ,A map that is automatically sorted by its keys.,TreeMap,engineer
+1517,Javaかるた,-,S,文字列を効率的に組み立てるクラス,A class for efficiently building strings.,StringBuilder,engineer
+1518,Javaかるた,-,O,値が存在しないかもしれないことを表すクラス,A class representing a value that may or may not be present.,Optional,engineer
+1519,Javaかるた,-,S,コレクションを関数的に処理するAPI,An API for processing collections in a functional style.,Stream,engineer
+1520,Javaかるた,-,I,メソッドの仕様だけを定義する型,A type that defines only method signatures.,Interface,engineer
+1521,Javaかるた,-,A,一部だけ実装したクラス,A class that is only partially implemented.,Abstract Class,engineer
+1522,Javaかるた,-,G,型を汎用的に扱う仕組み,A mechanism for handling types generically.,Generics,engineer
+1523,Javaかるた,-,T,例外処理を記述する構文,Syntax for handling exceptions.,try-catch-finally,engineer
+1524,Javaかるた,-,S,複数スレッドからの同時アクセスを制御する,Controls concurrent access from multiple threads.,synchronized,engineer
+1525,Javaかるた,-,T,並行して処理を実行する単位,A unit of execution that runs concurrently.,Thread,engineer
+1526,Javaかるた,-,O,親クラスのメソッドを子クラスで上書きする,Overrides a parent class's method in a subclass.,Override,engineer
+1527,Javaかるた,-,E,オブジェクトの等価性を判定する仕組み,A mechanism for determining object equality.,equals/hashCode,engineer
+1528,Javaかるた,-,F,値や継承を変更不可にするキーワード,A keyword that makes a value or inheritance unchangeable.,final,engineer
+1529,Javaかるた,-,S,インスタンスに依存しないメンバーを定義するキーワード,A keyword for defining members that don't depend on an instance.,static,engineer
+1601,コードレビューかるた,-,D,同じコードが複数箇所に存在する,The same code exists in multiple places.,DRY原則,engineer
+1602,コードレビューかるた,-,か,変数名から役割が分からない,It's unclear what a variable does from its name.,可読性,engineer
+1603,コードレビューかるた,-,た,1つのメソッドが長すぎる,A single method is too long.,単一責任の原則,engineer
+1604,コードレビューかるた,-,ま,意味のわからない数値が直接書かれている,An unexplained number is hard-coded directly in the code.,マジックナンバー,engineer
+1605,コードレビューかるた,-,ね,条件分岐が何重にも入れ子になっている,Conditional branches are nested many levels deep.,ネストが深い,engineer
+1606,コードレビューかるた,-,め,変数名やクラス名のつけ方が統一されていない,Variable and class naming is inconsistent.,命名規則違反,engineer
+1607,コードレビューかるた,-,て,重要な処理にテストが書かれていない,Critical logic has no tests.,テストカバレッジ不足,engineer
+1608,コードレビューかるた,-,は,設定値がコード中に直接埋め込まれている,Configuration values are embedded directly in the code.,ハードコーディング,engineer
+1609,コードレビューかるた,-,れ,catchした例外を何もせず無視している,A caught exception is silently ignored.,例外の握りつぶし,engineer
+1610,コードレビューかるた,-,ぐ,どこからでも書き換えられる変数を多用している,Overuse of variables that can be modified from anywhere.,グローバル変数の濫用,engineer
+1611,コードレビューかるた,-,こ,複雑な処理の意図が説明されていない,The intent behind complex logic is not explained.,コメント不足,engineer
+1612,コードレビューかるた,-,じ,同じロジックが何箇所にもコピーされている,The same logic is copy-pasted in many places.,重複コード,engineer
+1613,コードレビューかるた,-,そ,条件を満たしたらすぐに関数を抜けず深く入れ子にしている,"Doesn't exit early when a condition is met, leading to deep nesting.",早期return,engineer
+1614,コードレビューかるた,-,ふ,名前から想像できない値の変更を行う関数,A function that changes values in ways its name doesn't suggest.,副作用のある関数,engineer
+1615,コードレビューかるた,-,み,クラス同士が内部実装に強く依存している,Classes depend heavily on each other's internal implementation.,密結合,engineer
+1616,コードレビューかるた,-,で,呼び出されない不要なコードが残っている,Unused code that is never called remains in the codebase.,デッドコード,engineer
+1617,コードレビューかるた,-,S,ユーザー入力をそのままSQLに組み込んでいる,User input is embedded directly into SQL without sanitization.,SQLインジェクション脆弱性,engineer
+1618,コードレビューかるた,-,ふ,使われていないモジュールが読み込まれている,Unused modules are imported.,不要なimport,engineer
+1619,コードレビューかるた,-,ろ,エラー発生時に原因を追えるログがない,There are no logs to trace the cause when an error occurs.,ログ出力不足,engineer
+1620,コードレビューかるた,-,ば,入力値の検証が行われていない,Input values are not validated.,バリデーション漏れ,engineer
+1621,コードレビューかるた,-,れ,並行処理の実行順序によって結果が変わる不具合,A bug where the result depends on the timing of concurrent execution.,レースコンディション,engineer
+1622,コードレビューかるた,-,か,将来使うかもしれない機能を先に作り込んでいる,Building functionality preemptively for hypothetical future use.,過剰な抽象化,engineer
+1701,セキュリティ大ピンチ,10,は,アカウント全部　同じパスワードだった,I used the same password for every account.,パスワードリスト攻撃,engineer
+1702,セキュリティ大ピンチ,15,ふ,いそいで振り込め　メールを信じた,I trusted an urgent payment email.,フィッシング,engineer
+1703,セキュリティ大ピンチ,12,ま,USBを拾って　そのまま挿した,I plugged in a USB drive I found.,マルウェア,engineer
+1704,セキュリティ大ピンチ,40,し,APIキーを　GitHubで公開した,I exposed an API key on GitHub.,シークレット管理,engineer
+1705,セキュリティ大ピンチ,15,ふ,おなじログイン画面だと　思い込んだ,I assumed the login page was genuine.,フィッシングサイト,engineer
+1706,セキュリティ大ピンチ,20,て,開発用パスワードを　本番でも使った,I used a development password in production.,デフォルトパスワード,engineer
+1707,セキュリティ大ピンチ,25,し,きょうもパッチを　後回しにした,I postponed installing security patches again.,脆弱性,engineer
+1708,セキュリティ大ピンチ,25,ら,暗号化されても　バックアップがない,Everything was encrypted and I had no backup.,ランサムウェア,engineer
+1709,セキュリティ大ピンチ,40,え,検索欄から　データベースが壊れた,The database broke through the search box.,SQLインジェクション,engineer
+1710,セキュリティ大ピンチ,40,く,コメントを書いたら　勝手に画面が動いた,A comment caused unexpected script execution.,XSS,engineer
+1711,セキュリティ大ピンチ,45,し,サイトを見ただけで　退会していた,I was logged out or unsubscribed just by visiting a page.,CSRF,engineer
+1712,セキュリティ大ピンチ,35,に,知らない人まで　管理画面に入れた,Unauthorized users reached the admin screen.,認可不備,engineer
+1713,セキュリティ大ピンチ,20,あ,すでに退職した人が　まだログインしていた,A former employee could still log in.,アカウント管理,engineer
+1714,セキュリティ大ピンチ,30,さ,全員を管理者に　してしまった,I gave everyone administrator privileges.,最小権限の原則,engineer
+1715,セキュリティ大ピンチ,15,て,そのままHTTPで　ログインした,I logged in over HTTP.,TLS,engineer
+1716,セキュリティ大ピンチ,20,か,だれが操作したか　分からない,Nobody knew who performed the operation.,監査ログ,engineer
+1717,セキュリティ大ピンチ,35,せ,社内だから安全と　思い込んでいた,I assumed the internal network was safe.,ゼロトラスト,engineer
+1718,セキュリティ大ピンチ,40,あ,つうしんの異常に　誰も気付かなかった,Nobody noticed the suspicious traffic.,IDS,engineer
+1719,セキュリティ大ピンチ,45,あ,敵は見つけたのに　止められなかった,We detected the attack but couldn't stop it.,IPS,engineer
+1720,セキュリティ大ピンチ,40,え,取りつかれても　誰も気付かなかった,The endpoint was compromised without anyone noticing.,EDR,engineer
+1721,セキュリティ大ピンチ,20,せ,長いこと更新を　していなかった,The server hadn't been updated for a long time.,セキュリティパッチ,engineer
+1722,セキュリティ大ピンチ,15,た,認証が　パスワードだけだった,Only a password protected the account.,多要素認証,engineer
+1723,セキュリティ大ピンチ,35,せ,ぬすまれたCookieで　ログインされた,Someone logged in using my stolen cookie.,セッションハイジャック,engineer
+1724,セキュリティ大ピンチ,20,あ,ねだんより　個人情報を守れ,Personal data was stored without protection.,暗号化,engineer
+1725,セキュリティ大ピンチ,15,て,残っていた初期設定で　入られた,Someone logged in with default credentials.,デフォルト認証情報,engineer
+1726,セキュリティ大ピンチ,20,と,アクセスが急に　100万件来た,A million requests suddenly flooded the server.,DoS攻撃,engineer
+1727,セキュリティ大ピンチ,35,こ,秘密鍵を　メールで送ってしまった,I emailed a private key.,公開鍵暗号方式,engineer
+1728,セキュリティ大ピンチ,35,せ,古い設定をコピーしたら　穴だらけだった,I copied an insecure server configuration.,セキュア設定,engineer
+1729,セキュリティ大ピンチ,30,し,へいきだろうで　本番公開した,I released it to production assuming it was safe.,脆弱性診断,engineer
+1730,セキュリティ大ピンチ,15,さ,ほんとうに開いてよかった？　その添付ファイル,Should I really have opened that attachment?,サンドボックス,engineer
+1731,セキュリティ大ピンチ,70,え,まさか社内サーバが　外から操作された,The internal server was manipulated from outside.,SSRF,engineer
+1732,セキュリティ大ピンチ,80,え,見せるはずのない　サーバのファイルが見えた,Internal server files became visible.,XXE,engineer
+1733,セキュリティ大ピンチ,70,お,無害な入力のはずが　コマンドが動いた,A harmless input executed a command.,OSコマンドインジェクション,engineer
+1734,セキュリティ大ピンチ,85,し,メンバーなのに　管理者になっていた,A normal user became an administrator.,JWT,engineer
+1735,セキュリティ大ピンチ,65,お,もれたトークンで　勝手に操作された,A leaked token was used for unauthorized access.,OAuth,engineer
+1736,セキュリティ大ピンチ,55,に,やっぱり開発環境だからと　認証を外した,I disabled authentication because it was only a development environment.,認証,engineer
+1737,セキュリティ大ピンチ,60,に,ユーザー画面だけで　権限チェックしていた,Authorization was checked only on the client side.,認可,engineer
+1801,Webアプリ大ピンチ,10,き,更新したのに昨日の画面のままだった,The page still showed yesterday's version after deployment.,キャッシュ,engineer
+1802,Webアプリ大ピンチ,15,せ,ログインしたのにすぐログアウトされた,I was logged out right after logging in.,セッション,engineer
+1803,Webアプリ大ピンチ,20,と,注文ボタンを連打したら二重登録された,Clicking the order button repeatedly created duplicate records.,トランザクション,engineer
+1804,Webアプリ大ピンチ,15,く,Cookieを消したらログインできるようになった,Deleting cookies fixed the login problem.,Cookie,engineer
+1805,Webアプリ大ピンチ,20,H,404しか返ってこない,Everything returned a 404 error.,HTTPステータスコード,engineer
+1806,Webアプリ大ピンチ,25,り,POSTしたのに画面が別ページへ飛んだ,"After POST, I was sent to another page.",リダイレクト,engineer
+1807,Webアプリ大ピンチ,25,ふ,画面遷移したら入力内容が消えなかった,The input remained after changing pages.,フォワード,engineer
+1808,Webアプリ大ピンチ,20,さ,画面は開くのにデータが表示されない,The page loads but no data appears.,Servlet,engineer
+1809,Webアプリ大ピンチ,25,J,JSPを直したのに画面が変わらない,I edited a JSP but nothing changed.,JSP,engineer
+1810,Webアプリ大ピンチ,30,E,HTMLの中にJavaだらけで読めない,The JSP is full of Java code and unreadable.,EL式,engineer
+1811,Webアプリ大ピンチ,30,J,同じ処理を何度もJSPに書いてしまった,I duplicated the same logic across JSPs.,JSTL,engineer
+1812,Webアプリ大ピンチ,35,え,DBにはあるのに画面には表示されない,The data exists in the database but isn't shown.,MVC,engineer
+1813,Webアプリ大ピンチ,35,J,SQLは成功したのに画面が更新されない,The SQL succeeded but the screen didn't update.,JDBC,engineer
+1814,Webアプリ大ピンチ,20,S,SQLを書き換えたら全部落ちた,Changing one SQL query broke everything.,SQL,engineer
+1815,Webアプリ大ピンチ,45,い,検索だけやたら遅い,Only searches are extremely slow.,インデックス,engineer
+1816,Webアプリ大ピンチ,40,こ,接続数がいっぱいでDBにつながらない,The database refused more connections.,コネクションプール,engineer
+1817,Webアプリ大ピンチ,20,M,データベースが起動していなかった,The database server wasn't running.,MySQL,engineer
+1818,Webアプリ大ピンチ,30,P,再起動したら直った,Restarting the server fixed it.,Payara,engineer
+1819,Webアプリ大ピンチ,25,わ,デプロイしたのに反映されない,I deployed it but nothing changed.,WAR,engineer
+1820,Webアプリ大ピンチ,35,G,依存ライブラリを追加したのに読み込まれない,The dependency wasn't picked up after adding it.,Gradle,engineer
+1821,Webアプリ大ピンチ,35,い,昨日までビルドできたのに今日は失敗する,Yesterday's build worked but today's doesn't.,依存関係,engineer
+1822,Webアプリ大ピンチ,20,び,ソースは変えていないのに実行できない,"I changed nothing, but it no longer runs.",ビルド,engineer
+1823,Webアプリ大ピンチ,20,J,ボタンを押しても何も起きない,Clicking the button does nothing.,JavaScript,engineer
+1824,Webアプリ大ピンチ,25,D,要素が見つからないと言われた,The browser says the element can't be found.,DOM,engineer
+1825,Webアプリ大ピンチ,15,し,画面レイアウトがぐちゃぐちゃになった,The page layout completely broke.,CSS,engineer
+1826,Webアプリ大ピンチ,30,J,APIの返却結果が読めない,I can't parse the API response.,JSON,engineer
+1827,Webアプリ大ピンチ,30,A,画面はあるのにデータだけ取れない,The page loads but no data comes back.,AJAX,engineer
+1828,Webアプリ大ピンチ,35,ば,入力したのに保存できない,The form won't save my input.,バリデーション,engineer
+1829,Webアプリ大ピンチ,35,れ,エラー画面しか出ない,Only an error page is displayed.,例外処理,engineer
+1830,Webアプリ大ピンチ,20,ろ,何が起きたのか全然分からない,I have no idea what happened.,ログ,engineer
+1831,Webアプリ大ピンチ,35,す,エラーは出たけど原因が読めない,I see an error but can't identify the cause.,スタックトレース,engineer
+1832,Webアプリ大ピンチ,20,で,デバッグしたら動いてしまう,The bug disappears during debugging.,デバッグ,engineer
+1833,Webアプリ大ピンチ,30,も,文字が全部「???」になった,All the text turned into question marks.,文字コード,engineer
+1834,Webアプリ大ピンチ,25,U,日本語だけ文字化けした,Only Japanese characters are garbled.,UTF-8,engineer
+1835,Webアプリ大ピンチ,20,G,最新コードを取ったら動かなくなった,Pulling the latest code broke everything.,Git,engineer
+1836,Webアプリ大ピンチ,40,ま,同じファイルを編集して取り込めない,I can't merge because we edited the same file.,マージコンフリクト,engineer
+1837,Webアプリ大ピンチ,40,C,ブラウザからだけAPIが呼べない,The API works elsewhere but not from the browser.,CORS,engineer
+1838,Webアプリ大ピンチ,45,N,SQLを1件取得するたびにSQLが増えていく,One query turns into hundreds of queries.,N+1問題,engineer
+1839,Webアプリ大ピンチ,40,ら,他の人が更新して保存できなかった,Someone else updated the record first.,楽観ロック,engineer
+1840,Webアプリ大ピンチ,35,に,ログイン状態なのに403になった,I'm logged in but received a 403.,認可,engineer
+1901,Windowsショートカット,10,C,コピーしたつもりが　できていなかった,I thought I copied it but it wasn't copied.,Ctrl+C,engineer
+1902,Windowsショートカット,10,V,貼り付けたいのに　右クリックできない,I want to paste but can't use the mouse.,Ctrl+V,engineer
+1903,Windowsショートカット,10,X,別の場所へ　移動したい,I want to move it somewhere else.,Ctrl+X,engineer
+1904,Windowsショートカット,10,Z,間違えて消してしまった,I accidentally deleted it.,Ctrl+Z,engineer
+1905,Windowsショートカット,15,Y,戻しすぎて　やっぱり元に戻したい,I undid too much.,Ctrl+Y,engineer
+1906,Windowsショートカット,10,A,全部まとめて選びたい,I want to select everything.,Ctrl+A,engineer
+1907,Windowsショートカット,15,F,探したい文字が　見つからない,I can't find the text I'm looking for.,Ctrl+F,engineer
+1908,Windowsショートカット,10,S,保存する前に　落ちそうだ,The application might crash before I save.,Ctrl+S,engineer
+1909,Windowsショートカット,15,P,印刷したい,I want to print this.,Ctrl+P,engineer
+1910,Windowsショートカット,20,T,新しいタブを　開きたい,I want to open a new tab.,Ctrl+T,engineer
+1911,Windowsショートカット,25,T,閉じたタブを　戻したい,I want to reopen the tab I just closed.,Ctrl+Shift+T,engineer
+1912,Windowsショートカット,15,R,更新したい,I want to refresh the page.,Ctrl+R,engineer
+1913,Windowsショートカット,20,T,隣のタブへ　移動したい,I want to move to the next tab.,Ctrl+Tab,engineer
+1914,Windowsショートカット,20,T,開きすぎて　目的の画面が見つからない,I have too many windows open.,Alt+Tab,engineer
+1915,Windowsショートカット,15,D,デスクトップを　一瞬だけ見たい,I need to see the desktop quickly.,Windows+D,engineer
+1916,Windowsショートカット,20,E,エクスプローラーを　開きたい,I need File Explorer.,Windows+E,engineer
+1917,Windowsショートカット,20,L,席を離れるので　すぐロックしたい,I'm leaving my desk and want to lock my PC.,Windows+L,engineer
+1918,Windowsショートカット,20,I,設定画面を　開きたい,I need to open Settings.,Windows+I,engineer
+1919,Windowsショートカット,20,S,アプリやファイルを　すぐ探したい,I need to search for an app or file.,Windows+S,engineer
+1920,Windowsショートカット,15,F,ファイル名を　変更したい,I want to rename a file.,F2,engineer
+1921,Windowsショートカット,10,F,画面を　更新したい,I want to refresh the screen.,F5,engineer
+1922,Windowsショートカット,10,F,ヘルプを　開きたい,I need help.,F1,engineer
+1923,Windowsショートカット,25,F,終了ボタンが　押せない,I need to close the current application.,Alt+F4,engineer
+1924,Windowsショートカット,30,E,固まったアプリを　調べたい,I need Task Manager.,Ctrl+Shift+Esc,engineer
+1925,Windowsショートカット,20,D,ログイン画面に　戻りたい,I need the Windows security screen.,Ctrl+Alt+Delete,engineer
+1926,Windowsショートカット,25,+,文字が小さすぎて　見えない,The text is too small to read.,Windows++,engineer
+1927,Windowsショートカット,25,-,画面が大きすぎて　見づらい,Everything is zoomed in too much.,Windows+-,engineer
+1928,Windowsショートカット,30,P,画面を　そのまま保存したい,I want to save a screenshot.,Windows+PrintScreen,engineer
+1929,Windowsショートカット,20,S,画面の一部だけ　切り取りたい,I only need part of the screen.,Windows+Shift+S,engineer
+1930,Windowsショートカット,25,.,絵文字を　入力したい,I want to insert an emoji.,Windows+.,engineer
+1931,Windowsショートカット,30,V,さっきコピーしたものを　もう一度使いたい,I need something I copied earlier.,Windows+V,engineer
+1932,Windowsショートカット,35,S,日本語入力に　切り替わらない,I can't switch the input language.,Alt+Shift,engineer
+1933,Windowsショートカット,35,`,かな入力に　なってしまった,I accidentally switched input modes.,Alt+`,engineer
+1934,Windowsショートカット,30,D,同じ操作を　何度も繰り返している,I'm repeating the same action over and over.,Ctrl+D,engineer
+1935,Windowsショートカット,35,F,右クリックメニューを　開きたい,I need the context menu without a mouse.,Shift+F10,engineer

--- a/backend/seed.js
+++ b/backend/seed.js
@@ -45,10 +45,13 @@ async function seed() {
       }
 
       const existingItem = existingItemsMap.get(`${category}-${id}`);
+      const groupRaw = record.group ? record.group.trim() : "";
+      const group = groupRaw === "engineer" ? "engineer" : "kids";
 
       newItemsMap.set(`${category}-${id}`, {
         id,
         category,
+        group,
         level,
         kana: record.kana ? record.kana.trim() : "-",
         phrase: record.phrase ? record.phrase.trim() : "",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,11 +11,15 @@ const serializeCategoriesParam = (categories) => categories.map(encodeURICompone
 
 function App() {
   const [categories, setCategories] = useState([]);
+  const [division, setDivision] = useState(() => {
+    const params = new URLSearchParams(window.location.search);
+    return params.get("division") || null;
+  });
   const [selectedCategories, setSelectedCategories] = useState(() => {
     const params = new URLSearchParams(window.location.search);
     return parseCategoriesParam(params.get("category"));
   });
-  
+
   const [detailPhraseId, setDetailPhraseId] = useState(() => {
     const params = new URLSearchParams(window.location.search);
     return params.get("id");
@@ -75,6 +79,11 @@ function App() {
   const categoryLabel = useMemo(() => {
     return selectedCategories.join("・");
   }, [selectedCategories]);
+
+  const categoriesForDivision = useMemo(() => {
+    if (division !== "kids" && division !== "engineer") return [];
+    return categories.filter(cat => cat.group === division);
+  }, [categories, division]);
 
   const currentHistory = useMemo(() => {
     return categoryKey ? (historyByCategory[categoryKey] || []) : [];
@@ -161,7 +170,8 @@ function App() {
           setCategories(availableCategories);
 
           if (selectedCategories.length > 0 && availableCategories.length > 0 && view === "game") {
-            const stillValid = selectedCategories.filter(cat => availableCategories.includes(cat));
+            const availableNames = availableCategories.map(cat => cat.name);
+            const stillValid = selectedCategories.filter(cat => availableNames.includes(cat));
             if (stillValid.length !== selectedCategories.length) {
               setSelectedCategories(stillValid);
             }
@@ -514,6 +524,12 @@ function App() {
       params.delete("category");
     }
 
+    if (division) {
+      params.set("division", division);
+    } else {
+      params.delete("division");
+    }
+
     if (detailPhraseId) {
       params.set("id", detailPhraseId);
     } else {
@@ -529,13 +545,14 @@ function App() {
     const newSearch = params.toString();
     const url = newSearch ? `?${newSearch}` : window.location.pathname;
     window.history.pushState({}, "", url);
-  }, [selectedCategories, detailPhraseId, view]);
+  }, [selectedCategories, division, detailPhraseId, view]);
 
   useEffect(() => {
     const handlePopState = () => {
       const params = new URLSearchParams(window.location.search);
       const category = params.get("category");
       setSelectedCategories(parseCategoriesParam(category));
+      setDivision(params.get("division") || null);
       setDetailPhraseId(params.get("id"));
       setView(params.get("view") || "game");
     };
@@ -598,7 +615,21 @@ function App() {
     setIsFadingOut(false);
   };
 
+  const selectDivision = (div) => {
+    setDivision(div);
+    setDraftCategories([]);
+  };
+
+  const goBackToDivisionSelect = () => {
+    setDivision(null);
+    setDraftCategories([]);
+  };
+
   const toggleDraftCategory = (cat) => {
+    if (division === "kids") {
+      setDraftCategories(prev => (prev.includes(cat) ? [] : [cat]));
+      return;
+    }
     setDraftCategories(prev =>
       prev.includes(cat) ? prev.filter(c => c !== cat) : [...prev, cat]
     );
@@ -892,6 +923,47 @@ function App() {
     );
   }
 
+  if (selectedCategories.length === 0 && !division) {
+    return (
+      <div className="container py-5 mx-auto">
+        <header className="text-center mb-5">
+          <img src="favicon.png" alt="かるたのアイコン" className="mb-4" style={{ width: "120px", height: "auto" }} />
+          <h1 className="display-4 fw-bold">かるた読み上げアプリ</h1>
+        </header>
+
+        <main className="category-selection-container p-4 mx-auto mb-5" style={{ maxWidth: "600px" }}>
+          <h2 className="h4 text-center mb-4 text-dark">どなた向けに遊びますか？</h2>
+          <div className="d-flex flex-wrap gap-3 justify-content-center">
+            <button
+              onClick={() => selectDivision("kids")}
+              className="btn btn-lg px-4 py-3 fw-bold rounded-pill shadow-sm btn-karuta"
+            >
+              こども向け
+            </button>
+            <button
+              onClick={() => selectDivision("engineer")}
+              className="btn btn-lg px-4 py-3 fw-bold rounded-pill shadow-sm btn-karuta"
+            >
+              エンジニア向け
+            </button>
+          </div>
+        </main>
+
+        <div className="text-center d-flex flex-column gap-2">
+          <button onClick={() => setView("all-phrases")} className="btn btn-link text-decoration-none text-muted">
+            全札一覧を見る →
+          </button>
+          <button onClick={() => setView("comments")} className="btn btn-link text-decoration-none text-muted small">
+            指摘された内容を確認する
+          </button>
+          <button onClick={() => setView("changelog")} className="btn btn-link text-decoration-none text-muted small">
+            更新履歴を見る
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   if (selectedCategories.length === 0) {
     return (
       <div className="container py-5 mx-auto">
@@ -901,24 +973,31 @@ function App() {
       </header>
 
       <main className="category-selection-container p-4 mx-auto mb-5" style={{ maxWidth: "600px" }}>
-        <h2 className="h4 text-center mb-4 text-dark">かるたの種類を選んでね（複数選択可）</h2>
+        <div className="d-flex justify-content-start mb-3">
+          <button onClick={goBackToDivisionSelect} className="btn btn-sm btn-outline-secondary rounded-pill">← 戻る</button>
+        </div>
+        <h2 className="h4 text-center mb-4 text-dark">
+          かるたの種類を選んでね{division === "engineer" ? "（複数選択可）" : ""}
+        </h2>
         <div className="d-flex flex-wrap gap-3 justify-content-center">
             {categories.length === 0 ? (
               <div className="text-success fw-bold p-3">読み込み中...</div>
+            ) : categoriesForDivision.length === 0 ? (
+              <div className="text-muted p-3">このかるたはまだありません。</div>
             ) : (
-              categories.map(cat => (
+              categoriesForDivision.map(cat => (
                 <button
-                  key={cat}
-                  onClick={() => toggleDraftCategory(cat)}
-                  className={`btn btn-lg px-4 py-3 fw-bold rounded-pill shadow-sm notranslate btn-karuta ${draftCategories.includes(cat) ? 'selected' : ''}`}
-                  aria-pressed={draftCategories.includes(cat)}
+                  key={cat.name}
+                  onClick={() => toggleDraftCategory(cat.name)}
+                  className={`btn btn-lg px-4 py-3 fw-bold rounded-pill shadow-sm notranslate btn-karuta ${draftCategories.includes(cat.name) ? 'selected' : ''}`}
+                  aria-pressed={draftCategories.includes(cat.name)}
                 >
-                  {draftCategories.includes(cat) ? '✓ ' : ''}{cat}
+                  {draftCategories.includes(cat.name) ? '✓ ' : ''}{cat.name}
                 </button>
               ))
             )}
           </div>
-          {categories.length > 0 && (
+          {categoriesForDivision.length > 0 && (
             <div className="text-center mt-4">
               <button
                 onClick={handleDecideClick}

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -38,10 +38,10 @@ describe('App', () => {
     window.history.pushState({}, '', '/');
   });
 
-  it('renders category selection screen initially', async () => {
+  it('renders division selection screen initially', async () => {
     fetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ categories: ['いろはかるた', 'テスト用'] }),
+      json: async () => ({ categories: [] }),
     });
 
     await act(async () => {
@@ -49,9 +49,139 @@ describe('App', () => {
     });
 
     expect(screen.getByText('かるた読み上げアプリ')).toBeInTheDocument();
+    expect(screen.getByText('こども向け')).toBeInTheDocument();
+    expect(screen.getByText('エンジニア向け')).toBeInTheDocument();
+  });
+
+  it('shows the matching category list after choosing a division', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        categories: [
+          { name: 'いろはかるた', group: 'kids' },
+          { name: 'テスト用', group: 'kids' },
+        ],
+      }),
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(screen.getByText('こども向け'));
+
     await waitFor(() => {
       expect(screen.getByText('いろはかるた')).toBeInTheDocument();
       expect(screen.getByText('テスト用')).toBeInTheDocument();
+    });
+  });
+
+  it('only shows categories belonging to the selected division', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        categories: [
+          { name: 'KidsCat', group: 'kids' },
+          { name: 'EngCat', group: 'engineer' },
+        ],
+      }),
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(screen.getByText('こども向け'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /KidsCat/ })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /EngCat/ })).not.toBeInTheDocument();
+  });
+
+  it('shows an empty-state message instead of a dead decide button when a division has no categories', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        categories: [{ name: 'EngCat', group: 'engineer' }],
+      }),
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(screen.getByText('こども向け'));
+
+    await waitFor(() => {
+      expect(screen.getByText('このかるたはまだありません。')).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/決定/)).not.toBeInTheDocument();
+  });
+
+  it('keeps the secondary navigation links reachable from the category selection screen', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }),
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(screen.getByText('こども向け'));
+    await screen.findByRole('button', { name: /Cat1/ });
+
+    expect(screen.getByText(/全札一覧を見る/)).toBeInTheDocument();
+    expect(screen.getByText(/指摘された内容を確認する/)).toBeInTheDocument();
+    expect(screen.getByText(/更新履歴を見る/)).toBeInTheDocument();
+  });
+
+  it('only allows a single category to be selected for the kids division', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        categories: [
+          { name: 'Cat1', group: 'kids' },
+          { name: 'Cat2', group: 'kids' },
+        ],
+      }),
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(screen.getByText('こども向け'));
+
+    const cat1Button = await screen.findByRole('button', { name: /Cat1/ });
+    const cat2Button = await screen.findByRole('button', { name: /Cat2/ });
+
+    fireEvent.click(cat1Button);
+    expect(screen.getByRole('button', { name: /Cat1/ })).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(cat2Button);
+    expect(screen.getByRole('button', { name: /Cat1/ })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: /Cat2/ })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('returns to the division selection screen via the back button', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }),
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(screen.getByText('こども向け'));
+    await screen.findByRole('button', { name: /Cat1/ });
+
+    fireEvent.click(screen.getByText('← 戻る'));
+
+    await waitFor(() => {
+      expect(screen.getByText('どなた向けに遊びますか？')).toBeInTheDocument();
     });
   });
 
@@ -91,7 +221,7 @@ describe('App', () => {
 
   it('starts game when category is selected', async () => {
     fetch.mockImplementation(async (url) => {
-      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: ['Cat1'] }) };
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
       if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
       return { ok: false };
     });
@@ -99,6 +229,8 @@ describe('App', () => {
     await act(async () => {
       render(<App />);
     });
+
+    fireEvent.click(await screen.findByText('こども向け'));
 
     await waitFor(() => {
       const elements = screen.queryAllByText('Cat1');
@@ -120,7 +252,7 @@ describe('App', () => {
 
   it('merges phrases from multiple categories when several are selected', async () => {
     fetch.mockImplementation(async (url) => {
-      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: ['Cat1', 'Cat2'] }) };
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }, { name: 'Cat2', group: 'engineer' }] }) };
       if (url.includes('category=Cat1')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
       if (url.includes('category=Cat2')) return { ok: true, json: async () => ({ phrases: [{ id: 'p2', category: 'Cat2' }] }) };
       return { ok: false };
@@ -129,6 +261,8 @@ describe('App', () => {
     await act(async () => {
       render(<App />);
     });
+
+    fireEvent.click(await screen.findByText('エンジニア向け'));
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Cat1/ })).toBeInTheDocument();
@@ -157,7 +291,7 @@ describe('App', () => {
     }));
 
     fetch.mockImplementation(async (url) => {
-      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: ['Cat1'] }) };
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
       if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases }) };
       return { ok: false };
     });
@@ -167,6 +301,8 @@ describe('App', () => {
     await act(async () => {
       render(<App />);
     });
+
+    fireEvent.click(await screen.findByText('こども向け'));
 
     const categoryButton = await screen.findByRole('button', { name: /Cat1/ });
     fireEvent.click(categoryButton);
@@ -198,7 +334,7 @@ describe('App', () => {
 
   it('packs printed efuda cards across categories onto the same page without breaking per category', async () => {
     fetch.mockImplementation(async (url) => {
-      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: ['Cat1', 'Cat2'] }) };
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }, { name: 'Cat2', group: 'engineer' }] }) };
       // Both categories reuse id "p1" to also verify same-id phrases from
       // different categories are kept distinct rather than deduped together.
       if (url.includes('category=Cat1')) {
@@ -213,6 +349,8 @@ describe('App', () => {
     await act(async () => {
       render(<App />);
     });
+
+    fireEvent.click(await screen.findByText('エンジニア向け'));
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Cat1/ })).toBeInTheDocument();
@@ -252,7 +390,7 @@ describe('App', () => {
     }));
 
     fetch.mockImplementation(async (url) => {
-      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: ['Cat1', 'Cat2'] }) };
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }, { name: 'Cat2', group: 'engineer' }] }) };
       if (url.includes('category=Cat1')) return { ok: true, json: async () => ({ phrases: cat1Phrases }) };
       if (url.includes('category=Cat2')) return { ok: true, json: async () => ({ phrases: cat2Phrases }) };
       return { ok: false };
@@ -261,6 +399,8 @@ describe('App', () => {
     await act(async () => {
       render(<App />);
     });
+
+    fireEvent.click(await screen.findByText('エンジニア向け'));
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Cat1/ })).toBeInTheDocument();
@@ -290,7 +430,7 @@ describe('App', () => {
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0); // 常にp1を選ばせる
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) {
-        return { ok: true, json: async () => ({ categories: ['Cat1'] }) };
+        return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
       }
       if (url.includes('get-phrases-list')) {
         return {
@@ -321,6 +461,8 @@ describe('App', () => {
       render(<App />);
     });
 
+    fireEvent.click(await screen.findByText('こども向け'));
+
     const categoryButton = await screen.findByRole('button', { name: 'Cat1' });
     fireEvent.click(categoryButton);
     fireEvent.click(screen.getByText(/決定/));
@@ -347,14 +489,16 @@ describe('App', () => {
 
   it('updates settings (lang, sort order, speech rate)', async () => {
     fetch.mockImplementation(async (url) => {
-      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: ['Cat1'] }) };
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
       return { ok: false };
     });
 
     await act(async () => {
       render(<App />);
     });
-    
+
+    fireEvent.click(await screen.findByText('こども向け'));
+
     // Select Category
     const categoryButton = await screen.findByRole('button', { name: /Cat1/ });
     fireEvent.click(categoryButton);


### PR DESCRIPTION
設計:
- 選定内容: phrases.csvにgroup列(kids/engineer)を追加。
- 選定内容: /get-categoriesはcategory名と{name,group}配列を返す形に変更。
- 選定内容: トップ画面はこども向け/エンジニア向けの二択画面を追加し、選択後に区分内のカテゴリ一覧を表示。
- 選定内容: こども向けは単一選択、エンジニア向けは既存の複数選択を維持。
- 却下内容: 区分ごとの選択数を抽象化する仕組み(maxSelectable等)は2区分のみのため見送り。
- 理由: 既存のカテゴリ選択UI・確認モーダルを流用し最小差分で区分選択を追加するため。

影響:
- 影響モジュール: backend/phrases.csv, backend/seed.js, backend/handler.js, frontend/src/App.jsx
- 振る舞いの変更: /get-categoriesのレスポンス形式が文字列配列からオブジェクト配列に変更。
- 振る舞いの変更: URLクエリパラメータにdivisionを追加し、リロード・戻る操作で状態を復元。

テスト:
- 追加済み: getCategoriesのgroup付与・デフォルト値(kids)に関するテスト。
- 追加済み: 区分選択画面の表示、カテゴリ絞り込み、単一選択制限、戻るボタン、空状態表示のテスト。
- 未追加: 本番DynamoDBへのseed.js実行結果の確認(デプロイ運用フローのため対象外)。