### PR TITLE
feat(reading): 複数種別選択時に読み上げ末尾でかるた種別を読み上げる

### DIFF
--- a/backend/handler.js
+++ b/backend/handler.js
@@ -7,6 +7,13 @@ const docClient = DynamoDBDocumentClient.from(dynamoClient);
 const pollyClient = new PollyClient({ region: "ap-northeast-1" });
 const crypto = require("crypto");
 
+function escapeSsml(text) {
+  return String(text)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 function normalizeSpeechRate(rate) {
   if (!rate) return "90%";
   const rateStr = String(rate);
@@ -220,6 +227,7 @@ exports.getPhrase = async (event) => {
     const rawSpeechRate = params.speechRate || "90%";
     const speechRate = normalizeSpeechRate(rawSpeechRate);
     const lang = params.lang || "ja";
+    const announceCategory = params.announceCategory === "true";
     let targetId = params.id || null;
     const pollyCacheTableName = process.env.POLLY_CACHE_TABLE_NAME;
 
@@ -277,7 +285,7 @@ exports.getPhrase = async (event) => {
       : selectedItem.phrase;
 
     const cacheId = crypto.createHash("sha256").update(
-      `${targetId}-${repeatCount}-${speechRate}-${lang}-${JSON.stringify([level, speechPhrase])}`
+      `${targetId}-${repeatCount}-${speechRate}-${lang}-${announceCategory}-${JSON.stringify([level, speechPhrase, selectedItem.category])}`
     ).digest("hex");
 
     if (pollyCacheTableName) {
@@ -308,6 +316,11 @@ exports.getPhrase = async (event) => {
       let innerContent = phraseWithLevel;
       if (repeatCount >= 2) {
         innerContent = `${phraseWithLevel}<break time="1500ms"/>${phraseWithLevel}`;
+      }
+
+      // 複数種別を選択している場合、読み札がどの種別のものかを最後に1回だけ読み上げる（言語設定によらず日本語で読み上げる）
+      if (announceCategory && selectedItem.category) {
+        innerContent = `${innerContent}<break time="800ms"/>${escapeSsml(selectedItem.category)}`;
       }
 
       const ssmlText = `<speak><prosody rate="${speechRate}">${innerContent}</prosody></speak>`;

--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -387,6 +387,133 @@ describe('getPhrase', () => {
         expect(pollyParams.Text).toContain('<prosody rate="110%">');
     });
 
+    it('should append the category once at the end when announceCategory is true', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: '犬棒かるた', phrase: 'phrase 1', level: '-' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined }); // Cache miss
+        ddbMock.on(PutCommand).resolves({}); // Cache put
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1', repeatCount: '1', announceCategory: 'true' } };
+        await getPhrase(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.Text).toBe('<speak><prosody rate="90%">phrase 1<break time="800ms"/>犬棒かるた</prosody></speak>');
+    });
+
+    it('should append the category only once after both repeats when repeatCount is 2', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: '犬棒かるた', phrase: 'phrase 1', level: '-' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined }); // Cache miss
+        ddbMock.on(PutCommand).resolves({}); // Cache put
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1', repeatCount: '2', announceCategory: 'true' } };
+        await getPhrase(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.Text).toBe(
+            '<speak><prosody rate="90%">phrase 1<break time="1500ms"/>phrase 1<break time="800ms"/>犬棒かるた</prosody></speak>'
+        );
+        // カテゴリの読み上げは1回のみ含まれる
+        expect(pollyParams.Text.split('犬棒かるた').length - 1).toBe(1);
+    });
+
+    it('should not append the category when announceCategory is not set', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: '犬棒かるた', phrase: 'phrase 1', level: '-' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined }); // Cache miss
+        ddbMock.on(PutCommand).resolves({}); // Cache put
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1', repeatCount: '1' } };
+        await getPhrase(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.Text).not.toContain('犬棒かるた');
+    });
+
+    it('should announce the category in Japanese even when lang is en', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: '犬棒かるた', phrase: 'phrase 1', phrase_en: 'Phrase 1', level: '-' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined }); // Cache miss
+        ddbMock.on(PutCommand).resolves({}); // Cache put
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1', repeatCount: '1', announceCategory: 'true', lang: 'en' } };
+        await getPhrase(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.Text).toContain('犬棒かるた');
+        expect(pollyParams.Text).toContain('Phrase 1');
+    });
+
+    it('should escape SSML-significant characters in the category name', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'A&B<C>', phrase: 'phrase 1', level: '-' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined }); // Cache miss
+        ddbMock.on(PutCommand).resolves({}); // Cache put
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1', repeatCount: '1', announceCategory: 'true' } };
+        await getPhrase(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.Text).toContain('A&amp;B&lt;C&gt;');
+        expect(pollyParams.Text).not.toContain('A&B<C>');
+    });
+
+    it('should use a different cache key when announceCategory changes', async () => {
+        ddbMock.on(GetCommand).resolves({ Item: undefined }); // Cache miss
+        ddbMock.on(PutCommand).resolves({});
+
+        const audioStream = () => {
+            const s = new Readable();
+            s.push('audio data');
+            s.push(null);
+            return s;
+        };
+        pollyMock.on(SynthesizeSpeechCommand).callsFake(() => ({ AudioStream: audioStream() }));
+
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: '犬棒かるた', phrase: 'phrase 1', level: '-' }],
+        });
+        const baseEvent = { queryStringParameters: { id: 'p1' } };
+        await getPhrase(baseEvent);
+        const firstCacheId = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item.id;
+
+        const announceEvent = { queryStringParameters: { id: 'p1', announceCategory: 'true' } };
+        await getPhrase(announceEvent);
+        const secondCacheId = ddbMock.commandCalls(PutCommand)[1].args[0].input.Item.id;
+
+        expect(secondCacheId).not.toBe(firstCacheId);
+    });
+
     it('should use a different cache key when the phrase text changes for the same id', async () => {
         ddbMock.on(GetCommand).resolves({ Item: undefined }); // Cache miss
         ddbMock.on(PutCommand).resolves({});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -81,6 +81,10 @@ function App() {
     return selectedCategories.join("・");
   }, [selectedCategories]);
 
+  const isMultiCategorySelection = useMemo(() => {
+    return selectedCategories.length > 1;
+  }, [selectedCategories]);
+
   const categoriesForDivision = useMemo(() => {
     if (division !== "kids" && division !== "engineer") return [];
     return categories.filter(cat => cat.group === division);
@@ -240,7 +244,7 @@ function App() {
       const fetchDetail = async () => {
         try {
           const categoryParam = detailPhraseCategory ? `&category=${encodeURIComponent(detailPhraseCategory)}` : "";
-          const response = await fetch(`${API_BASE_URL}/get-phrase?id=${detailPhraseId}${categoryParam}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}`);
+          const response = await fetch(`${API_BASE_URL}/get-phrase?id=${detailPhraseId}${categoryParam}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}&announceCategory=${isMultiCategorySelection}`);
           const data = await response.json();
           if (response.ok) {
             setDetailPhrase(data);
@@ -253,7 +257,7 @@ function App() {
     } else {
       setDetailPhrase(null);
     }
-  }, [detailPhraseId, detailPhraseCategory, repeatCount, speechRate, lang]);
+  }, [detailPhraseId, detailPhraseCategory, repeatCount, speechRate, lang, isMultiCategorySelection]);
 
   // 指摘一覧の取得
   useEffect(() => {
@@ -470,7 +474,8 @@ function App() {
         targetPhrase = unreadPhrases[randomIndex];
       }
 
-      const apiUrl = `${API_BASE_URL}/get-phrase?id=${targetPhrase.id}&category=${encodeURIComponent(targetPhrase.category)}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}`;
+      const announceCategory = isMultiCategorySelection;
+      const apiUrl = `${API_BASE_URL}/get-phrase?id=${targetPhrase.id}&category=${encodeURIComponent(targetPhrase.category)}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}&announceCategory=${announceCategory}`;
       const response = await fetch(apiUrl);
       const data = await response.json();
       
@@ -794,7 +799,7 @@ function App() {
                         <div className="efuda-card" key={slotIndex}>
                           {p && (
                             <>
-                              {selectedCategories.length > 1 && (
+                              {isMultiCategorySelection && (
                                 <p className="no-print text-muted small efuda-card-category">{p.category}</p>
                               )}
                               <div className="efuda-card-kana">{p.kana}</div>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -281,6 +281,122 @@ describe('App', () => {
     });
   });
 
+  it('requests announceCategory=true when reading with multiple categories selected', async () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }, { name: 'Cat2', group: 'engineer' }] }) };
+      if (url.includes('get-phrases-list') && url.includes('category=Cat1')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      if (url.includes('get-phrases-list') && url.includes('category=Cat2')) return { ok: true, json: async () => ({ phrases: [{ id: 'p2', category: 'Cat2' }] }) };
+      if (url.includes('/get-phrase?')) return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', phrase: '読み札1', audioData: 'dummy' }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('エンジニア向け'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Cat1/ })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Cat2/ })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Cat1/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Cat2/ }));
+    fireEvent.click(screen.getByText(/決定/));
+
+    await waitFor(() => screen.getByText(/「Cat1」「Cat2」をお手元に持っていますか？/));
+    fireEvent.click(screen.getByText('はい'));
+
+    await waitFor(() => screen.getByText('次の札'));
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      const getPhraseCall = fetch.mock.calls.find(([url]) => url.includes('/get-phrase?'));
+      expect(getPhraseCall).toBeDefined();
+      expect(getPhraseCall[0]).toContain('announceCategory=true');
+    });
+
+    randomSpy.mockRestore();
+  });
+
+  it('requests announceCategory=false when reading with a single category selected', async () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      if (url.includes('/get-phrase?')) return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', phrase: '読み札1', audioData: 'dummy' }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+
+    const categoryButton = await screen.findByRole('button', { name: /Cat1/ });
+    fireEvent.click(categoryButton);
+    fireEvent.click(screen.getByText(/決定/));
+    fireEvent.click(screen.getByText('はい'));
+
+    await waitFor(() => screen.getByText('次の札'));
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      const getPhraseCall = fetch.mock.calls.find(([url]) => url.includes('/get-phrase?'));
+      expect(getPhraseCall).toBeDefined();
+      expect(getPhraseCall[0]).toContain('announceCategory=false');
+    });
+
+    randomSpy.mockRestore();
+  });
+
+  it('requests announceCategory=true for the detail-view replay when multiple categories are selected', async () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }, { name: 'Cat2', group: 'engineer' }] }) };
+      if (url.includes('get-phrases-list') && url.includes('category=Cat1')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-' }] }) };
+      if (url.includes('get-phrases-list') && url.includes('category=Cat2')) return { ok: true, json: async () => ({ phrases: [{ id: 'p2', category: 'Cat2', kana: 'い', phrase: '読み札2', level: '-' }] }) };
+      if (url.includes('/get-phrase?')) return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', audioData: 'dummy' }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('エンジニア向け'));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Cat1/ })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Cat2/ })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Cat1/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Cat2/ }));
+    fireEvent.click(screen.getByText(/決定/));
+    await waitFor(() => screen.getByText(/「Cat1」「Cat2」をお手元に持っていますか？/));
+    fireEvent.click(screen.getByText('はい'));
+
+    await waitFor(() => screen.getByText('次の札'));
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(screen.getByText('読み札1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+    }, { timeout: 8000 });
+
+    fetch.mockClear();
+    fireEvent.click(await screen.findByText('詳細・報告 →'));
+
+    await waitFor(() => {
+      const getPhraseCall = fetch.mock.calls.find(([url]) => url.includes('/get-phrase?'));
+      expect(getPhraseCall).toBeDefined();
+      expect(getPhraseCall[0]).toContain('announceCategory=true');
+    });
+
+    randomSpy.mockRestore();
+  }, 15000);
+
   it('shows efuda print view with answer fallback to phrase and paginates by 10', async () => {
     const phrases = Array.from({ length: 11 }, (_, i) => ({
       id: `p${i}`,


### PR DESCRIPTION
設計:
- 選定内容: バックエンドのgetPhraseにannounceCategoryクエリパラメータを追加し、 真の場合のみ読み札(繰り返し読み上げ後)の末尾にカテゴリ名を1回だけSSMLで追記。 フロントエンドはselectedCategories.length > 1から導出した真偽値を、 ゲーム中の読み上げと詳細画面の再生の両方で送信する。種別名は言語設定に よらず常に日本語のまま読み上げる(翻訳ロジックは追加しない)。
- 却下内容: カテゴリ名をキャッシュキーから外す案(announceCategoryがfalseの 場合のキャッシュ断片化は避けられるが、同一idが複数カテゴリに存在する場合の キャッシュ衝突バグを再導入するため却下)。詳細画面の読み上げにカテゴリ告知を 付けない案(ゲーム中の履歴から開いた詳細画面で同じ札の音声挙動が一致しなく なるため却下)。
- 理由: 複数種別を混在させて読み上げる際、どの種別の札かを画面表示だけでなく 音声でも把握できるようにするため。SSMLへのカテゴリ名埋め込みはXML特殊文字の エスケープが必要なためescapeSsmlヘルパーを追加した。

影響:
- 影響モジュール: backend/handler.js(getPhrase)、frontend/src/App.jsx (playKaruta、詳細画面取得effect、絵札印刷表示)。
- 振る舞いの変更: 複数種別選択時のみ読み上げ末尾に種別名の音声が追加される。 単一種別選択時は従来と同じ音声。Pollyキャッシュキーの構成要素が変わるため、 既存キャッシュエントリは再利用されず初回のみ再合成される。

テスト:
- 追加済み: backend/handler.test.js(announceCategoryの有無・repeatCount=2時に 1回のみ読み上げ・言語設定によらず日本語で読み上げ・SSMLエスケープ・ キャッシュキー分離)、frontend/src/App.test.jsx(複数/単一種別選択時の announceCategoryパラメータ送信、詳細画面再生時の一貫性)。
- 未追加: 実機ブラウザでの音声再生確認(Pollyは実APIのためユニットテストでは SSMLテキストの検証に留める)。