### PR TITLE
fix(handler): 読み札本文のSSML未エスケープとspeechRateの検証不足を修正

### DIFF
--- a/backend/handler.js
+++ b/backend/handler.js
@@ -14,8 +14,12 @@ function escapeSsml(text) {
     .replace(/>/g, "&gt;");
 }
 
+// SSMLのprosody rate属性としてPollyが受け付けるキーワード
+const ALLOWED_SPEECH_RATE_KEYWORDS = ["x-slow", "slow", "medium", "fast", "x-fast"];
+const DEFAULT_SPEECH_RATE = "90%";
+
 function normalizeSpeechRate(rate) {
-  if (!rate) return "90%";
+  if (!rate) return DEFAULT_SPEECH_RATE;
   const rateStr = String(rate);
   if (/^\d/.test(rateStr)) {
     const num = parseInt(rateStr, 10);
@@ -23,7 +27,12 @@ function normalizeSpeechRate(rate) {
       return `${num}%`;
     }
   }
-  return rateStr;
+  if (ALLOWED_SPEECH_RATE_KEYWORDS.includes(rateStr)) {
+    return rateStr;
+  }
+  // 未知の値をそのままSSML属性に埋め込むとインジェクションの余地があるため、
+  // 許可されていない値は既定値にフォールバックする
+  return DEFAULT_SPEECH_RATE;
 }
 
 // タブを開いたまま放置する等で生じる異常値を統計に混入させないための経過時間の上限（秒）
@@ -322,7 +331,8 @@ exports.getPhrase = async (event) => {
       }
 
       const hasLevel = level !== "-" && level !== null && level !== undefined && String(level).trim() !== "";
-      const phraseWithLevel = hasLevel ? `${levelPrefix}, ${level}. ${speechPhrase}` : speechPhrase;
+      const escapedPhrase = escapeSsml(speechPhrase);
+      const phraseWithLevel = hasLevel ? `${levelPrefix}, ${escapeSsml(level)}. ${escapedPhrase}` : escapedPhrase;
 
       let innerContent = phraseWithLevel;
       if (repeatCount >= 2) {

--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -269,6 +269,36 @@ describe('getCongratulationAudio', () => {
         const pollyParams = pollyCalls[0].args[0].input;
         expect(pollyParams.Text).toContain('<prosody rate="120%">');
     });
+
+    it('should fall back to the default speechRate when given a value not on the allowlist (SSML injection attempt)', async () => {
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        // 数字始まりでない文字列を使い、キーワード許可リストのフォールバック分岐を確実に通す
+        const event = {
+            queryStringParameters: { lang: 'ja', speechRate: 'x-slow"/></prosody><speak>injected' },
+        };
+        await getCongratulationAudio(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.Text).toContain('<prosody rate="90%">');
+        expect(pollyParams.Text).not.toContain('injected');
+    });
+
+    it('should allow a known SSML rate keyword through unchanged', async () => {
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { lang: 'ja', speechRate: 'slow' } };
+        await getCongratulationAudio(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.Text).toContain('<prosody rate="slow">');
+    });
 });
 
 describe('getPhrase', () => {
@@ -385,6 +415,87 @@ describe('getPhrase', () => {
         expect(pollyCalls.length).toBe(1);
         const pollyParams = pollyCalls[0].args[0].input;
         expect(pollyParams.Text).toContain('<prosody rate="110%">');
+    });
+
+    it('should escape SSML special characters in the phrase text', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'c1', phrase: 'A & B <are> "friends"', level: '-' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        ddbMock.on(PutCommand).resolves({});
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1', repeatCount: '1' } };
+        await getPhrase(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.Text).toBe('<speak><prosody rate="90%">A &amp; B &lt;are&gt; "friends"</prosody></speak>');
+    });
+
+    it('should escape SSML special characters in the level text', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', level: '<injected>' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        ddbMock.on(PutCommand).resolves({});
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1', repeatCount: '1' } };
+        await getPhrase(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.Text).toContain('&lt;injected&gt;');
+        expect(pollyParams.Text).not.toContain('<injected>');
+    });
+
+    it('should fall back to the default speechRate when given a value not on the allowlist (SSML injection attempt)', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', level: '-' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        ddbMock.on(PutCommand).resolves({});
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        // 数字始まりでない文字列を使い、キーワード許可リストのフォールバック分岐を確実に通す
+        const event = {
+            queryStringParameters: { id: 'p1', speechRate: 'x-slow"/></prosody><speak>injected' },
+        };
+        await getPhrase(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.Text).toContain('<prosody rate="90%">');
+        expect(pollyParams.Text).not.toContain('injected');
+    });
+
+    it('should allow a known SSML rate keyword through unchanged', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', level: '-' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        ddbMock.on(PutCommand).resolves({});
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1', speechRate: 'slow' } };
+        await getPhrase(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.Text).toContain('<prosody rate="slow">');
     });
 
     it('should append the category once at the end when announceCategory is true', async () => {


### PR DESCRIPTION
## 概要
Closes #183

## 変更内容
- `getPhrase`でSSMLに埋め込む読み札本文（`speechPhrase`）とレベル（`level`）に`escapeSsml()`を適用しました。これまでは`category`にのみ適用されており、フレーズに`&`/`<`/`>`を含むとPolly合成が失敗する不具合がありました。
- `normalizeSpeechRate`の数字始まりでないフォールバック値を、Pollyのprosody rate属性が公式にサポートするキーワード（`x-slow`/`slow`/`medium`/`fast`/`x-fast`）のみを許可するアローリスト方式に変更しました。非該当の値は既定値（90%）にフォールバックし、`speechRate`クエリパラメータ経由でのSSML属性・タグ注入を防ぎます。

フロントエンドが実際に送信する`70%`/`80%`/`90%`/`100%`は従来通り数値解析されるため、既存の挙動に影響はありません。

## テスト
- フレーズ・レベルのSSMLエスケープ、`speechRate`のインジェクション試行に対するフォールバック（`getPhrase`・`getCongratulationAudio`両方）、既知キーワードの許可を検証するテストを追加しました。
- コードレビューで、最初に追加した「インジェクション試行」テストのペイロードが数字始まりだったため既存の数値解析分岐にしか掛からず、新設のアローリスト分岐を検証できていない不備が見つかったため、数字始まりでないペイロードに修正しています。アローリスト分岐を一時的に元の脆弱な実装に戻し、テストが実際に失敗することも確認済みです。