### PR TITLE
fix(ci): CDジョブの冗長ステップを削減しリリース競合を解消

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,143 +36,28 @@ jobs:
           cache: "npm"
       - name: Install dependencies
         run: npm ci
-  
-      - name: Fetch tags
+
+      # release を main の最新コミットまで追従させる（main の方が進んでいる場合のみマージ）
+      - name: Sync release with main
         run: |
           git fetch origin --tags --prune
-          git fetch origin
-          git log origin/main --oneline -5
-          git log origin/release --oneline -5
-          git rev-parse release
-          git rev-parse origin/release
-
-    # Release が Main の最新と同じか確認
-      - name: Sync check
-        id: sync
-        run: |
           git fetch origin main
           MAIN_HEAD=$(git rev-parse origin/main)
           RELEASE_HEAD=$(git rev-parse release)
-          echo "MAIN_HEAD=$MAIN_HEAD" >> $GITHUB_ENV
-          echo "RELEASE_HEAD=$RELEASE_HEAD" >> $GITHUB_ENV
-          if [ "$MAIN_HEAD" = "$RELEASE_HEAD" ]; then
-            echo "Release is up-to-date with main"
-            echo "up_to_date=true" >> $GITHUB_ENV
-          else
-            echo "Release needs to merge main"
-            echo "up_to_date=false" >> $GITHUB_ENV
-          fi
-      # 必要ならマージ
-      - name: Merge main into release if needed
-        if: env.up_to_date == 'false'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git merge --no-ff origin/main -m "Chore: Merge main into release"
-          git push origin release
-      # Release 上の HEAD に既にタグがあるか確認
-      - name: Check for existing tags
-        id: tag_check
-        run: |
-          TAGS=$(git tag --contains HEAD | grep "^v" || true)
-          if [ -n "$TAGS" ]; then
-            echo "HEAD already has tags: $TAGS"
-            echo "tag_exists=true" >> $GITHUB_ENV
-          else
-            echo "No tags on HEAD"
-            echo "tag_exists=false" >> $GITHUB_ENV
+          if [ "$MAIN_HEAD" != "$RELEASE_HEAD" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git merge --no-ff origin/main -m "Chore: Merge main into release"
+            git push origin release
           fi
 
-      - name: Skip if release branch has no new commits
-        run: |
-          if git tag --contains HEAD | grep -q "v"; then
-            echo "Release branch already contains latest tag(s). Skipping release."
-            exit 0
-          fi
-      - name: Checkout release branch
-        run: git checkout release
-      - name: Merge main into release
-        run: |
-          # Fast-forward マージ
-          git merge --ff-only origin/main || echo "Already up to date"
-      - name: Skip if no new commits
-        run: |
-          if git tag --contains HEAD | grep -q "v"; then
-            echo "Release branch already contains latest tag(s). Skipping release."
-            exit 0
-          fi
-      - name: Dry-run Semantic-release
-        id: dryrun
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN != '' && secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          NEXT_TAG=$(npx semantic-release --dry-run | grep "The next release version is" | awk '{print $6}')
-          echo "NEXT_TAG=$NEXT_TAG" >> $GITHUB_ENV
-      - name: Check tag existence
-        run: |
-          if git rev-parse "refs/tags/$NEXT_TAG" >/dev/null 2>&1; then
-            echo "Tag $NEXT_TAG already exists. Skipping release."
-            exit 0
-          fi
-
-      # デバッグ: Release ブランチの情報を出力
-      - name: Debug Release branch
-        run: |
-          echo "===== RELEASE BRANCH ====="
-          echo "Branch: $(git branch --show-current)"
-          echo "Commit: $(git rev-parse HEAD)"
-          echo "Tags containing HEAD:"
-          git tag --contains HEAD
-          echo "All tags:"
-          git fetch --tags origin
-          git tag -l | grep v1.1
-    
-      # デバッグ: Main ブランチの情報も確認
-      - name: Debug Main branch
-        run: |
-          echo "===== MAIN BRANCH ====="
-          git fetch origin main --depth=1
-          git checkout origin/main
-          echo "Branch: $(git branch --show-current)"
-          echo "Commit: $(git rev-parse HEAD)"
-          echo "Tags containing HEAD:"
-          git tag --contains HEAD
-          echo "All tags:"
-          git fetch --tags origin
-          git tag -l | grep v1.1
-          # Release ブランチに戻す
-          git checkout release
-      
-      - name: Check for tag conflicts
-        id: check-tags
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN != '' && secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          # semantic-release が付ける予定の次バージョンを確認
-          NEXT_TAG=$(npx semantic-release --dry-run | grep "The next release version is" | awk '{print $6}')
-          echo "NEXT_TAG=$NEXT_TAG" >> $GITHUB_ENV
-          # 既存タグと重複していないか確認
-          if git rev-parse "refs/tags/$NEXT_TAG" >/dev/null 2>&1; then
-            echo "Tag $NEXT_TAG already exists. Exiting."
-            exit 0
-          fi
-          git fetch --tags origin
-          git tag --contains HEAD
-
+      # release への追従直後に実行することで、他のマージとの競合（semantic-release が
+      # 「ローカルの release が remote より古い」と判定してリリースを黒くスキップする
+      # 問題）が起きる時間差を最小化する
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN != '' && secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
-          # DEBUG: semantic-release:*
-        run: |
-          git fetch --tags --force
-          NEXT_VERSION=$(npx semantic-release --dry-run | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-          echo "Next version: $NEXT_VERSION"
-          # ★ リモートタグチェック（これが重要）
-          if git ls-remote --tags origin | grep -q "refs/tags/v$NEXT_VERSION$"; then
-            echo "Tag v$NEXT_VERSION already exists on remote. Skipping release."
-            exit 0
-          fi      
-          npx semantic-release
+        run: npx semantic-release
       - name: Create PR from release to main
         id: sync-pr
         uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
設計:
- 選定内容: cd.ymlのreleaseジョブから、(1)機能していない「skip」ステップ群 (exit 0しても後続ステップは止まらず実質no-opだった)、(2)同じ npx semantic-release --dry-runを3回も呼び直していた重複ロジック、 (3)git fetch --depth=1でシャロー化しつつmain/releaseを往復していた デバッグ専用ステップを削除し、「release を main に同期 → semantic-release を実行」の2ステップに整理した。
- 却下内容: releaseブランチ方式自体の廃止(main直push化)は、main側のPR必須の ブランチ保護設定と矛盾するため別PR(#157)時点で却下済み。今回はその方式を 維持したまま、ジョブ内部の冗長性のみを削減する方針を採った。
- 理由: ローカルでsemantic-release(v25.0.2)のソース(lib/git.jsの isBranchUpToDate)を確認したところ、ローカルHEADとgit ls-remoteで取得した リモートのreleaseHEADが完全一致しない場合、エラーを出さず 「ℹ The local branch release is behind the remote one, therefore a new version won't be published.」と表示してexit code 0でリリースを黒く スキップする仕様であることが分かった。実際にこの状況をローカルで再現できた。 cd.ymlのreleaseジョブは2回のdry-run・複数のデバッグ用checkout/fetchを含み 完了まで時間がかかるため、その間に別の機能PRマージがreleaseへpushされると 即座にこの「behind」判定に引っかかる。直近のCD実行ログ(#157, #158のpush分) でも、ジョブ自体はsuccess扱いになる一方で新規タグが一切作られていないことを GitHub APIで確認しており、これが「ジョブは動くがバージョンが進まない」の 直接原因だった。

影響:
- 影響モジュール: .github/workflows/cd.ymlのreleaseジョブのみ。 build-and-deploy-frontend/deploy-backendジョブ、アプリケーションコードへの 変更はない。
- 振る舞いの変更: releaseブランチをmainに同期した直後にsemantic-releaseを実行 するようになり、ジョブの実行時間が大幅に短縮される。これにより、同時期に 別PRがマージされてreleaseが更新されても、staleチェックに引っかかる時間窓が ほぼ無くなる。完全に同時(数秒以内)にマージが重なった場合のレースは理論上 残るが、頻度は大幅に下がる。

テスト:
- 追加済み: N/A(CI/CD設定ファイルのみの変更で、ワークフロー自体の自動テストは 本リポジトリに存在しない)。実際の挙動はGitHub Actions上の次回リリース実行で 確認する。
- 未追加: frontend(lint/test/build)・backend(test)を実行し全件成功を確認 (既存テストに影響がないことを確認)。PythonのYAMLパーサで構文検証も実施した。