### PR TITLE
feat(game): こども向けモードの読み札表示を最適化

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -141,6 +141,20 @@
   margin-top: 0.5rem;
 }
 
+/* こども向けは、より大きな文字でかな（読み仮名）を優先して見せる */
+.yomifuda-kids .yomifuda-kana {
+  width: 84px;
+  height: 84px;
+}
+
+.yomifuda-kids .yomifuda-kana span {
+  font-size: 44px;
+}
+
+.yomifuda-kids .yomifuda-phrase {
+  font-size: clamp(24px, 9vw, 40px);
+}
+
 .yomifuda-level {
   position: absolute;
   bottom: 20px;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1131,10 +1131,10 @@ function App() {
   const renderPhrase = (phrase) => {
     if (!phrase) return null;
     return (
-        <div className="yomifuda" onClick={repeatPhrase} role="button" aria-label="もう一度">
+        <div className={`yomifuda ${division === "kids" ? "yomifuda-kids" : ""}`} onClick={repeatPhrase} role="button" aria-label="もう一度">
             <div className="yomifuda-kana"><span>{phrase.kana || (phrase.phrase && phrase.phrase[0])}</span></div>
             <div className="yomifuda-phrase">{phrase.phrase}</div>
-            {phrase.level !== "-" && <div className="yomifuda-level fw-bold">レベル: {phrase.level}</div>}
+            {division !== "kids" && phrase.level !== "-" && <div className="yomifuda-level fw-bold">レベル: {phrase.level}</div>}
         </div>
     );
   }
@@ -1152,9 +1152,13 @@ function App() {
               🎉 平均より速い！
             </div>
           )}
-          
-          <div className="text-muted mb-2">難易度レベル</div>
-          <div className="h3 fw-bold text-danger">{result.difficulty.toFixed(2)}</div>
+
+          {division !== "kids" && (
+            <>
+              <div className="text-muted mb-2">難易度レベル</div>
+              <div className="h3 fw-bold text-danger">{result.difficulty.toFixed(2)}</div>
+            </>
+          )}
 
           {result.answer && result.answer !== "-" && (
             <>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -588,6 +588,56 @@ describe('App', () => {
     });
   });
 
+  it('hides the level/difficulty jargon and enlarges the phrase card for the kids division', async () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      }
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({
+            phrases: [
+              { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '3' },
+              { id: 'p2', category: 'Cat1', kana: 'い', phrase: '読み札2', level: '3' },
+            ],
+          }),
+        };
+      }
+      if (url.includes('get-phrase')) {
+        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '3', audioData: 'dummy' }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Cat1' }));
+
+    await waitFor(() => screen.getByText('次の札'));
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      const phraseCard = screen.getByText('読み札1', { selector: '.yomifuda-phrase' }).closest('.yomifuda');
+      expect(phraseCard).toHaveClass('yomifuda-kids');
+    }, { timeout: 8000 });
+
+    expect(screen.queryByText(/レベル:/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(screen.getByText('所要時間')).toBeInTheDocument();
+    }, { timeout: 4000 });
+    expect(screen.queryByText('難易度レベル')).not.toBeInTheDocument();
+
+    randomSpy.mockRestore();
+  }, 15000);
+
   it('shows the answer on the result screen after reading a phrase with answer data', async () => {
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0); // 常にp1を選ばせる
     fetch.mockImplementation(async (url) => {


### PR DESCRIPTION
## Summary
- `division === "kids"` の場合、読み札カードのかな（読み仮名）と本文の文字サイズを拡大した（Issue #221）
- レベル表示・結果画面の難易度レベル数値など、こども向けにそぐわない専門的な文言をkidsモードでは非表示にした
- 効果音・アニメーション演出の追加は、Issue #219（読了時のリザルト画面）とスコープが重複し仕様も未指定のため、今回は見送った

Closes #221

## Test plan
- [x] backend: test 1134/1134 pass（本PRではbackendへの変更なし）
- [x] frontend: lint 0 errors、test 34/34 pass、build成功
- [x] kidsモードで読み札カードにyomifuda-kidsクラスが付与され、レベル表示・難易度レベルが表示されないことを検証するテストを追加
- [x] Playwright（Chromium）でdevサーバーを起動し、かなの丸バッジ・読み札本文の拡大表示とレベル非表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj

---
_Generated by [Claude Code](https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj)_