### PR TITLE
fix(handler): CORSをフロントエンドオリジンに制限しコメント長を検証

### DIFF
--- a/backend/handler.js
+++ b/backend/handler.js
@@ -7,6 +7,19 @@ const docClient = DynamoDBDocumentClient.from(dynamoClient);
 const pollyClient = new PollyClient({ region: "ap-northeast-1" });
 const crypto = require("crypto");
 
+// フロントエンド（GitHub Pages）およびローカル開発サーバーのオリジンのみ許可し、
+// CORSを介した第三者からの無制限なAPI呼び出し（Amazon Pollyの課金濫用等）を防ぐ
+const ALLOWED_ORIGINS = [
+  "https://bamiyanapp.github.io",
+  "http://localhost:5173", // npm run dev（Vite開発サーバー）
+  "http://localhost:4173", // npm run preview（Viteプレビューサーバー）
+];
+
+function resolveAllowedOrigin(event) {
+  const requestOrigin = event?.headers?.origin || event?.headers?.Origin;
+  return ALLOWED_ORIGINS.includes(requestOrigin) ? requestOrigin : ALLOWED_ORIGINS[0];
+}
+
 function escapeSsml(text) {
   return String(text)
     .replace(/&/g, "&amp;")
@@ -30,6 +43,7 @@ function normalizeSpeechRate(rate) {
 const MAX_ELAPSED_SECONDS = 300;
 
 exports.recordTime = async (event) => {
+  const allowedOrigin = resolveAllowedOrigin(event);
   try {
     const body = JSON.parse(event.body);
     const { id, category, time, difficulty } = body; // category, difficultyを追加
@@ -45,7 +59,7 @@ exports.recordTime = async (event) => {
     ) {
       return {
         statusCode: 400,
-        headers: { "Access-Control-Allow-Origin": "*" },
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
         body: JSON.stringify({ message: "Invalid input" }),
       };
     }
@@ -58,7 +72,7 @@ exports.recordTime = async (event) => {
     if (!Item) {
       return {
         statusCode: 404,
-        headers: { "Access-Control-Allow-Origin": "*" },
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
         body: JSON.stringify({ message: "Phrase not found" }),
       };
     }
@@ -99,28 +113,37 @@ exports.recordTime = async (event) => {
 
     return {
       statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
       body: JSON.stringify({ message: "Time recorded successfully" }),
     };
   } catch (error) {
     console.error(error);
     return {
       statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
       body: JSON.stringify({ message: "Internal Server Error" }),
     };
   }
 }
 
+// コメントの過大な長さによるスパム・ストレージ濫用を防ぐための上限
+const MAX_COMMENT_LENGTH = 1000;
+
 exports.postComment = async (event) => {
+  const allowedOrigin = resolveAllowedOrigin(event);
   try {
     const body = JSON.parse(event.body);
     const { phraseId, category, phrase, comment } = body;
 
-    if (!phraseId || !comment) {
+    if (
+      !phraseId ||
+      !comment ||
+      typeof comment !== 'string' ||
+      comment.length > MAX_COMMENT_LENGTH
+    ) {
       return {
         statusCode: 400,
-        headers: { "Access-Control-Allow-Origin": "*" },
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
         body: JSON.stringify({ message: "Invalid input" }),
       };
     }
@@ -141,20 +164,21 @@ exports.postComment = async (event) => {
 
     return {
       statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
       body: JSON.stringify({ message: "Comment posted successfully" }),
     };
   } catch (error) {
     console.error(error);
     return {
       statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
       body: JSON.stringify({ message: "Internal Server Error" }),
     };
   }
 };
 
 exports.getComments = async (event) => {
+  const allowedOrigin = resolveAllowedOrigin(event);
   try {
     const scanParams = {
       TableName: process.env.COMMENTS_TABLE_NAME,
@@ -166,20 +190,21 @@ exports.getComments = async (event) => {
 
     return {
       statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
       body: JSON.stringify({ comments: items }),
     };
   } catch (error) {
     console.error(error);
     return {
       statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
       body: JSON.stringify({ message: "Internal Server Error" }),
     };
   }
 };
 
 exports.getCongratulationAudio = async (event) => {
+  const allowedOrigin = resolveAllowedOrigin(event);
   try {
     const params = event.queryStringParameters || {};
     const rawSpeechRate = params.speechRate || "90%";
@@ -213,7 +238,7 @@ exports.getCongratulationAudio = async (event) => {
     return {
       statusCode: 200,
       headers: {
-        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Origin": allowedOrigin,
         "Access-Control-Allow-Credentials": true,
       },
       body: JSON.stringify({
@@ -224,13 +249,14 @@ exports.getCongratulationAudio = async (event) => {
     console.error(error);
     return {
       statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
       body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
     };
   }
 };
 
 exports.getPhrase = async (event) => {
+  const allowedOrigin = resolveAllowedOrigin(event);
   try {
     const params = event.queryStringParameters || {};
     const category = params.category || null;
@@ -281,7 +307,7 @@ exports.getPhrase = async (event) => {
     if (!selectedItem) {
       return {
         statusCode: 404,
-        headers: { "Access-Control-Allow-Origin": "*" },
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
         body: JSON.stringify({ message: "Phrase not found" }),
       };
     }
@@ -378,7 +404,7 @@ exports.getPhrase = async (event) => {
     return {
       statusCode: 200,
       headers: {
-        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Origin": allowedOrigin,
         "Access-Control-Allow-Credentials": true,
       },
       body: JSON.stringify(responseBody),
@@ -387,13 +413,14 @@ exports.getPhrase = async (event) => {
     console.error(error);
     return {
       statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
       body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
     };
   }
 };
 
 exports.getPhrasesList = async (event) => {
+  const allowedOrigin = resolveAllowedOrigin(event);
   try {
     const category = event.queryStringParameters ? event.queryStringParameters.category : null;
     let items = [];
@@ -426,20 +453,21 @@ exports.getPhrasesList = async (event) => {
 
     return {
       statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
       body: JSON.stringify({ phrases: items }),
     };
   } catch (error) {
     console.error(error);
     return {
       statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
       body: JSON.stringify({ message: "Internal Server Error" }),
     };
   }
 };
 
 exports.getCategories = async (event) => {
+  const allowedOrigin = resolveAllowedOrigin(event);
   try {
     const scanParams = {
       TableName: process.env.TABLE_NAME,
@@ -467,7 +495,7 @@ exports.getCategories = async (event) => {
     return {
       statusCode: 200,
       headers: {
-        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Origin": allowedOrigin,
         "Access-Control-Allow-Credentials": true,
       },
       body: JSON.stringify({ categories }),
@@ -476,7 +504,7 @@ exports.getCategories = async (event) => {
     console.error(error);
     return {
       statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
       body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
     };
   }

--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -202,6 +202,101 @@ describe('postComment', () => {
         expect(response.statusCode).toBe(400);
     });
 
+    it('should return 400 when comment exceeds the maximum length', async () => {
+        const event = {
+            body: JSON.stringify({
+                phraseId: 'p1',
+                category: 'c1',
+                phrase: 'phrase 1',
+                comment: 'a'.repeat(1001),
+            }),
+        };
+        const response = await postComment(event);
+        expect(response.statusCode).toBe(400);
+        expect(ddbMock.commandCalls(PutCommand).length).toBe(0);
+    });
+
+    it('should accept a comment exactly at the maximum length', async () => {
+        ddbMock.on(PutCommand).resolves({});
+        const event = {
+            body: JSON.stringify({
+                phraseId: 'p1',
+                category: 'c1',
+                phrase: 'phrase 1',
+                comment: 'a'.repeat(1000),
+            }),
+        };
+        const response = await postComment(event);
+        expect(response.statusCode).toBe(200);
+    });
+
+    it('should return 400 when comment is not a string', async () => {
+        const event = {
+            body: JSON.stringify({ phraseId: 'p1', category: 'c1', phrase: 'phrase 1', comment: 12345 }),
+        };
+        const response = await postComment(event);
+        expect(response.statusCode).toBe(400);
+    });
+
+    it('should only allow the configured frontend origin in CORS headers', async () => {
+        ddbMock.on(PutCommand).resolves({});
+        const event = {
+            body: JSON.stringify({
+                phraseId: 'p1',
+                category: 'c1',
+                phrase: 'phrase 1',
+                comment: 'This is a comment',
+            }),
+        };
+        const response = await postComment(event);
+        expect(response.headers['Access-Control-Allow-Origin']).toBe('https://bamiyanapp.github.io');
+    });
+
+    it('should reflect the local dev server origin so `npm run dev` against the deployed API keeps working', async () => {
+        ddbMock.on(PutCommand).resolves({});
+        const event = {
+            headers: { origin: 'http://localhost:5173' },
+            body: JSON.stringify({
+                phraseId: 'p1',
+                category: 'c1',
+                phrase: 'phrase 1',
+                comment: 'This is a comment',
+            }),
+        };
+        const response = await postComment(event);
+        expect(response.headers['Access-Control-Allow-Origin']).toBe('http://localhost:5173');
+    });
+
+    it('should not reflect an untrusted origin, falling back to the production origin', async () => {
+        ddbMock.on(PutCommand).resolves({});
+        const event = {
+            headers: { origin: 'https://evil.example.com' },
+            body: JSON.stringify({
+                phraseId: 'p1',
+                category: 'c1',
+                phrase: 'phrase 1',
+                comment: 'This is a comment',
+            }),
+        };
+        const response = await postComment(event);
+        expect(response.headers['Access-Control-Allow-Origin']).toBe('https://bamiyanapp.github.io');
+    });
+
+    it('should also read a capitalized Origin header (some proxy integrations do not lowercase it)', async () => {
+        ddbMock.on(PutCommand).resolves({});
+        const event = {
+            headers: { Origin: 'http://localhost:5173' },
+            body: JSON.stringify({
+                phraseId: 'p1',
+                category: 'c1',
+                phrase: 'phrase 1',
+                comment: 'This is a comment',
+            }),
+        };
+        const response = await postComment(event);
+        expect(response.headers['Access-Control-Allow-Origin']).toBe('http://localhost:5173');
+    });
+
     it('should handle errors', async () => {
         ddbMock.on(PutCommand).rejects(new Error('DynamoDB error'));
         const event = {

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -31,6 +31,10 @@ custom:
   tableName: karuta-phrases
   commentsTableName: karuta-comments
   pollyCacheTableName: karuta-polly-cache # 追加
+  allowedOrigins:
+    - https://bamiyanapp.github.io
+    - http://localhost:5173 # npm run dev（Vite開発サーバー）
+    - http://localhost:4173 # npm run preview（Viteプレビューサーバー）
 
 functions:
   getPhrase:
@@ -39,49 +43,56 @@ functions:
       - http:
           path: get-phrase
           method: get
-          cors: true
+          cors:
+            origins: ${self:custom.allowedOrigins}
   getCategories:
     handler: handler.getCategories
     events:
       - http:
           path: get-categories
           method: get
-          cors: true
+          cors:
+            origins: ${self:custom.allowedOrigins}
   getCongratulationAudio:
     handler: handler.getCongratulationAudio
     events:
       - http:
           path: get-congratulation-audio
           method: get
-          cors: true
+          cors:
+            origins: ${self:custom.allowedOrigins}
   getPhrasesList:
     handler: handler.getPhrasesList
     events:
       - http:
           path: get-phrases-list
           method: get
-          cors: true
+          cors:
+            origins: ${self:custom.allowedOrigins}
   postComment:
     handler: handler.postComment
     events:
       - http:
           path: post-comment
           method: post
-          cors: true
+          cors:
+            origins: ${self:custom.allowedOrigins}
   getComments:
     handler: handler.getComments
     events:
       - http:
           path: get-comments
           method: get
-          cors: true
+          cors:
+            origins: ${self:custom.allowedOrigins}
   recordTime:
     handler: handler.recordTime
     events:
       - http:
           path: record-time
           method: post
-          cors: true
+          cors:
+            origins: ${self:custom.allowedOrigins}
 
 resources:
   Resources:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -766,12 +766,13 @@ function App() {
               <h2 className="h5 fw-bold mb-3 text-dark">かるたの誤りを指摘する</h2>
               <form onSubmit={postComment}>
                   <div className="mb-3">
-                    <textarea 
-                      className="form-control rounded-3" 
-                      rows="3" 
+                    <textarea
+                      className="form-control rounded-3"
+                      rows="3"
                       placeholder="例：かなが間違っている、フレーズが違うなど"
                       value={commentText}
                       onChange={(e) => setCommentText(e.target.value)}
+                      maxLength={1000}
                       required
                     ></textarea>
                   </div>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -659,6 +659,10 @@ describe('App', () => {
       expect(screen.getByText('回答A')).toBeInTheDocument();
     });
 
+    // バックエンドの上限(1000文字)と揃え、送信後に拒否される体験を防ぐ
+    const commentTextarea = screen.getByPlaceholderText('例：かなが間違っている、フレーズが違うなど');
+    expect(commentTextarea).toHaveAttribute('maxlength', '1000');
+
     randomSpy.mockRestore();
   }, 15000);
 


### PR DESCRIPTION
## 概要
Closes #184

## 変更内容
- `Access-Control-Allow-Origin`をワイルドカード（`*`）から、本番フロントエンド（`https://bamiyanapp.github.io`）およびローカル開発サーバー（`http://localhost:5173`/`4173`）のみを許可するアローリスト方式に変更しました。リクエストの`Origin`ヘッダーを照合し、許可リストに一致すればそれを反映、しなければ本番オリジンにフォールバックします。
- `serverless.yml`の各関数の`cors`設定も同じオリジン一覧を許可するよう更新しました。
- `postComment`にコメント長（1000文字）と型チェックを追加し、フロントエンドの投稿フォームにも同じ上限の`maxLength`を設定しました。

## 実装中に気づいた点
`frontend/src/App.jsx`の`API_BASE_URL`はローカル開発用ではなく、実際にデプロイ済みのAWS API Gatewayを指しています。つまり`npm run dev`でのローカル動作確認は本番バックエンドに対して行う運用になっており、オリジンを本番の1つだけに固定すると、この既存の開発フローがCORSエラーで壊れてしまうことがわかりました。そのため、単純な固定オリジンではなく、許可リスト＋リクエストごとの反映方式に設計を変更しています。

## スコープ外にしたもの
API Gatewayの使用量プラン・APIキーによるスロットリングは含めていません。この環境からは実際のAWSデプロイを検証できず、CloudFormationリソースの設定ミスがCD経由の`serverless deploy`自体を壊すリスクがあるため見送りました。また、CORS制限はブラウザの同一オリジンポリシーに基づくものであり、curl等の非ブラウザクライアントによる直接呼び出しには効果がありません。Amazon Pollyの課金濫用という核心的なリスクへの対策は依然として必要で、別Issューとして切り出すのが適切と考えます。

## テスト
- コメント長上限・型チェック・CORSオリジンの反映（本番/localhost/未許可オリジン/大文字Originヘッダー）を検証するテストを追加しました。
- フロントエンドのtextareaの`maxLength`属性を検証するテストを追加しました。