### PR TITLE
feat(ui): OS設定に自動追従するダークモードを追加

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,6 +10,17 @@
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <title>かるた読み上げアプリ</title>
+    <script>
+      (function () {
+        try {
+          var theme = localStorage.getItem("theme") || "system";
+          var isDark = theme === "dark" || (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+          document.documentElement.setAttribute("data-bs-theme", isDark ? "dark" : "light");
+        } catch (e) {
+          // localStorage/matchMediaが使えない環境ではライトのまま
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3,6 +3,54 @@
   width: 100%;
 }
 
+/* ダークモード: bg-light/bg-white/text-dark等はBootstrap 5.3のカラーモードに追従しない
+   静的ユーティリティのため、その参照元のCSS変数を直接再定義して連動させる */
+[data-bs-theme="dark"] {
+  --bs-light-rgb: 43, 43, 43;
+  --bs-dark-rgb: 228, 228, 228;
+  --bs-white-rgb: 30, 30, 30;
+}
+
+/* かるた札は常に紙面のような明るい配色を保つ意匠のため、文字色の反転対象から除外する */
+[data-bs-theme="dark"] .yomifuda {
+  --bs-dark-rgb: 33, 37, 41;
+}
+
+[data-bs-theme="dark"] .btn-dark {
+  --bs-btn-bg: #e4e4e4;
+  --bs-btn-border-color: #e4e4e4;
+  --bs-btn-color: #121212;
+  --bs-btn-hover-bg: #cfcfcf;
+  --bs-btn-hover-border-color: #cfcfcf;
+  --bs-btn-hover-color: #121212;
+  --bs-btn-active-bg: #cfcfcf;
+  --bs-btn-active-border-color: #cfcfcf;
+  --bs-btn-active-color: #121212;
+}
+
+/* btn-outline-dark/btn-outline-secondaryは--bs-btn-colorに固定の16進値を持つため、
+   --bs-dark-rgb等の再定義では追従しない。個別に上書きする */
+[data-bs-theme="dark"] .btn-outline-dark {
+  --bs-btn-color: #e4e4e4;
+  --bs-btn-border-color: #e4e4e4;
+  --bs-btn-hover-color: #121212;
+  --bs-btn-hover-bg: #e4e4e4;
+  --bs-btn-hover-border-color: #e4e4e4;
+  --bs-btn-active-color: #121212;
+  --bs-btn-active-bg: #e4e4e4;
+  --bs-btn-active-border-color: #e4e4e4;
+  --bs-btn-disabled-color: #e4e4e4;
+  --bs-btn-disabled-border-color: #e4e4e4;
+}
+
+[data-bs-theme="dark"] .btn-outline-secondary {
+  --bs-btn-color: #adb5bd;
+  --bs-btn-border-color: #6c757d;
+  --bs-btn-hover-color: #121212;
+  --bs-btn-hover-bg: #adb5bd;
+  --bs-btn-hover-border-color: #adb5bd;
+}
+
 /* ページ全体の中央寄せを保証 */
 .container {
   max-width: 800px; /* PCで見やすい幅に制限 */
@@ -107,6 +155,10 @@
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
 }
 
+[data-bs-theme="dark"] .category-selection-container {
+  background-color: #1e1e1e;
+}
+
 .btn-karuta {
   background-color: #e44d26;
   color: white;
@@ -152,6 +204,19 @@ button:active:not(:disabled) {
   top: 0;
   z-index: 1;
   background-color: #f8f9fa;
+}
+
+/* thead.table-lightは--bs-table-color/--bs-table-bgに固定の16進値を持つため、
+   --bs-dark-rgb等の再定義では追従しない。個別に上書きする。
+   なおsticky化のためthead thには背景色を直接指定しているため、--bs-table-bgとは別に
+   background-colorも上書きする必要がある */
+[data-bs-theme="dark"] .all-phrases-scroll-container thead.table-light {
+  --bs-table-color: #e4e4e4;
+  --bs-table-bg: #2b2b2b;
+}
+
+[data-bs-theme="dark"] .all-phrases-scroll-container thead th {
+  background-color: #2b2b2b;
 }
 
 /* 絵札印刷（エーワン マルチカード ZT51677_A 実測準拠：上下7mm・左右12mm余白、列間4mm・行間2mm） */

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -61,6 +61,12 @@ function App() {
   const [sortOrder, setSortOrder] = useState(() => {
     return localStorage.getItem("sortOrder") || "random";
   });
+  const [themeSetting, setThemeSetting] = useState(() => {
+    return localStorage.getItem("theme") || "system";
+  });
+  const [systemPrefersDark, setSystemPrefersDark] = useState(() => {
+    return window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
+  });
   const [historyByCategory, setHistoryByCategory] = useState({});
   
   const [showConfirmModal, setShowConfirmModal] = useState(false);
@@ -72,6 +78,10 @@ function App() {
 
   const flipTimeoutRef = useRef(null);
   const startTimeRef = useRef(null);
+
+  const resolvedTheme = useMemo(() => {
+    return themeSetting === "system" ? (systemPrefersDark ? "dark" : "light") : themeSetting;
+  }, [themeSetting, systemPrefersDark]);
 
   const categoryKey = useMemo(() => {
     return JSON.stringify(selectedCategories.slice().sort());
@@ -619,6 +629,23 @@ function App() {
   useEffect(() => {
     localStorage.setItem("sortOrder", sortOrder);
   }, [sortOrder]);
+
+  useEffect(() => {
+    localStorage.setItem("theme", themeSetting);
+  }, [themeSetting]);
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-bs-theme", resolvedTheme);
+  }, [resolvedTheme]);
+
+  // OSの配色設定(ダーク/ライト)の変更をリアルタイムに反映する
+  useEffect(() => {
+    const mediaQuery = window.matchMedia?.("(prefers-color-scheme: dark)");
+    if (!mediaQuery) return;
+    const handleChange = (e) => setSystemPrefersDark(e.matches);
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
 
   const resetGame = () => {
     setSelectedCategories([]);
@@ -1200,6 +1227,14 @@ function App() {
 
       <footer className="text-center mt-5 pt-4 border-top">
         <section className="settings-container mb-4 p-3 mx-auto shadow-sm rounded-4 bg-light border" style={{ maxWidth: "500px" }}>
+          <div className="mb-3 d-flex align-items-center justify-content-center gap-3 border-bottom pb-2">
+            <span className="fw-bold text-dark small">テーマ:</span>
+            <div className="btn-group btn-group-sm" role="group">
+              <button onClick={() => setThemeSetting("system")} className={`btn ${themeSetting === "system" ? 'btn-dark' : 'btn-outline-dark'}`}>自動</button>
+              <button onClick={() => setThemeSetting("light")} className={`btn ${themeSetting === "light" ? 'btn-dark' : 'btn-outline-dark'}`}>ライト</button>
+              <button onClick={() => setThemeSetting("dark")} className={`btn ${themeSetting === "dark" ? 'btn-dark' : 'btn-outline-dark'}`}>ダーク</button>
+            </div>
+          </div>
           <div className="mb-3 d-flex align-items-center justify-content-center gap-3 border-bottom pb-2">
             <span className="fw-bold text-dark small">言語:</span>
             <div className="btn-group btn-group-sm" role="group">

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -692,6 +692,38 @@ describe('App', () => {
     expect(localStorage.getItem('speechRate')).toBe('100%');
   });
 
+  it('applies the selected theme to the document and persists it', async () => {
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    // 初期値は自動(システム設定追従)で、matchMediaが使えない環境ではライト扱い
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('light');
+
+    fireEvent.click(await screen.findByText('こども向け'));
+
+    const categoryButton = await screen.findByRole('button', { name: /Cat1/ });
+    fireEvent.click(categoryButton);
+    fireEvent.click(screen.getByText(/決定/));
+    fireEvent.click(screen.getByText('はい'));
+
+    fireEvent.click(await screen.findByText('ダーク'));
+    expect(localStorage.getItem('theme')).toBe('dark');
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('dark');
+
+    fireEvent.click(screen.getByText('ライト'));
+    expect(localStorage.getItem('theme')).toBe('light');
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('light');
+
+    fireEvent.click(screen.getByText('自動'));
+    expect(localStorage.getItem('theme')).toBe('system');
+  });
+
   it('shows an answer column with data and blank fallback in all-phrases view', async () => {
     fetch.mockResolvedValueOnce({
       ok: true,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,13 +1,20 @@
 :root {
   font-family: 'M PLUS Rounded 1c', sans-serif;
+  --app-bg: #ffffff;
+  --app-fg: #213547;
+}
+
+[data-bs-theme="dark"] {
+  --app-bg: #121212;
+  --app-fg: #e4e4e4;
 }
 
 body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  background-color: #ffffff;
-  color: #213547;
+  background-color: var(--app-bg);
+  color: var(--app-fg);
 }
 
 /* Viteのデフォルトスタイルをリセット */


### PR DESCRIPTION
設計:
- 選定内容: テーマ設定を「自動(system)/ライト/ダーク」の3値でlocalStorageに保持し、 「自動」時はprefers-color-schemeメディアクエリの変化をリアルタイムに監視して Bootstrap 5.3のdata-bs-theme属性に反映する。あわせてbg-light/bg-white/text-dark/ btn-outline-dark等、カラーモードに追従しないBootstrap静的ユーティリティが参照する CSS変数(--bs-light-rgb等)をdata-bs-theme="dark"配下で再定義し、既存クラス名を 変更せずに全画面へ反映させた。index.htmlに初期化スクリプトを追加し、React描画前に data-bs-theme属性を設定することでFOUC(意図しないテーマでの一瞬の表示)を防止する。
- 却下内容: JSXの各クラス名(bg-light/text-dark等)を個別に置き換える方式は却下。 変更箇所が全画面に及び差分が肥大化するため。
- 理由: かるた札(.yomifuda)は紙面を模した意匠として常に明るい配色を保つ設計のため、 スコープ内で--bs-dark-rgbを元の値に戻して反転対象から除外している。

影響:
- 影響モジュール: frontend/src/App.jsx, App.css, index.css, index.html
- 振る舞いの変更: 設定パネルに「テーマ:」の切り替えボタン(自動/ライト/ダーク)を追加。 初回訪問時はOSの配色設定に自動追従し、手動選択時はlocalStorageの値を優先する。 既存のlang/sortOrder/speechRate/repeatCount設定への影響はない。

テスト:
- 追加済み: テーマ切り替えでdata-bs-theme属性とlocalStorageが更新されることを検証する Vitestテストを追加。またPlaywrightで実アプリを起動し、ダーク/ライト双方の主要画面 (トップ・カテゴリ選択・設定パネル・全札一覧・かるた札結果画面)の文字色と背景色の コントラスト比をWCAG AA基準で計測し、可読性を手動検証した。
- 未追加: 印刷用絵札(efuda-print-area)はテーマ非対応のまま(印刷物のため意図的に対象外)。