### PR TITLE
fix(app): record-time送信失敗時にエラーハンドリングを追加

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -453,6 +453,8 @@ function App() {
             time: elapsedTime,
             difficulty: difficulty,
           }),
+        }).catch((error) => {
+          console.error("Error recording time:", error);
         });
       }
       startTimeRef.current = null;

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -967,4 +967,56 @@ describe('App', () => {
     expect(body.time).toBeGreaterThan(2);
   }, 15000);
 
+  it('logs an error instead of throwing an unhandled rejection when record-time fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      }
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({
+            phrases: [
+              { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-' },
+              { id: 'p2', category: 'Cat1', kana: 'い', phrase: '読み札2', level: '-' },
+            ],
+          }),
+        };
+      }
+      if (url.includes('/get-phrase?')) {
+        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', audioData: 'dummy' }) };
+      }
+      if (url.includes('/record-time')) {
+        return Promise.reject(new Error('network error'));
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    fireEvent.click(screen.getByText(/決定/));
+    fireEvent.click(screen.getByText('はい'));
+
+    await waitFor(() => screen.getByText('次の札'));
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(screen.getByText('読み札1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+    }, { timeout: 8000 });
+
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error recording time:', expect.any(Error));
+    });
+
+    consoleErrorSpy.mockRestore();
+  }, 15000);
+
 });


### PR DESCRIPTION
## Summary
- `record-time` へのfetchに `.catch` を追加し、通信失敗時にunhandled rejectionとなっていた問題を解消（Issue #192）
- 失敗時はconsole.errorでログを残すのみとし、ユーザー体験（ゲーム進行）をブロックしない

## Test plan
- [x] frontend: lint / test / build 実行、エラー0件
- [x] backend: test 実行、エラー0件（本PRはbackendへの変更なし）
- [x] record-time失敗時にconsole.errorが呼ばれ、unhandled rejectionにならないことを検証するテストを追加

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)