### PR TITLE
fix(handler): recordTimeの読み書きを非アトミックな平均計算からADD加算方式に修正

### DIFF
--- a/backend/backfill-total-stats.js
+++ b/backend/backfill-total-stats.js
@@ -1,0 +1,77 @@
+const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
+const { DynamoDBDocumentClient, ScanCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
+
+const client = new DynamoDBClient({ region: "ap-northeast-1" });
+const docClient = DynamoDBDocumentClient.from(client);
+
+const TABLE_NAME = "karuta-phrases";
+
+// recordTimeを非アトミックな平均計算からDynamoDBのADDによる合計値（totalTime/totalDifficulty）
+// 加算方式に変更したことに伴い、既存アイテムのaverageTime/averageDifficulty（平均値）から
+// totalTime/totalDifficulty（合計値）を一度だけ逆算して補完するための移行スクリプト。
+//
+// 重要: 新しいrecordTime（ADD方式）をデプロイする前、もしくはトラフィックが無い時間帯に
+// 一度だけ実行すること。デプロイ後・本番トラフィックがある状態で実行した場合、
+// このスクリプトが対象アイテムをScanしてから実際にUpdateするまでの間にrecordTimeの
+// ADDが先に走っていると、そのアイテムはtotalTime/totalDifficultyが既に存在するため
+// スキップされる（ConditionExpressionにより上書きはしない＝同時書き込みの消失は防ぐが、
+// そのアイテムの移行前の履歴はtotalTimeに反映されないまま残る）。
+// 使い方: node backfill-total-stats.js
+async function backfillTotalStats() {
+  let updatedCount = 0;
+  let skippedCount = 0;
+  let exclusiveStartKey;
+
+  do {
+    const scanResult = await docClient.send(new ScanCommand({
+      TableName: TABLE_NAME,
+      ExclusiveStartKey: exclusiveStartKey,
+    }));
+    const items = scanResult.Items || [];
+
+    for (const item of items) {
+      if (typeof item.totalTime === "number" && typeof item.totalDifficulty === "number") {
+        continue;
+      }
+
+      const readCount = item.readCount || 0;
+      const totalTime = (item.averageTime || 0) * readCount;
+      const totalDifficulty = (item.averageDifficulty || 0) * readCount;
+
+      try {
+        await docClient.send(new UpdateCommand({
+          TableName: TABLE_NAME,
+          Key: { category: item.category, id: item.id },
+          // Scan時点から実際の更新までの間にrecordTimeのADDが先に走っていた場合、
+          // このUpdateで上書きしてライブトラフィックの記録を消してしまわないようにする
+          ConditionExpression: "attribute_not_exists(totalTime)",
+          UpdateExpression: "set totalTime = :tt, totalDifficulty = :td",
+          ExpressionAttributeValues: { ":tt": totalTime, ":td": totalDifficulty },
+        }));
+        updatedCount++;
+      } catch (error) {
+        if (error.name === "ConditionalCheckFailedException") {
+          skippedCount++;
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    exclusiveStartKey = scanResult.LastEvaluatedKey;
+  } while (exclusiveStartKey);
+
+  console.log(`Backfilled totalTime/totalDifficulty for ${updatedCount} item(s), skipped ${skippedCount} item(s) already updated by live traffic.`);
+  return updatedCount;
+}
+
+module.exports = { backfillTotalStats };
+
+/* c8 ignore start */
+if (require.main === module) {
+  backfillTotalStats().catch((error) => {
+    console.error("Backfill failed:", error);
+    process.exitCode = 1;
+  });
+}
+/* c8 ignore stop */

--- a/backend/backfill-total-stats.test.js
+++ b/backend/backfill-total-stats.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { DynamoDBDocumentClient, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { backfillTotalStats } from './backfill-total-stats';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+describe('backfillTotalStats', () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  it('derives totalTime/totalDifficulty from averageTime/averageDifficulty * readCount for items missing the totals', async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        { id: 'p1', category: 'c1', readCount: 5, averageTime: 10, averageDifficulty: 2 },
+      ],
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+
+    const updatedCount = await backfillTotalStats();
+
+    expect(updatedCount).toBe(1);
+    const updateParams = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateParams.Key).toEqual({ category: 'c1', id: 'p1' });
+    expect(updateParams.ConditionExpression).toBe('attribute_not_exists(totalTime)');
+    expect(updateParams.ExpressionAttributeValues[':tt']).toBe(50);
+    expect(updateParams.ExpressionAttributeValues[':td']).toBe(10);
+  });
+
+  it('follows LastEvaluatedKey to migrate every page of a multi-page Scan', async () => {
+    ddbMock.on(ScanCommand)
+      .resolvesOnce({
+        Items: [{ id: 'p1', category: 'c1', readCount: 5, averageTime: 10, averageDifficulty: 2 }],
+        LastEvaluatedKey: { category: 'c1', id: 'p1' },
+      })
+      .resolvesOnce({
+        Items: [{ id: 'p2', category: 'c1', readCount: 3, averageTime: 4, averageDifficulty: 1 }],
+      });
+    ddbMock.on(UpdateCommand).resolves({});
+
+    const updatedCount = await backfillTotalStats();
+
+    expect(updatedCount).toBe(2);
+    const scanCalls = ddbMock.commandCalls(ScanCommand);
+    expect(scanCalls.length).toBe(2);
+    expect(scanCalls[1].args[0].input.ExclusiveStartKey).toEqual({ category: 'c1', id: 'p1' });
+    const updatedIds = ddbMock.commandCalls(UpdateCommand).map(call => call.args[0].input.Key.id);
+    expect(updatedIds).toEqual(['p1', 'p2']);
+  });
+
+  it('skips (without throwing) an item that live traffic already wrote totalTime for between the Scan and the Update', async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [{ id: 'p1', category: 'c1', readCount: 5, averageTime: 10, averageDifficulty: 2 }],
+    });
+    const conditionalError = new Error('The conditional request failed');
+    conditionalError.name = 'ConditionalCheckFailedException';
+    ddbMock.on(UpdateCommand).rejects(conditionalError);
+
+    const updatedCount = await backfillTotalStats();
+
+    expect(updatedCount).toBe(0);
+  });
+
+  it('treats an unread item (readCount 0) as having zero totals', async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [{ id: 'p1', category: 'c1', readCount: 0 }],
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+
+    await backfillTotalStats();
+
+    const updateParams = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateParams.ExpressionAttributeValues[':tt']).toBe(0);
+    expect(updateParams.ExpressionAttributeValues[':td']).toBe(0);
+  });
+
+  it('skips items that already have totalTime/totalDifficulty (idempotent re-run)', async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [{ id: 'p1', category: 'c1', readCount: 5, totalTime: 50, totalDifficulty: 10 }],
+    });
+
+    const updatedCount = await backfillTotalStats();
+
+    expect(updatedCount).toBe(0);
+    expect(ddbMock.commandCalls(UpdateCommand).length).toBe(0);
+  });
+});

