### PR TITLE
feat(game): ゲーム画面に残り札数・進捗表示を追加

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -177,6 +177,10 @@
   box-shadow: 0 0 0 3px rgba(45, 90, 39, 0.4);
 }
 
+.progress-bar-karuta {
+  background-color: #e44d26;
+}
+
 .modal-overlay {
   background-color: rgba(0, 0, 0, 0.5);
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1178,8 +1178,32 @@ function App() {
     <div className="container py-4 mx-auto">
       <header className="text-center mb-4">
         <h1 className="h2 fw-bold text-dark notranslate">{categoryLabel}</h1>
+        {!isAllRead && allPhrasesForCategory.length > 0 && (() => {
+          const readCount = Math.min(currentHistory.length, allPhrasesForCategory.length);
+          return (
+            <div className="mt-2 mx-auto" style={{ maxWidth: "300px" }}>
+              <div className="text-muted small mb-1">
+                読み上げ済み {readCount} / 全{allPhrasesForCategory.length}枚
+              </div>
+              <div
+                className="progress"
+                style={{ height: "8px" }}
+                role="progressbar"
+                aria-label="読み上げ進捗"
+                aria-valuenow={readCount}
+                aria-valuemin={0}
+                aria-valuemax={allPhrasesForCategory.length}
+              >
+                <div
+                  className="progress-bar progress-bar-karuta"
+                  style={{ width: `${(readCount / allPhrasesForCategory.length) * 100}%` }}
+                ></div>
+              </div>
+            </div>
+          );
+        })()}
       </header>
-      
+
       <main className="text-center">
         {isAllRead ? (
           <div className="alert alert-success py-5 mb-5 shadow-sm rounded-4 border-0">

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -363,6 +363,43 @@ describe('App', () => {
     randomSpy.mockRestore();
   });
 
+  it('shows a read/total progress counter that updates as phrases are read', async () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }, { id: 'p2', category: 'Cat1' }] }),
+        };
+      }
+      if (url.includes('/get-phrase?')) return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', phrase: '読み札1', audioData: 'dummy' }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    const categoryButton = await screen.findByRole('button', { name: /Cat1/ });
+    fireEvent.click(categoryButton);
+    fireEvent.click(screen.getByText(/決定/));
+    fireEvent.click(screen.getByText('はい'));
+
+    await waitFor(() => {
+      expect(screen.getByText('読み上げ済み 0 / 全2枚')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(screen.getByText('読み上げ済み 1 / 全2枚')).toBeInTheDocument();
+    });
+
+    randomSpy.mockRestore();
+  });
+
   it('requests announceCategory=true for the detail-view replay when multiple categories are selected', async () => {
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     fetch.mockImplementation(async (url) => {


### PR DESCRIPTION
## Summary
- ゲーム画面のヘッダーに「読み上げ済み ○ / 全△枚」のカウンタとBootstrapの`progress`コンポーネントによる進捗バーを追加（Issue #213）
- 既存の`allPhrasesForCategory`（選択カテゴリの全札）と`currentHistory`（読み上げ済み履歴）から算出しており、追加のAPI通信は不要
- 全札読了後（`isAllRead`）はお祝い画面と重複しないよう非表示にする
- 自己レビューで検出した「`currentHistory`が`allPhrasesForCategory`を超過した場合に進捗が100%を超えて表示され得る」問題に対応し、`Math.min`でクランプ

Closes #213

## Test plan
- [x] backend: test 1134/1134 pass（本PRではbackendへの変更なし）
- [x] frontend: lint 0 errors、test 33/33 pass、build成功
- [x] 進捗カウンタが初期値（0 / 全2枚）と1枚読み上げ後（1 / 全2枚）で正しく表示・更新されることを検証するテストを追加
- [x] Playwright（Chromium）でdevサーバーを起動し、進捗バーの幅（0% → 50%）と配色が実際のDOM上で正しく反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj

---
_Generated by [Claude Code](https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj)_