### PR TITLE
fix(efuda): 選択が1種別のみでも絵札印刷画面に種別名を表示

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -826,9 +826,7 @@ function App() {
                         <div className="efuda-card" key={slotIndex}>
                           {p && (
                             <>
-                              {isMultiCategorySelection && (
-                                <p className="no-print text-muted small efuda-card-category">{p.category}</p>
-                              )}
+                              <p className="no-print text-muted small efuda-card-category">{p.category}</p>
                               <div className="efuda-card-kana">{p.kana}</div>
                               <div className="efuda-card-text">{getEfudaText(p)}</div>
                             </>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -446,6 +446,9 @@ describe('App', () => {
 
     fireEvent.click(screen.getByText('印刷する'));
     expect(window.print).toHaveBeenCalled();
+
+    // 選択カテゴリが1つの場合でも、絵札にかるた種別が表示される
+    expect(document.querySelector('.efuda-card-category')).toHaveTextContent('Cat1');
   });
 
   it('packs printed efuda cards across categories onto the same page without breaking per category', async () => {


### PR DESCRIPTION
設計:
- 選定内容: efuda-card-category表示を囲むisMultiCategorySelection条件を撤去し、常に種別名を表示する
- 却下内容: 種別数に応じた表示条件の作り直し（表示条件の複雑化を避け、既存のno-printプレビュー挙動をそのまま単一種別にも適用する最小変更を採用）
- 理由: 単一種別選択時のみ種別名が非表示になっており、印刷前プレビューでどの種別の絵札か判別しづらいため

影響:
- 影響モジュール: frontend/src/App.jsx（絵札印刷画面 print-efuda ビュー）
- 振る舞いの変更: 選択カテゴリ数に関わらず、各絵札カード左上に種別名（プレビューのみ、印刷時はno-printで非表示）を表示するようになる。isMultiCategorySelection自体は読み上げ時のannounceCategory判定用途としてそのまま残置

テスト:
- 追加済み: frontend/src/App.test.jsxに単一カテゴリ選択時、絵札印刷プレビューに.efuda-card-categoryで種別名が表示されることを検証するアサーションを追加
- 未追加: N/A