--- a/backend/handler.js
+++ b/backend/handler.js
@@ -27,6 +27,29 @@ function escapeSsml(text) {
     .replace(/>/g, "&gt;");
 }
 
+// recordTimeがtotalTime/totalDifficulty（合計値）をADDで積み上げる方式のため、
+// 表示側で平均値（averageTime/averageDifficulty）を都度計算する。
+// totalTime/totalDifficultyが無い（移行前の）アイテムは、既存のaverageTime/averageDifficultyを
+// そのまま使う（後方互換）。
+function safeAverage(total, readCount, legacyAverage) {
+  if (readCount > 0 && typeof total === "number") {
+    const average = total / readCount;
+    return isNaN(average) || !isFinite(average) ? 0 : average;
+  }
+  return legacyAverage || 0;
+}
+
+function computePhraseStats(item) {
+  if (typeof item.totalTime !== "number" && typeof item.totalDifficulty !== "number") {
+    return item;
+  }
+  const { totalTime, totalDifficulty, ...rest } = item;
+  const readCount = item.readCount || 0;
+  const averageTime = safeAverage(totalTime, readCount, item.averageTime);
+  const averageDifficulty = safeAverage(totalDifficulty, readCount, item.averageDifficulty);
+  return { ...rest, averageTime, averageDifficulty };
+}
+
 // SSMLのprosody rate属性としてPollyが受け付けるキーワード
 const ALLOWED_SPEECH_RATE_KEYWORDS = ["x-slow", "slow", "medium", "fast", "x-fast"];
 const DEFAULT_SPEECH_RATE = "90%";
