### PR TITLE
fix(ci): releaseブランチへのpushでCIジョブを起動しないように変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - release
   pull_request:
 
 permissions:
@@ -24,12 +23,6 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "npm"
-      - name: Branch check
-        run: |
-          if [ "$GITHUB_REF" = "refs/heads/release" ]; then
-            echo "Skipping push to release to avoid loop"
-            exit 0
-          fi
       - name: Install dependencies
         run: npm ci
       - name: Validate current commit (last commit)


### PR DESCRIPTION
設計:
- 選定内容: ci.ymlのon.push.branchesから`release`を削除し、CIの起動を `main`へのpushとpull_requestのみに限定した。あわせて、到達不能になった commitlintジョブの「Branch check」ステップ（exit 0では当該ジョブの後続 ステップを止められず実質無効だった）を削除した。
- 却下内容: 「Branch check」ステップ内のif分岐をジョブ全体のif条件に 書き換えて維持する案は、トリガー自体を絞る方が意図が明確で却下した。
- 理由: sync-releaseジョブやcd.ymlのマージ処理がreleaseブランチへpushする たびにci.ymlのテストジョブが再実行され、プルリクのCIと重複していたため。

影響:
- 影響モジュール: .github/workflows/ci.yml のみ。アプリケーションコードへの 変更はない。
- 振る舞いの変更: releaseブランチへのpushではCI(commitlint/frontend-test/ backend-test)が起動しなくなる。pull_requestトリガーは変更なし。 releaseブランチのデプロイを担うcd.ymlのpushトリガーは変更していない。

テスト:
- 追加済み: N/A(CI設定ファイルのみの変更で、ワークフロー自体の自動テストは 本リポジトリに存在しない)。
- 未追加: frontend(lint/test/build)・backend(test)を実行し全件成功を確認。 PythonのYAMLパーサでci.ymlの構文検証も実施した。