### PR TITLE
feat(all-phrases): 種別フィルタ追加とヘッダ固定表示

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -139,6 +139,20 @@ button:active:not(:disabled) {
   transform: translateY(2px);
 }
 
+/* 全札一覧テーブル：スクロール可能・ヘッダ固定 */
+.all-phrases-table-container {
+  overflow-x: auto;
+  overflow-y: auto;
+  max-height: calc(100vh - 260px);
+}
+
+.all-phrases-table-container thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background-color: #f8f9fa;
+}
+
 /* 絵札印刷（エーワン マルチカード ZT51677_A 実測準拠：上下7mm・左右12mm余白、列間4mm・行間2mm） */
 .efuda-print-area {
   display: flex;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,9 +34,10 @@ function App() {
   });
   const [allComments, setAllComments] = useState([]);
 
-  const [allPhrasesForCategory, setAllPhrasesForCategory] = useState([]); 
+  const [allPhrasesForCategory, setAllPhrasesForCategory] = useState([]);
   const [allPhrases, setAllPhrases] = useState([]); // 全札一覧用
   const [sortConfig, setSortConfig] = useState({ key: null, direction: 'asc' }); // ソート設定
+  const [filterCategory, setFilterCategory] = useState(''); // 全札一覧フィルタ
   const [currentPhrase, setCurrentPhrase] = useState(null);
   
   const [displayContent, setDisplayContent] = useState({ type: "initial" });
@@ -154,6 +155,23 @@ function App() {
     }
     return sortableItems;
   }, [allPhrases, sortConfig]);
