### PR TITLE
fix(frontend): 読み札カードのiOS Safariでの下端見切れを修正

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -56,7 +56,10 @@
   max-width: 800px; /* PCで見やすい幅に制限 */
 }
 
-/* 札の表示コンテナ（縦横比維持） */
+/* 札の表示コンテナ（縦横比維持）
+   overflow: hiddenは3Dフリップアニメーション時代の名残で、フェード方式に移行した現在は
+   コンテンツをクリップする必要がない。iOS Safariではaspect-ratio指定の要素にoverflow: hiddenを
+   組み合わせると札の下端（枠線）が描画されないことがあるため外す */
 .yomifuda-container {
   width: 100%;
   max-width: 300px;
@@ -64,7 +67,6 @@
   margin-left: auto;
   margin-right: auto;
   cursor: pointer;
-  overflow: hidden;
 }
 
 /* フェードアニメーション用 */


### PR DESCRIPTION
設計:
- 選定内容: .yomifuda-containerからoverflow: hiddenを削除する
- 却下内容: aspect-ratioをやめてJSで高さを計算する対応、-webkit-transform: translateZ(0)等のGPUレイヤー強制ハック
- 理由: git履歴を確認したところoverflow: hiddenは3Dフリップアニメーション（perspective/preserve-3d）時代に追加されたもので、フェード方式への移行後は機能的に不要と判明した。カード内コンテンツはaspect-ratioで確保される高さに対して十分な余白があり（Chromium/WebKit双方・極端な長文でも検証済み）、クリップは本来不要。iOS Safari実機（ブラウザ/PWA両方）でaspect-ratio指定要素とoverflow: hiddenの組み合わせにより札下端の緑枠線が描画されない不具合が報告されたため、根本原因であるoverflow: hiddenそのものを取り除く方が、ハックを追加するより保守的で望ましいと判断した

影響:
- 影響モジュール: frontend/src/App.css（.yomifuda-containerのみ）
- 振る舞いの変更: 通常時の見た目は変化なし。理論上、想定を超える長さのフレーズが来た場合はクリップされず枠外にはみ出す可能性があるが、実データでは発生しないことを確認済み

テスト:
- 追加済み: frontend側 lint / vitest / build を実行しすべて成功（既存29件のテストが通過）。Playwright（Chromium/WebKit、iPhoneデバイスプロファイル込み）で修正前後の描画を目視確認し、通常表示が崩れていないことを確認
- 未追加: CSSのクリップ挙動自体を検証する自動テストは追加していない（jsdom環境ではレイアウト・描画を再現できないため）