### PR TITLE
fix(ci): sync-releaseジョブのchangelog.jsonマージコンフリクトを解消

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# frontend/src/changelog.json は semantic-release が release ブランチ上でのみ
+# 生成する成果物であり、main 側の内容は sync PR 経由の副産物に過ぎない。
+# release と main のマージ時に不要なコンフリクトを起こさないよう、
+# 常に現在のブランチ（マージ先）側の内容を優先する。
+frontend/src/changelog.json merge=ours

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,6 +47,12 @@ jobs:
           if [ "$MAIN_HEAD" != "$RELEASE_HEAD" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
+            # frontend/src/changelog.json は release 専用の生成物であり release 側の内容を常に優先する。
+            # リポジトリの .gitattributes は release ブランチに反映されるまで有効にならないため、
+            # ローカルの属性ファイルを直接指定してこの実行から即時に効かせる。
+            echo "frontend/src/changelog.json merge=ours" > "$RUNNER_TEMP/karuta-merge.gitattributes"
+            git config core.attributesFile "$RUNNER_TEMP/karuta-merge.gitattributes"
+            git config merge.ours.driver true
             git merge --no-ff origin/main -m "Chore: Merge main into release"
             git push origin release
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,12 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          # frontend/src/changelog.json は release 専用の生成物であり release 側の内容を常に優先する。
+          # リポジトリの .gitattributes は release ブランチに反映されるまで有効にならないため、
+          # ローカルの属性ファイルを直接指定してこの実行から即時に効かせる。
+          echo "frontend/src/changelog.json merge=ours" > "$RUNNER_TEMP/karuta-merge.gitattributes"
+          git config --global core.attributesFile "$RUNNER_TEMP/karuta-merge.gitattributes"
+          git config --global merge.ours.driver true
           git fetch --tags origin
           # ローカル release にチェックアウト
           git checkout release


### PR DESCRIPTION
## Summary
- `frontend/src/changelog.json` は semantic-release が `release` ブランチ上でのみ生成する成果物で、`main` 側の内容は sync PR 経由の副産物に過ぎないが、生成スクリプトの日時計算がタグ取得状況で変動するため、`main`/`release` の内容が食い違い `sync-release` ジョブが継続的に失敗していた
- `ci.yml` / `cd.yml` のマージ処理で `frontend/src/changelog.json` に `merge=ours` driver を適用し、release↔main 同期時は常に release 側の内容を採用するようにした（コミット済みの `.gitattributes` はまだ release ブランチに伝播していないため、ワークフロー実行時に `core.attributesFile` を都度指定して次回実行から即時に効かせている）

## Test plan
- [x] ローカルでリポジトリを複製し、ci.yml/cd.yml と同じgit操作（`core.attributesFile` 指定 + `merge.ours.driver` 設定 + `git merge`）を再現し、従来発生していた `changelog.json` のコンフリクトが解消されることを確認
- [x] frontend: lint / test / build 成功
- [x] backend: test 成功（lint/buildスクリプトは元々存在せず対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)