### PR TITLE
fix(record-time): 読み上げ経過時間の異常値が統計を汚染しないよう上限チェックを追加

### DIFF
--- a/backend/handler.js
+++ b/backend/handler.js
@@ -26,12 +26,23 @@ function normalizeSpeechRate(rate) {
   return rateStr;
 }
 
+// タブを開いたまま放置する等で生じる異常値を統計に混入させないための経過時間の上限（秒）
+const MAX_ELAPSED_SECONDS = 300;
+
 exports.recordTime = async (event) => {
   try {
     const body = JSON.parse(event.body);
     const { id, category, time, difficulty } = body; // category, difficultyを追加
 
-    if (!id || !category || typeof time !== 'number' || isNaN(time) || !isFinite(time)) {
+    if (
+      !id ||
+      !category ||
+      typeof time !== 'number' ||
+      isNaN(time) ||
+      !isFinite(time) ||
+      time <= 0 ||
+      time > MAX_ELAPSED_SECONDS
+    ) {
       return {
         statusCode: 400,
         headers: { "Access-Control-Allow-Origin": "*" },
@@ -55,7 +66,7 @@ exports.recordTime = async (event) => {
     const oldReadCount = Item.readCount || 0;
     const oldAverageTime = Item.averageTime || 0;
     const oldAverageDifficulty = Item.averageDifficulty || 0;
-    
+
     const newReadCount = oldReadCount + 1;
     let newAverageTime = ((oldAverageTime * oldReadCount) + time) / newReadCount;
 

--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -609,4 +609,40 @@ describe('recordTime', () => {
         const response = await recordTime(event);
         expect(response.statusCode).toBe(400);
     });
+
+    it('should return 400 when time is zero', async () => {
+        const event = { body: JSON.stringify({ id: 'p1', category: 'c1', time: 0 }) };
+        const response = await recordTime(event);
+        expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 when time is negative', async () => {
+        const event = { body: JSON.stringify({ id: 'p1', category: 'c1', time: -5 }) };
+        const response = await recordTime(event);
+        expect(response.statusCode).toBe(400);
+    });
+
+    it('should accept time exactly at the abnormal-value cap boundary and update the average', async () => {
+        ddbMock.on(GetCommand).resolves({
+            Item: { id: 'p1', category: 'c1', readCount: 0, averageTime: 0 }
+        });
+        ddbMock.on(UpdateCommand).resolves({});
+
+        const event = { body: JSON.stringify({ id: 'p1', category: 'c1', time: 300 }) };
+        const response = await recordTime(event);
+        expect(response.statusCode).toBe(200);
+
+        const updateParams = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+        expect(updateParams.ExpressionAttributeValues[':at']).toBe(300);
+    });
+
+    it('should reject (400) time above the abnormal-value cap without writing to DynamoDB, so readCount/averageTime stay consistent (e.g. left idle for hours)', async () => {
+        const event = { body: JSON.stringify({ id: 'p1', category: 'c1', time: 21673.39 }) };
+        const response = await recordTime(event);
+        expect(response.statusCode).toBe(400);
+        // readCountとaverageTimeが常に対応するサンプル数を保つよう、
+        // 異常値のときはDB書き込み自体を行わない（部分更新はしない）
+        expect(ddbMock.commandCalls(GetCommand).length).toBe(0);
+        expect(ddbMock.commandCalls(UpdateCommand).length).toBe(0);
+    });
 });

--- a/backend/reset-stats.js
+++ b/backend/reset-stats.js
@@ -1,0 +1,50 @@
+const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
+const { DynamoDBDocumentClient, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
+
+const client = new DynamoDBClient({ region: "ap-northeast-1" });
+const docClient = DynamoDBDocumentClient.from(client);
+
+const TABLE_NAME = "karuta-phrases";
+
+// 放置等で読み上げ統計（readCount/averageTime/averageDifficulty）に異常値が
+// 混入してしまったフレーズを、手動でリセットするための保守スクリプト。
+// 使い方: node reset-stats.js <category> <id>
+async function resetStats(category, id) {
+  if (!category || !id) {
+    console.error("使い方: node reset-stats.js <category> <id>");
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Resetting stats for category="${category}" id="${id}"...`);
+  try {
+    await docClient.send(new UpdateCommand({
+      TableName: TABLE_NAME,
+      Key: { category, id },
+      // カテゴリ/IDの入力ミスで存在しない項目を新規作成してしまわないようにする
+      ConditionExpression: "attribute_exists(category)",
+      UpdateExpression: "set readCount = :zero, averageTime = :zero, averageDifficulty = :zero",
+      ExpressionAttributeValues: { ":zero": 0 },
+    }));
+    console.log("Reset complete.");
+  } catch (error) {
+    if (error.name === "ConditionalCheckFailedException") {
+      console.error(`指定されたフレーズが見つかりません: category="${category}" id="${id}"`);
+      process.exitCode = 1;
+      return;
+    }
+    throw error;
+  }
+}
+
+module.exports = { resetStats };
+
+/* c8 ignore start */
+if (require.main === module) {
+  const [, , category, id] = process.argv;
+  resetStats(category, id).catch((error) => {
+    console.error("Reset failed:", error);
+    process.exitCode = 1;
+  });
+}
+/* c8 ignore stop */

--- a/backend/reset-stats.test.js
+++ b/backend/reset-stats.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { resetStats } from './reset-stats';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+describe('resetStats', () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    process.exitCode = 0;
+  });
+
+  it('resets readCount/averageTime/averageDifficulty to 0 for the given category and id', async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+
+    await resetStats('c1', 'p1');
+
+    const calls = ddbMock.commandCalls(UpdateCommand);
+    expect(calls.length).toBe(1);
+    const input = calls[0].args[0].input;
+    expect(input.Key).toEqual({ category: 'c1', id: 'p1' });
+    expect(input.ExpressionAttributeValues[':zero']).toBe(0);
+    expect(input.UpdateExpression).toContain('readCount = :zero');
+    expect(input.UpdateExpression).toContain('averageTime = :zero');
+    expect(input.UpdateExpression).toContain('averageDifficulty = :zero');
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('does not call DynamoDB and sets a non-zero exit code when category or id is missing', async () => {
+    await resetStats(undefined, 'p1');
+
+    expect(ddbMock.commandCalls(UpdateCommand).length).toBe(0);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('reports a clear error instead of creating a stray item when category/id do not match an existing phrase', async () => {
+    const error = new Error('The conditional request failed');
+    error.name = 'ConditionalCheckFailedException';
+    ddbMock.on(UpdateCommand).rejects(error);
+
+    await resetStats('typo-category', 'p1');
+
+    expect(process.exitCode).toBe(1);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('typo-category'));
+  });
+
+  it('rethrows unexpected errors', async () => {
+    ddbMock.on(UpdateCommand).rejects(new Error('network error'));
+
+    await expect(resetStats('c1', 'p1')).rejects.toThrow('network error');
+  });
+});


### PR DESCRIPTION
## 概要
Closes #132

タブを開いたまま放置する等で発生する異常に大きい経過時間（例: 21673.39秒）が、そのままフレーズの`averageTime`/`averageDifficulty`に永続的に混入していました。

## 変更内容
- `recordTime`のバリデーションに `time <= 0` および `time > 300秒` の上限チェックを追加。範囲外の場合はDB書き込みを一切行わず400を返します。
- 既に汚染されてしまったフレーズの統計を手動でリセットするための保守スクリプト `backend/reset-stats.js` を追加（`node reset-stats.js <category> <id>`）。カテゴリ/IDの入力ミスで空の不正レコードを作成しないよう`ConditionExpression`で存在チェックを行います。

## 設計上の判断
最初は「readCountだけ加算し、平均値の更新はスキップする」設計を検討しましたが、コードレビューで、加重平均の計算式が`oldReadCount`を「平均を構成した実サンプル数」として前提にしているため、readCountだけ加算すると以降の正常な記録の平均値まで永続的に歪ませてしまう重大な副作用が判明したため撤回しました。最終的に「異常値は丸ごと拒否し、DB書き込み自体を行わない」というシンプルで不変条件を壊さない設計にしています。

## テスト
- `time<=0`・上限超過・境界値(300)の各ケースを追加し、上限超過時にGetCommand/UpdateCommandが一切呼ばれないこと（部分更新をしないこと）を検証しました。
- `reset-stats.js`用のテストを新規追加し、正常リセット・引数不足・対象不在・想定外エラーの再スローを検証しました。