### PR TITLE
feat(reading): 読み上げ中に停止できる機能を追加

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -87,6 +87,8 @@ function App() {
 
   const flipTimeoutRef = useRef(null);
   const startTimeRef = useRef(null);
+  const currentAudioRef = useRef(null);
+  const stopRequestedRef = useRef(false);
 
   const resolvedTheme = useMemo(() => {
     return themeSetting === "system" ? (systemPrefersDark ? "dark" : "light") : themeSetting;
@@ -333,8 +335,15 @@ function App() {
   const playAudio = useCallback((audioData) => {
     return new Promise((resolve, reject) => {
       const audio = new Audio(audioData);
-      audio.onended = () => resolve();
-      audio.onerror = (e) => reject(e);
+      currentAudioRef.current = { audio, resolve };
+      audio.onended = () => {
+        if (currentAudioRef.current?.audio === audio) currentAudioRef.current = null;
+        resolve();
+      };
+      audio.onerror = (e) => {
+        if (currentAudioRef.current?.audio === audio) currentAudioRef.current = null;
+        reject(e);
+      };
       audio.play().catch(e => reject(e));
     });
   }, []);
@@ -373,6 +382,11 @@ function App() {
       }
   
       await playIntroSound();
+      // 停止ボタンが押されていたら、次のフェーズ（本編読み上げ）に進まず打ち切る
+      if (stopRequestedRef.current) {
+        stopRequestedRef.current = false;
+        return;
+      }
 
       let animationPromise = Promise.resolve();
 
@@ -395,16 +409,24 @@ function App() {
           setIsFadingOut(true);
         }, 3000); // 待機時間
       }
-      
+
       await playAudio(audioData).catch(e => console.error("Audio playback failed:", e));
-      
+      if (stopRequestedRef.current) {
+        stopRequestedRef.current = false;
+        return;
+      }
+
       await animationPromise;
+      if (stopRequestedRef.current) {
+        stopRequestedRef.current = false;
+        return;
+      }
 
       if (!phraseData) {
         nextContentRef.current = { type: 'initial' };
         setIsFadingOut(true);
       }
-      
+
       setAudioQueue(prev => prev.slice(1));
       setIsReading(false);
     };
@@ -519,6 +541,40 @@ function App() {
     if (target && target.audioData) {
         setAudioQueue(prev => [...prev, { phraseData: null, audioData: target.audioData }]);
     }
+  };
+
+  const stopReading = () => {
+    if (!isReading) return;
+
+    // playNextInQueue内のawaitチェーンを、次の工程（本編読み上げ・フェード）に
+    // 進ませずに打ち切るためのフラグ
+    stopRequestedRef.current = true;
+
+    if (currentAudioRef.current) {
+      const { audio, resolve } = currentAudioRef.current;
+      audio.pause();
+      currentAudioRef.current = null;
+      resolve();
+    }
+
+    if (flipTimeoutRef.current) {
+      clearTimeout(flipTimeoutRef.current);
+      flipTimeoutRef.current = null;
+    }
+
+    if (animationResolveRef.current) {
+      animationResolveRef.current();
+      animationResolveRef.current = null;
+    }
+
+    // 中断された読み上げの計測を、次回の記録に誤って持ち越さないようにする
+    startTimeRef.current = null;
+
+    setIsFadingOut(false);
+    nextContentRef.current = { type: "initial" };
+    setDisplayContent({ type: "initial" });
+    setAudioQueue([]);
+    setIsReading(false);
   };
 
   const playCongratulationAudio = async () => {
@@ -1246,6 +1302,7 @@ function App() {
                 {loading ? "読み込み中..." : "次の札"}
               </button>
               <button onClick={repeatPhrase} disabled={isReading || !currentPhrase} className="btn btn-lg px-4 py-3 fw-bold rounded-pill border-3 border-dark bg-white text-dark shadow-sm">もう一度</button>
+              <button onClick={stopReading} disabled={!isReading} className="btn btn-lg px-4 py-3 fw-bold rounded-pill border-3 border-danger bg-white text-danger shadow-sm">停止</button>
             </div>
           </>
         )}

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -13,6 +13,7 @@ window.fetch = vi.fn();
 window.Audio = vi.fn().mockImplementation((url) => {
   const audio = {
     play: vi.fn().mockResolvedValue(),
+    pause: vi.fn(),
     load: vi.fn(),
     // Simulate successful loading
     set src(url) {
@@ -1034,6 +1035,56 @@ describe('App', () => {
       expect(document.title).toBe('全札一覧 | かるた読み上げアプリ');
     });
   });
+
+  it('stops the current reading and resets the queue when the stop button is pressed', async () => {
+    const originalAudio = window.Audio;
+    const pauseMock = vi.fn();
+    // このテストは「再生中に停止ボタンを押す」挙動を検証するため、通常のモックのように
+    // 即座にonendedを発火させず、再生が継続している状態（ユーザーが停止ボタンを押す
+    // 前に音声が終わってしまわない状態）を維持できるAudioモックに差し替える
+    window.Audio = vi.fn().mockImplementation((url) => {
+      const audio = {
+        play: vi.fn().mockResolvedValue(),
+        pause: pauseMock,
+        load: vi.fn(),
+        set src(_url) {
+          // onendedを意図的に発火させない
+        },
+      };
+      if (url) audio.src = url;
+      return audio;
+    });
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      if (url.includes('/get-phrase?')) return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', phrase: '読み札1', audioData: 'dummy' }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+    await waitFor(() => screen.getByText('次の札'));
+    fireEvent.click(screen.getByText('次の札'));
+
+    const stopButton = await screen.findByRole('button', { name: '停止' });
+    await waitFor(() => expect(stopButton).not.toBeDisabled(), { timeout: 4000 });
+
+    fireEvent.click(stopButton);
+
+    expect(pauseMock).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '停止' })).toBeDisabled();
+      expect(screen.getByText('準備完了')).toBeInTheDocument();
+    });
+
+    window.Audio = originalAudio;
+  }, 10000);
 
   it('does not reset the elapsed-time start point when the card is replayed before advancing', async () => {
     fetch.mockImplementation(async (url) => {


### PR DESCRIPTION
## Summary
- 再生中のAudioインスタンスを`currentAudioRef`で保持し、「停止」ボタンで`audio.pause()`を呼びつつ読み上げ状態・再生キュー・フェード演出を初期状態にリセットできるようにした（Issue #218）
- `stopRequestedRef`フラグを追加し、停止操作後にイントロ音声→本編音声→フェード演出のawaitチェーンが誤って次の工程へ進まないようにした
- 中断された読み上げの計測開始時刻をクリアし、次回の記録に誤って持ち越されないようにした
- スキップ機能（対応案で「追加する場合は」という条件付き言及）は今回のスコープ外とし、停止機能のみを実装

Closes #218

## Test plan
- [x] backend: test 1134/1134 pass（本PRではbackendへの変更なし）
- [x] frontend: lint 0 errors、test 36/36 pass、build成功
- [x] onendedを発火させないAudioモックを用いて、再生中に停止ボタンを押すとpause()が呼ばれUIが準備完了画面に戻ることを検証するテストを追加
- [x] Playwright（Chromium）で実際の`<audio>`要素に対しpause()が呼ばれること、UIが準備完了画面に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj

---
_Generated by [Claude Code](https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj)_