### PR TITLE
fix(ci): releaseブランチ同期とバージョン自動リリースの不具合を修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -174,17 +174,25 @@ jobs:
           fi      
           npx semantic-release
       - name: Create PR from release to main
+        id: sync-pr
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.BOT_TOKEN }}
           base: main
           head: release
+          branch: sync/release-to-main
+          branch-suffix: timestamp
+          delete-branch: true
           title: "Sync release branch into main"
           body: "Automated PR to sync release changes into main."
           draft: false
           commit-message: "chore: sync release branch into main [skip ci]"
-          merge-method: squash
-          auto-merge: true
+      - name: Enable auto-merge for sync PR
+        if: steps.sync-pr.outputs.pull-request-number
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: gh pr merge --auto --squash "${{ steps.sync-pr.outputs.pull-request-url }}"
   build-and-deploy-frontend:
     needs: release
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,9 @@ jobs:
     needs: [merge]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    concurrency:
+      group: sync-release-branch
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -140,8 +143,7 @@ jobs:
           git fetch --tags origin
           # ローカル release にチェックアウト
           git checkout release
-          # Release を Main と完全一致させる
-          git reset --hard origin/main
+          # main の新規コミットを release に取り込む（release 側の未マージなリリースコミットは保持する）
+          git merge origin/main --no-edit
           git tag --contains HEAD
-          # release を main と完全一致させる
-          git push origin release --force --tags
+          git push origin release --tags


### PR DESCRIPTION
設計:
- 選定内容: (1) ci.ymlのsync-releaseジョブで`git reset --hard origin/main`を `git merge origin/main`に変更し、release側の未マージなリリースコミットを破壊しない ようにした。(2) cd.ymlの「Create PR from release to main」で指定していた `merge-method`/`auto-merge`はpeter-evans/create-pull-request@v5に存在しない 入力で無視されていたため、`gh pr merge --auto --squash`による実際のGitHub auto-merge呼び出しに置き換えた。あわせてPRブランチ名に`branch-suffix: timestamp` を付与し、過去にクローズされた同名ブランチのPR(#130)に永久に塞がれない構成にした。
- 却下内容: release方式を廃止しmain直push+semantic-release方式へ簡略化する案は、 main直push禁止・PR必須というブランチ保護設定と矛盾するため却下し、release方式を 維持したまま同期バグのみを修正する方針を採った。
- 理由: v1.13.1タグがmain/releaseの祖先になっておらず(`git merge-base --is-ancestor`で未確認)、release上のバージョンアップコミットが一度もmainへ マージされていないことを確認した。原因は上記2点の組み合わせで、semantic-release が作るリリースコミットがPRとしてmainへ戻る前に、次の機能PRマージ時の `reset --hard`で毎回消去されていたため。

影響:
- 影響モジュール: .github/workflows/ci.yml(sync-releaseジョブ)、 .github/workflows/cd.yml(releaseジョブのPR作成・マージ部分)のみ。 アプリケーションコードへの変更はない。
- 振る舞いの変更: releaseブランチが機能PRマージ時に強制リセットされなくなり、 semantic-releaseのバージョンアップ/CHANGELOGコミットがPR経由で確実にmainへ 戻るようになる。並行マージ時の競合を防ぐためsync-releaseジョブに concurrencyグループを追加した。auto-merge有効化ステップは continue-on-errorとし、リポジトリ側で「Allow auto-merge」設定が無効でも デプロイジョブをブロックしないようにした(別途リポジトリ設定の確認が必要)。

テスト:
- 追加済み: N/A(CI/CD設定ファイルのみの変更で、ワークフロー自体の自動テストは 本リポジトリに存在しない)。
- 未追加: frontend(lint/test/build)・backend(test)を実行し全件成功を確認。 PythonのYAMLパーサで両ワークフローファイルの構文検証も実施した。