+
+  const uniqueCategories = useMemo(() => {
+    return [...new Set(allPhrases.map(p => p.category))].sort((a, b) => a.localeCompare(b, 'ja'));
+  }, [allPhrases]);
+
+  const categoryCount = useMemo(() => {
+    const counts = {};
+    allPhrases.forEach(p => {
+      counts[p.category] = (counts[p.category] || 0) + 1;
+    });
+    return counts;
+  }, [allPhrases]);
+
+  const filteredPhrases = useMemo(() => {
+    if (!filterCategory) return sortedPhrases;
+    return sortedPhrases.filter(p => p.category === filterCategory);
+  }, [sortedPhrases, filterCategory]);
 
   const renderSortArrow = (key) => {
       if (sortConfig.key === key) {
@@ -799,9 +817,9 @@ function App() {
   if (view === "all-phrases") {
     return (
       <div className="container py-4 mx-auto">
-        <header className="text-center mb-5 border-bottom pb-3">
+        <header className="text-center mb-4 border-bottom pb-3">
           <div className="d-flex justify-content-between align-items-center">
-            <button onClick={() => { setView("game"); setSelectedCategories([]); }} className="btn btn-sm btn-outline-secondary rounded-pill">← 戻る</button>
+            <button onClick={() => { setView("game"); setSelectedCategories([]); setFilterCategory(''); }} className="btn btn-sm btn-outline-secondary rounded-pill">← 戻る</button>
             <h1 className="h2 fw-bold m-0 text-dark">全札一覧</h1>
             <div style={{ width: "60px" }}></div>
           </div>
@@ -811,50 +829,70 @@ function App() {
           {allPhrases.length === 0 ? (
             <p className="text-muted text-center py-5">読み込み中...</p>
           ) : (
-            <div className="table-responsive shadow-sm rounded-4 bg-white">
-              <table className="table table-hover mb-0">
-                <thead className="table-light">
-                  <tr>
-                    <th scope="col" className="ps-4" style={{ cursor: "pointer" }} onClick={() => handleSort('category')}>
-                      カテゴリ{renderSortArrow('category')}
-                    </th>
-                    <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('phrase')}>
-                      読み札{renderSortArrow('phrase')}
-                    </th>
-                    <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('answer')}>
-                      答え{renderSortArrow('answer')}
-                    </th>
-                    <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('level')}>
-                      Lv{renderSortArrow('level')}
-                    </th>
-                    <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('readCount')}>
-                      回数{renderSortArrow('readCount')}
-                    </th>
-                    <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('averageTime')}>
-                      平均時間{renderSortArrow('averageTime')}
-                    </th>
-                    <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('averageDifficulty')}>
-                      難易度{renderSortArrow('averageDifficulty')}
-                    </th>
-                    <th scope="col" className="text-end pe-4">詳細</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {sortedPhrases.map((p) => (
-                    <tr key={p.id} style={{ cursor: "pointer" }} onClick={() => openDetail(p.id, p.category)}>
-                      <td className="ps-4 text-muted small">{p.category}</td>
-                      <td className="fw-bold">{p.phrase}</td>
-                      <td>{p.answer && p.answer !== "-" ? p.answer : ""}</td>
-                      <td>{p.level !== "-" ? p.level : ""}</td>
-                      <td>{p.readCount || 0}</td>
-                      <td>{(p.averageTime || 0).toFixed(2)}s</td>
-                      <td>{(p.averageDifficulty || 0).toFixed(2)}</td>
-                      <td className="text-end pe-4 text-primary">→</td>
+            <>
+              <div className="mb-3 d-flex flex-wrap align-items-center gap-2">
+                <span className="text-muted small fw-bold me-1">種別:</span>
+                <button
+                  className={`btn btn-sm rounded-pill ${filterCategory === '' ? 'btn-dark' : 'btn-outline-secondary'}`}
+                  onClick={() => setFilterCategory('')}
+                >
+                  すべて ({allPhrases.length})
+                </button>
+                {uniqueCategories.map(cat => (
+                  <button
+                    key={cat}
+                    className={`btn btn-sm rounded-pill notranslate ${filterCategory === cat ? 'btn-karuta' : 'btn-outline-secondary'}`}
+                    onClick={() => setFilterCategory(cat)}
+                  >
+                    {cat} ({categoryCount[cat] || 0})
+                  </button>
+                ))}
+              </div>
+              <div className="all-phrases-table-container shadow-sm rounded-4 bg-white">
+                <table className="table table-hover mb-0">
+                  <thead className="table-light">
+                    <tr>
+                      <th scope="col" className="ps-4" style={{ cursor: "pointer" }} onClick={() => handleSort('category')}>
+                        カテゴリ{renderSortArrow('category')}
+                      </th>
+                      <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('phrase')}>
+                        読み札{renderSortArrow('phrase')}
+                      </th>
+                      <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('answer')}>
+                        答え{renderSortArrow('answer')}
+                      </th>
+                      <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('level')}>
+                        Lv{renderSortArrow('level')}
+                      </th>
+                      <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('readCount')}>
+                        回数{renderSortArrow('readCount')}
+                      </th>
+                      <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('averageTime')}>
+                        平均時間{renderSortArrow('averageTime')}
+                      </th>
+                      <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('averageDifficulty')}>
+                        難易度{renderSortArrow('averageDifficulty')}
+                      </th>
+                      <th scope="col" className="text-end pe-4">詳細</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+                  </thead>
+                  <tbody>
+                    {filteredPhrases.map((p) => (
+                      <tr key={`${p.category}-${p.id}`} style={{ cursor: "pointer" }} onClick={() => openDetail(p.id, p.category)}>
+                        <td className="ps-4 text-muted small">{p.category}</td>
+                        <td className="fw-bold">{p.phrase}</td>
+                        <td>{p.answer && p.answer !== "-" ? p.answer : ""}</td>
+                        <td>{p.level !== "-" ? p.level : ""}</td>
+                        <td>{p.readCount || 0}</td>
+                        <td>{(p.averageTime || 0).toFixed(2)}s</td>
+                        <td>{(p.averageDifficulty || 0).toFixed(2)}</td>
+                        <td className="text-end pe-4 text-primary">→</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
           )}
         </main>
       </div>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -613,6 +613,109 @@ describe('App', () => {
     });
   });
 
