### PR TITLE
fix(all-phrases): 種別フィルタも表と一緒にスクロールさせヘッダのみ固定

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -139,14 +139,15 @@ button:active:not(:disabled) {
   transform: translateY(2px);
 }
 
-/* 全札一覧テーブル：スクロール可能・ヘッダ固定 */
-.all-phrases-table-container {
+/* 全札一覧：種別フィルタと表を同じ領域でスクロールし、表のヘッダのみ画面内に固定 */
+/* 140px は画面上部の「戻る」ヘッダ（高さ約53px + 上下パディング/余白約73px）分の差し引き */
+.all-phrases-scroll-container {
   overflow-x: auto;
   overflow-y: auto;
-  max-height: calc(100vh - 260px);
+  max-height: calc(100vh - 140px);
 }
 
-.all-phrases-table-container thead th {
+.all-phrases-scroll-container thead th {
   position: sticky;
   top: 0;
   z-index: 1;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -829,7 +829,7 @@ function App() {
           {allPhrases.length === 0 ? (
             <p className="text-muted text-center py-5">読み込み中...</p>
           ) : (
-            <>
+            <div className="all-phrases-scroll-container">
               <div className="mb-3 d-flex flex-wrap align-items-center gap-2">
                 <span className="text-muted small fw-bold me-1">種別:</span>
                 <button
@@ -892,7 +892,7 @@ function App() {
                   </tbody>
                 </table>
               </div>
-            </>
+            </div>
           )}
         </main>
       </div>


### PR DESCRIPTION
設計:
- 選定内容: 種別フィルタ行と表を同じスクロール領域 （.all-phrases-scroll-container、overflow-x/y: auto + max-height: calc(100vh - 140px)）にまとめ、表の thead th のみ position: sticky で画面内に固定する構成に変更。
- 却下内容: 表側の .all-phrases-table-container に max-height を 残したままフィルタ行だけ外に出す案（従来構成）。フィルタ行が 常時表示されたままになり「画面の多くを占める」という要望を 解消できないため却下。
- 理由: sticky の基準となる最寄りのスクロール祖先要素が実際に 内部スクロールしない（max-height を持たない）と、 position: sticky が機能しないことを実機検証で確認したため、 フィルタ行と表を同一のスクロール祖先に含める構成にした。 overflow-x: auto は overflow-y を暗黙的に auto 化するため、 横スクロール用のラッパーを別要素に分離すると sticky が壊れる ことも確認済み。.all-phrases-table-container は表の見た目 （shadow/rounded/背景色）専用の入れ子要素として残した。

影響:
- 影響モジュール: frontend/src/App.jsx, frontend/src/App.css
- 振る舞いの変更: 全札一覧で「戻る」ヘッダは常時表示のまま、 種別フィルタボタン行はスクロールで隠れるようになり、表の ヘッダ行だけが画面内に固定表示される。モバイル幅でも表が ページ全体を横方向にはみ出させないことを確認済み。

テスト:
- 追加済み: N/A（既存の App.test.jsx 25件が変更後も全件成功する ことを確認）
- 未追加: スクロール位置に応じた sticky ヘッダ表示のE2E的な 検証（Playwright での手動確認は実施済みだが、自動テストとしては 未追加）