### PR TITLE
feat(history): 読み上げ履歴をsessionStorageに永続化

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,8 @@ import changelogData from "./changelog.json";
 
 const API_BASE_URL = "https://akmnirkx3m.execute-api.ap-northeast-1.amazonaws.com/dev";
 
+const HISTORY_STORAGE_KEY = "historyByCategory";
+
 const parseCategoriesParam = (value) => (value ? value.split(",").filter(Boolean).map(decodeURIComponent) : []);
 const serializeCategoriesParam = (categories) => categories.map(encodeURIComponent).join(",");
 
@@ -67,7 +69,14 @@ function App() {
   const [systemPrefersDark, setSystemPrefersDark] = useState(() => {
     return window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
   });
-  const [historyByCategory, setHistoryByCategory] = useState({});
+  const [historyByCategory, setHistoryByCategory] = useState(() => {
+    try {
+      const stored = sessionStorage.getItem(HISTORY_STORAGE_KEY);
+      return stored ? JSON.parse(stored) : {};
+    } catch {
+      return {};
+    }
+  });
   
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [draftCategories, setDraftCategories] = useState([]);
@@ -635,6 +644,10 @@ function App() {
   useEffect(() => {
     localStorage.setItem("theme", themeSetting);
   }, [themeSetting]);
+
+  useEffect(() => {
+    sessionStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(historyByCategory));
+  }, [historyByCategory]);
 
   useEffect(() => {
     document.documentElement.setAttribute("data-bs-theme", resolvedTheme);
@@ -1299,7 +1312,7 @@ function App() {
             </div>
           </div>
         </section>
-      <p className="text-muted small mb-4">リロードすると履歴はリセットされます。</p>
+      <p className="text-muted small mb-4">履歴はこのタブを閉じるまで保持されます（リロードしても消えません）。</p>
       <div className="d-flex flex-wrap gap-2 justify-content-center">
         <button onClick={() => setView("print-efuda")} className="btn btn-outline-dark px-4 rounded-pill">絵札を印刷する</button>
         <button onClick={resetGame} className="btn btn-outline-secondary px-4 rounded-pill">かるたの種類を選び直す</button>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -36,6 +36,8 @@ describe('App', () => {
     vi.clearAllMocks();
     // Reset URL
     window.history.pushState({}, '', '/');
+    // 読み上げ履歴の永続化先（sessionStorage）をテスト間で引き継がないようにする
+    sessionStorage.clear();
   });
 
   it('renders division selection screen initially', async () => {
@@ -754,6 +756,46 @@ describe('App', () => {
 
     randomSpy.mockRestore();
   }, 15000);
+
+  it('persists the reading history across a reload via sessionStorage', async () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }, { id: 'p2', category: 'Cat1' }] }),
+        };
+      }
+      if (url.includes('/get-phrase?')) return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', phrase: '読み札1', audioData: 'dummy' }) };
+      return { ok: false };
+    });
+
+    const { unmount } = render(<App />);
+    await act(async () => {});
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+    await waitFor(() => screen.getByText('読み上げ済み 0 / 全2枚'));
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(screen.getByText('読み上げ済み 1 / 全2枚')).toBeInTheDocument();
+    });
+
+    // ページリロードを模擬する（URLはpushStateにより既にcategory/divisionを保持している）
+    unmount();
+    await act(async () => {
+      render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('読み上げ済み 1 / 全2枚')).toBeInTheDocument();
+    });
+
+    randomSpy.mockRestore();
+  });
 
   it('updates settings (lang, sort order, speech rate)', async () => {
     fetch.mockImplementation(async (url) => {


### PR DESCRIPTION
## Summary
- `historyByCategory` をsessionStorageに永続化し、リロード後も読み上げ履歴・進捗表示が保持されるようにした（Issue #194）
- 永続化先はlocalStorageではなくsessionStorageを選定。複数タブ・別セッションをまたいで履歴が共有され続けることを避け、タブを閉じれば履歴がリセットされる挙動にした
- フッターの注意書き（「リロードすると履歴はリセットされます。」）を実際の挙動に合わせて更新

Closes #194

## Test plan
- [x] backend: test 1134/1134 pass（本PRではbackendへの変更なし）
- [x] frontend: lint 0 errors、test 35/35 pass、build成功
- [x] 読み上げ履歴がリロード（再マウント）後も保持されることを検証するテストを追加
- [x] テスト実行時にjsdomのsessionStorageがテスト間で共有され4件のテストが失敗する問題を発見し、`beforeEach`に`sessionStorage.clear()`を追加してテストの独立性を確保
- [x] Playwright（Chromium）で実際の`page.reload()`により履歴・進捗表示が保持されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj

---
_Generated by [Claude Code](https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj)_