@@ -51,6 +74,10 @@ function normalizeSpeechRate(rate) {
 // タブを開いたまま放置する等で生じる異常値を統計に混入させないための経過時間の上限（秒）
 const MAX_ELAPSED_SECONDS = 300;
 
+// readCount/averageTime/averageDifficultyはGetItemで読んだ値を元にアプリ側で平均を
+// 計算してからUpdateItemする方式だと、複数端末からの同時リクエストで競合し値がずれる。
+// そのため合計値（totalTime, totalDifficulty）とreadCountをDynamoDBのADDで加算し、
+// 表示側（getPhrase/getPhrasesList）で平均を計算する方式にすることでアトミックに更新する。
 exports.recordTime = async (event) => {
   const allowedOrigin = resolveAllowedOrigin(event);
   try {
@@ -73,52 +100,36 @@ exports.recordTime = async (event) => {
       };
     }
 
-    const { Item } = await docClient.send(new GetCommand({
-      TableName: process.env.TABLE_NAME,
-      Key: { category, id },
-    }));
-
-    if (!Item) {
-      return {
-        statusCode: 404,
-        headers: { "Access-Control-Allow-Origin": allowedOrigin },
-        body: JSON.stringify({ message: "Phrase not found" }),
-      };
-    }
-
-    const oldReadCount = Item.readCount || 0;
-    const oldAverageTime = Item.averageTime || 0;
-    const oldAverageDifficulty = Item.averageDifficulty || 0;
-
-    const newReadCount = oldReadCount + 1;
-    let newAverageTime = ((oldAverageTime * oldReadCount) + time) / newReadCount;
-
-    // 数値の健全性チェック
-    if (isNaN(newAverageTime) || !isFinite(newAverageTime)) {
-        newAverageTime = time;
-    }
-
-    let updateExpression = "set readCount = :rc, averageTime = :at";
+    let updateExpression = "ADD readCount :one, totalTime :time";
     let expressionAttributeValues = {
-      ":rc": newReadCount,
-      ":at": newAverageTime,
+      ":one": 1,
+      ":time": time,
     };
 
     if (typeof difficulty === 'number' && !isNaN(difficulty) && isFinite(difficulty)) {
-      let newAverageDifficulty = ((oldAverageDifficulty * oldReadCount) + difficulty) / newReadCount;
-      if (isNaN(newAverageDifficulty) || !isFinite(newAverageDifficulty)) {
-        newAverageDifficulty = difficulty;
-      }
-      updateExpression += ", averageDifficulty = :ad";
-      expressionAttributeValues[":ad"] = newAverageDifficulty;
+      updateExpression += ", totalDifficulty :difficulty";
+      expressionAttributeValues[":difficulty"] = difficulty;
     }
 
-    await docClient.send(new UpdateCommand({
-      TableName: process.env.TABLE_NAME,
-      Key: { category, id },
-      UpdateExpression: updateExpression,
-      ExpressionAttributeValues: expressionAttributeValues,
-    }));
+    try {
+      await docClient.send(new UpdateCommand({
+        TableName: process.env.TABLE_NAME,
+        Key: { category, id },
+        // カテゴリ/IDの入力ミスで存在しない項目を新規作成してしまわないようにする
+        ConditionExpression: "attribute_exists(id)",
+        UpdateExpression: updateExpression,
+        ExpressionAttributeValues: expressionAttributeValues,
+      }));
+    } catch (error) {
+      if (error.name === "ConditionalCheckFailedException") {
+        return {
+          statusCode: 404,
+          headers: { "Access-Control-Allow-Origin": allowedOrigin },
+          body: JSON.stringify({ message: "Phrase not found" }),
+        };
+      }
+      throw error;
+    }
 
     return {
       statusCode: 200,
@@ -290,7 +301,7 @@ exports.getPhrase = async (event) => {
       // それ以外は従来通りScan（またはQueryに最適化可能だが一旦Scan）
       const scanParams = {
         TableName: process.env.TABLE_NAME,
-        ProjectionExpression: "id, category, phrase, #lvl, kana, phrase_en, answer, readCount, averageTime, averageDifficulty",
+        ProjectionExpression: "id, category, phrase, #lvl, kana, phrase_en, answer, readCount, averageTime, averageDifficulty, totalTime, totalDifficulty",
         ExpressionAttributeNames: {
           "#lvl": "level",
         },
@@ -397,6 +408,7 @@ exports.getPhrase = async (event) => {
       }
     }
 
+    const stats = computePhraseStats(selectedItem);
     const responseBody = {
       id: selectedItem.id,
       category: selectedItem.category,
@@ -406,9 +418,9 @@ exports.getPhrase = async (event) => {
       kana: selectedItem.kana,
       answer: selectedItem.answer,
       audioData: audioData,
-      readCount: selectedItem.readCount || 0,
-      averageTime: selectedItem.averageTime || 0,
-      averageDifficulty: selectedItem.averageDifficulty || 0,
+      readCount: stats.readCount || 0,
+      averageTime: stats.averageTime || 0,
+      averageDifficulty: stats.averageDifficulty || 0,
     };
 
     return {
@@ -442,7 +454,7 @@ exports.getPhrasesList = async (event) => {
         ExpressionAttributeValues: {
           ":cat": category,
         },
-        ProjectionExpression: "id, category, phrase, #lvl, kana, answer, readCount, averageTime, averageDifficulty",
+        ProjectionExpression: "id, category, phrase, #lvl, kana, answer, readCount, averageTime, averageDifficulty, totalTime, totalDifficulty",
         ExpressionAttributeNames: {
           "#lvl": "level",
         },
@@ -452,7 +464,7 @@ exports.getPhrasesList = async (event) => {
     } else {
       const scanParams = {
         TableName: process.env.TABLE_NAME,
-        ProjectionExpression: "id, category, phrase, #lvl, kana, answer, readCount, averageTime, averageDifficulty",
+        ProjectionExpression: "id, category, phrase, #lvl, kana, answer, readCount, averageTime, averageDifficulty, totalTime, totalDifficulty",
         ExpressionAttributeNames: {
           "#lvl": "level",
         },
@@ -464,7 +476,7 @@ exports.getPhrasesList = async (event) => {
     return {
       statusCode: 200,
       headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ phrases: items }),
+      body: JSON.stringify({ phrases: items.map(computePhraseStats) }),
     };
   } catch (error) {
     console.error(error);

--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -147,6 +147,19 @@ describe('getPhrasesList', () => {
       const response = await getPhrasesList({});
       expect(response.statusCode).toBe(500);
     });
+
+    it('should compute averageTime/averageDifficulty from totalTime/totalDifficulty and not leak the raw totals', async () => {
+      ddbMock.on(ScanCommand).resolves({
+        Items: [{ id: '1', category: 'Category1', readCount: 4, totalTime: 40, totalDifficulty: 8 }],
+      });
+
+      const response = await getPhrasesList({});
+      const body = JSON.parse(response.body);
+
+      expect(body.phrases).toEqual([
+        { id: '1', category: 'Category1', readCount: 4, averageTime: 10, averageDifficulty: 2 },
+      ]);
+    });
 });
 
 describe('getComments', () => {
@@ -473,6 +486,45 @@ describe('getPhrase', () => {
         expect(body.averageTime).toBe(12.3);
     });
 
+    it('should compute averageTime/averageDifficulty from totalTime/totalDifficulty when present (post-migration data)', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', level: '1', readCount: 4, totalTime: 40, totalDifficulty: 8 }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        ddbMock.on(PutCommand).resolves({});
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1' } };
+        const response = await getPhrase(event);
+        const body = JSON.parse(response.body);
+        expect(body.readCount).toBe(4);
+        expect(body.averageTime).toBe(10);
+        expect(body.averageDifficulty).toBe(2);
+    });
+
+    it('should fall back to 0 instead of returning NaN/Infinity if totalTime/totalDifficulty end up corrupted', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', level: '1', readCount: 4, totalTime: NaN, totalDifficulty: Infinity }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        ddbMock.on(PutCommand).resolves({});
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1' } };
+        const response = await getPhrase(event);
+        const body = JSON.parse(response.body);
+        expect(body.averageTime).toBe(0);
+        expect(body.averageDifficulty).toBe(0);
+    });
+
     it('should include the answer field in the response when present', async () => {
         ddbMock.on(ScanCommand).resolves({
             Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', level: '1', answer: '回答A' }],
@@ -784,27 +836,44 @@ describe('recordTime', () => {
         process.env.TABLE_NAME = 'TestTable';
     });
 
-    it('should record time and update statistics', async () => {
-        ddbMock.on(GetCommand).resolves({
-            Item: { id: 'p1', category: 'c1', readCount: 1, averageTime: 10 }
-        });
+    it('should atomically ADD readCount/totalTime/totalDifficulty without reading current values first', async () => {
         ddbMock.on(UpdateCommand).resolves({});
 
         const event = {
-            body: JSON.stringify({ id: 'p1', category: 'c1', time: 20 })
+            body: JSON.stringify({ id: 'p1', category: 'c1', time: 20, difficulty: 3 })
         };
         const response = await recordTime(event);
         expect(response.statusCode).toBe(200);
 
+        // 読み取り→書き込みの競合を避けるため、GetItemを使わずUpdateItemのADDのみで完結させる
+        expect(ddbMock.commandCalls(GetCommand).length).toBe(0);
         const updateCalls = ddbMock.commandCalls(UpdateCommand);
         expect(updateCalls.length).toBe(1);
         const updateParams = updateCalls[0].args[0].input;
-        expect(updateParams.ExpressionAttributeValues[':rc']).toBe(2);
-        expect(updateParams.ExpressionAttributeValues[':at']).toBe(15);
+        expect(updateParams.Key).toEqual({ category: 'c1', id: 'p1' });
+        expect(updateParams.ConditionExpression).toBe('attribute_exists(id)');
+        expect(updateParams.UpdateExpression).toBe('ADD readCount :one, totalTime :time, totalDifficulty :difficulty');
+        expect(updateParams.ExpressionAttributeValues[':one']).toBe(1);
+        expect(updateParams.ExpressionAttributeValues[':time']).toBe(20);
+        expect(updateParams.ExpressionAttributeValues[':difficulty']).toBe(3);
+    });
+
+    it('should ADD only readCount/totalTime when difficulty is omitted', async () => {
+        ddbMock.on(UpdateCommand).resolves({});
+
+        const event = { body: JSON.stringify({ id: 'p1', category: 'c1', time: 20 }) };
+        const response = await recordTime(event);
+        expect(response.statusCode).toBe(200);
+
+        const updateParams = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+        expect(updateParams.UpdateExpression).toBe('ADD readCount :one, totalTime :time');
+        expect(updateParams.ExpressionAttributeValues[':difficulty']).toBeUndefined();
     });
 
     it('should return 404 if phrase not found', async () => {
-        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        const error = new Error('The conditional request failed');
+        error.name = 'ConditionalCheckFailedException';
+        ddbMock.on(UpdateCommand).rejects(error);
         const event = { body: JSON.stringify({ id: 'p1', category: 'c1', time: 10 }) };
         const response = await recordTime(event);
         expect(response.statusCode).toBe(404);
@@ -828,10 +897,7 @@ describe('recordTime', () => {
         expect(response.statusCode).toBe(400);
     });
 
-    it('should accept time exactly at the abnormal-value cap boundary and update the average', async () => {
-        ddbMock.on(GetCommand).resolves({
-            Item: { id: 'p1', category: 'c1', readCount: 0, averageTime: 0 }
-        });
+    it('should accept time exactly at the abnormal-value cap boundary', async () => {
         ddbMock.on(UpdateCommand).resolves({});
 
         const event = { body: JSON.stringify({ id: 'p1', category: 'c1', time: 300 }) };
@@ -839,16 +905,15 @@ describe('recordTime', () => {
         expect(response.statusCode).toBe(200);
 
         const updateParams = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
-        expect(updateParams.ExpressionAttributeValues[':at']).toBe(300);
+        expect(updateParams.ExpressionAttributeValues[':time']).toBe(300);
     });
 
-    it('should reject (400) time above the abnormal-value cap without writing to DynamoDB, so readCount/averageTime stay consistent (e.g. left idle for hours)', async () => {
+    it('should reject (400) time above the abnormal-value cap without writing to DynamoDB, so readCount/totalTime stay consistent (e.g. left idle for hours)', async () => {
         const event = { body: JSON.stringify({ id: 'p1', category: 'c1', time: 21673.39 }) };
         const response = await recordTime(event);
         expect(response.statusCode).toBe(400);
-        // readCountとaverageTimeが常に対応するサンプル数を保つよう、
+        // readCountとtotalTimeが常に対応するサンプル数を保つよう、
         // 異常値のときはDB書き込み自体を行わない（部分更新はしない）
-        expect(ddbMock.commandCalls(GetCommand).length).toBe(0);
         expect(ddbMock.commandCalls(UpdateCommand).length).toBe(0);
     });
 });

--- a/backend/reset-stats.js
+++ b/backend/reset-stats.js
@@ -23,7 +23,7 @@ async function resetStats(category, id) {
       Key: { category, id },
       // カテゴリ/IDの入力ミスで存在しない項目を新規作成してしまわないようにする
       ConditionExpression: "attribute_exists(category)",
-      UpdateExpression: "set readCount = :zero, averageTime = :zero, averageDifficulty = :zero",
+      UpdateExpression: "set readCount = :zero, averageTime = :zero, averageDifficulty = :zero, totalTime = :zero, totalDifficulty = :zero",
       ExpressionAttributeValues: { ":zero": 0 },
     }));
     console.log("Reset complete.");

--- a/backend/seed.js
+++ b/backend/seed.js
@@ -59,7 +59,9 @@ async function seed() {
         answer: record.answer ? record.answer.trim() : "-",
         readCount: existingItem ? existingItem.readCount : 0,
         averageTime: existingItem ? existingItem.averageTime : 0,
-        averageDifficulty: existingItem ? (existingItem.averageDifficulty || 0) : 0
+        averageDifficulty: existingItem ? (existingItem.averageDifficulty || 0) : 0,
+        totalTime: existingItem ? (existingItem.totalTime || 0) : 0,
+        totalDifficulty: existingItem ? (existingItem.totalDifficulty || 0) : 0
       });
     }
 


### PR DESCRIPTION
## Summary
- `recordTime` を「GetItemで読む→アプリ側で平均計算→UpdateItem」という非アトミックな流れから、DynamoDBの `ADD` で `readCount`/`totalTime`/`totalDifficulty`（合計値）を加算するアトミックな方式に変更。複数端末から同時に記録された場合の競合によるずれを解消（Issue #186）
- 平均値（`averageTime`/`averageDifficulty`）は `getPhrase`/`getPhrasesList` の表示側で `computePhraseStats` により都度計算する方式に変更。フロントエンドから見えるレスポンス形状（フィールド構成）は変更なし
- 既存項目の404判定は、GetItemではなくUpdateItemの `ConditionExpression: attribute_exists(id)` で行う
- 既存データ（合計値未移行のアイテム）のため、一度だけ実行する移行スクリプト `backend/backfill-total-stats.js` を追加。`averageTime × readCount` から `totalTime` を逆算する。ライブトラフィックのADD書き込みを上書きしないよう `ConditionExpression: attribute_not_exists(totalTime)` を付与し、Scanは `LastEvaluatedKey` によるページネーションに対応
- 読み取り側の平均計算に、旧コードにあった `isNaN`/`isFinite` の健全性チェックを復元（不正値は0にフォールバック）
- `seed.js`/`reset-stats.js` も新しい `totalTime`/`totalDifficulty` フィールドを保持・リセットするよう更新

Closes #186

## Test plan
- [x] backend: test 1130/1130 pass（lint/buildスクリプトなし）
- [x] frontend: lint 0 errors、test 31/31 pass、build成功（本PRでは変更なし）
- [x] recordTimeがADD方式でGetItemを使わずに完結し、404判定・difficulty有無・abnormal-value cap境界を検証するテストを追加
- [x] getPhrase/getPhrasesListがtotalTime/totalDifficultyから平均を計算し、レスポンスに生の合計値を含めないことを検証するテストを追加
- [x] 移行スクリプトの合計値逆算・ページネーション・ライブトラフィックとの競合時のスキップ動作を検証するテストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj

---
_Generated by [Claude Code](https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj)_