+  it('filters all-phrases table by category when a filter button is clicked', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ categories: [] }),
+    });
+    await act(async () => {
+      render(<App />);
+    });
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        return { ok: true, json: async () => ({ categories: [] }) };
+      }
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({
+            phrases: [
+              { id: 'p1', category: 'Cat1', phrase: '読み札Cat1', level: '-', answer: '-' },
+              { id: 'p2', category: 'Cat2', phrase: '読み札Cat2', level: '-', answer: '-' },
+            ],
+          }),
+        };
+      }
+      return { ok: false };
+    });
+
+    fireEvent.click(screen.getByText(/全札一覧を見る/i));
+
+    // 両カテゴリの行が表示されるまで待機
+    await waitFor(() => {
+      expect(screen.getByText('読み札Cat1')).toBeInTheDocument();
+      expect(screen.getByText('読み札Cat2')).toBeInTheDocument();
+    });
+
+    // Cat1 フィルタボタンをクリック
+    const cat1FilterBtn = screen.getByRole('button', { name: /^Cat1/ });
+    fireEvent.click(cat1FilterBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText('読み札Cat1')).toBeInTheDocument();
+      expect(screen.queryByText('読み札Cat2')).not.toBeInTheDocument();
+    });
+
+    // 「すべて」ボタンで全件に戻る
+    fireEvent.click(screen.getByRole('button', { name: /^すべて/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText('読み札Cat1')).toBeInTheDocument();
+      expect(screen.getByText('読み札Cat2')).toBeInTheDocument();
+    });
+  });
+
+  it('resets filter category when navigating back from all-phrases view', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ categories: [] }),
+    });
+    await act(async () => {
+      render(<App />);
+    });
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        return { ok: true, json: async () => ({ categories: [] }) };
+      }
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({
+            phrases: [
+              { id: 'p1', category: 'Cat1', phrase: '読み札Cat1', level: '-', answer: '-' },
+              { id: 'p2', category: 'Cat2', phrase: '読み札Cat2', level: '-', answer: '-' },
+            ],
+          }),
+        };
+      }
+      return { ok: false };
+    });
+
+    fireEvent.click(screen.getByText(/全札一覧を見る/i));
+
+    await waitFor(() => {
+      expect(screen.getByText('読み札Cat1')).toBeInTheDocument();
+    });
+
+    // フィルタを Cat1 に絞る
+    fireEvent.click(screen.getByRole('button', { name: /^Cat1/ }));
+    await waitFor(() => {
+      expect(screen.queryByText('読み札Cat2')).not.toBeInTheDocument();
+    });
+
+    // 戻るボタンで離脱し再度「全札一覧」へ
+    fireEvent.click(screen.getByRole('button', { name: /← 戻る/ }));
+    fireEvent.click(screen.getByText(/全札一覧を見る/i));
+
+    // フィルタがリセットされ全件表示されること
+    await waitFor(() => {
+      expect(screen.getByText('読み札Cat1')).toBeInTheDocument();
+      expect(screen.getByText('読み札Cat2')).toBeInTheDocument();
+    });
+  });
+
   it('updates document title when viewing all-phrases', async () => {
     fetch.mockResolvedValueOnce({
       ok: true,


### PR DESCRIPTION
設計:
- 選定内容: filterCategory state + useMemo（uniqueCategories / categoryCount / filteredPhrases）でフィルタロジックを実装。 CSS .all-phrases-table-container に max-height + overflow-y: auto、 thead th に position: sticky を付与しヘッダ固定。
- 却下内容: URL params でフィルタ状態を永続化する案（最小変更の原則）
- 理由: 既存の sortConfig/sortedPhrases パターンに準拠し差分を最小化。 レビュー指摘により key={p.id} を key={`${p.category}-${p.id}`} に 修正（異カテゴリ間 id 重複時の React reconciliation 誤動作を防止）。 .sort() を localeCompare('ja') に変更し日本語五十音順を保証。 「← 戻る」時に filterCategory をリセットし再訪時のフィルタ残留を防止。

影響:
- 影響モジュール: frontend/src/App.jsx, frontend/src/App.css
- 振る舞いの変更: 全札一覧に種別フィルタボタンを追加（「すべて」で全件 表示に戻る）。テーブルヘッダがスクロール中も固定される。戻る操作で フィルタがリセットされる。

テスト:
- 追加済み: フィルタで特定カテゴリのみ表示されること、「すべて」で全件に 戻ること、戻るボタンでフィルタがリセットされること（App.test.jsx 2件追加）
- 未追加: N/A