### PR TITLE
feat(reading): 次の札の音声をプリフェッチして待ち時間を削減

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,18 @@ const HISTORY_STORAGE_KEY = "historyByCategory";
 const parseCategoriesParam = (value) => (value ? value.split(",").filter(Boolean).map(decodeURIComponent) : []);
 const serializeCategoriesParam = (categories) => categories.map(encodeURIComponent).join(",");
 
+// 未読み札から次に読み上げる1件を選ぶ（プリフェッチと実際の選択で同じロジックを使う）
+const pickTargetPhrase = (unreadPhrases, sortOrder) => {
+  if (sortOrder === "easy") {
+    return [...unreadPhrases].sort((a, b) => (a.averageDifficulty || 0) - (b.averageDifficulty || 0))[0];
+  }
+  if (sortOrder === "hard") {
+    return [...unreadPhrases].sort((a, b) => (b.averageDifficulty || 0) - (a.averageDifficulty || 0))[0];
+  }
+  const randomIndex = Math.floor(Math.random() * unreadPhrases.length);
+  return unreadPhrases[randomIndex];
+};
+
 function App() {
   const [categories, setCategories] = useState([]);
   const [division, setDivision] = useState(() => {
@@ -89,6 +101,7 @@ function App() {
   const startTimeRef = useRef(null);
   const currentAudioRef = useRef(null);
   const stopRequestedRef = useRef(false);
+  const prefetchedNextRef = useRef(null);
 
   const resolvedTheme = useMemo(() => {
     return themeSetting === "system" ? (systemPrefersDark ? "dark" : "light") : themeSetting;
@@ -438,6 +451,50 @@ function App() {
     }
   }, [audioQueue, isReading, playAudio, playIntroSound, categoryKey, historyByCategory]);
 
+  // 現在の札を読み上げている間に、次に読み上げる予定の札の音声を先読みしておく
+  useEffect(() => {
+    if (!isReading || selectedCategories.length === 0 || allPhrasesForCategory.length === 0) {
+      return;
+    }
+
+    const readKeys = new Set(currentHistory.map(p => `${p.category}:${p.id}`));
+    const unreadPhrases = allPhrasesForCategory.filter(p => !readKeys.has(`${p.category}:${p.id}`));
+    if (unreadPhrases.length === 0) {
+      return;
+    }
+
+    const announceCategory = isMultiCategorySelection;
+    const settingsSignature = JSON.stringify({ repeatCount, speechRate, lang, announceCategory, sortOrder });
+
+    const alreadyPrefetched = prefetchedNextRef.current;
+    if (
+      alreadyPrefetched &&
+      alreadyPrefetched.settingsSignature === settingsSignature &&
+      unreadPhrases.some(p => p.id === alreadyPrefetched.phrase.id && p.category === alreadyPrefetched.phrase.category)
+    ) {
+      return;
+    }
+
+    const nextTargetPhrase = pickTargetPhrase(unreadPhrases, sortOrder);
+    let cancelled = false;
+
+    const apiUrl = `${API_BASE_URL}/get-phrase?id=${nextTargetPhrase.id}&category=${encodeURIComponent(nextTargetPhrase.category)}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}&announceCategory=${announceCategory}`;
+
+    fetch(apiUrl)
+      .then(response => response.json().then(data => ({ ok: response.ok, data })))
+      .then(({ ok, data }) => {
+        if (cancelled || !ok) return;
+        prefetchedNextRef.current = { phrase: nextTargetPhrase, data, settingsSignature };
+      })
+      .catch(error => {
+        console.error("Error prefetching next phrase:", error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isReading, selectedCategories, allPhrasesForCategory, currentHistory, sortOrder, repeatCount, speechRate, lang, isMultiCategorySelection]);
+
   const playKaruta = async () => {
     const targetPhrase = currentPhrase;
     
@@ -505,27 +562,33 @@ function App() {
         return;
       }
 
+      const announceCategory = isMultiCategorySelection;
+      const settingsSignature = JSON.stringify({ repeatCount, speechRate, lang, announceCategory, sortOrder });
+      const prefetched = prefetchedNextRef.current;
       let targetPhrase;
-      if (sortOrder === "easy") {
-        unreadPhrases.sort((a, b) => (a.averageDifficulty || 0) - (b.averageDifficulty || 0));
-        targetPhrase = unreadPhrases[0];
-      } else if (sortOrder === "hard") {
-        unreadPhrases.sort((a, b) => (b.averageDifficulty || 0) - (a.averageDifficulty || 0));
-        targetPhrase = unreadPhrases[0];
+      let data;
+
+      if (
+        prefetched &&
+        prefetched.settingsSignature === settingsSignature &&
+        unreadPhrases.some(p => p.id === prefetched.phrase.id && p.category === prefetched.phrase.category)
+      ) {
+        // プリフェッチ済みの音声データをそのまま使い、取得待ちをスキップする
+        targetPhrase = prefetched.phrase;
+        data = prefetched.data;
+        prefetchedNextRef.current = null;
       } else {
-        const randomIndex = Math.floor(Math.random() * unreadPhrases.length);
-        targetPhrase = unreadPhrases[randomIndex];
+        targetPhrase = pickTargetPhrase(unreadPhrases, sortOrder);
+
+        const apiUrl = `${API_BASE_URL}/get-phrase?id=${targetPhrase.id}&category=${encodeURIComponent(targetPhrase.category)}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}&announceCategory=${announceCategory}`;
+        const response = await fetch(apiUrl);
+        data = await response.json();
+
+        if (!response.ok) {
+          throw new Error(data.message || "Fetch failed");
+        }
       }
 
-      const announceCategory = isMultiCategorySelection;
-      const apiUrl = `${API_BASE_URL}/get-phrase?id=${targetPhrase.id}&category=${encodeURIComponent(targetPhrase.category)}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}&announceCategory=${announceCategory}`;
-      const response = await fetch(apiUrl);
-      const data = await response.json();
-      
-      if (!response.ok) {
-        throw new Error(data.message || "Fetch failed");
-      }
-      
       setAudioQueue(prev => [...prev, { phraseData: data, audioData: data.audioData }]);
 
     } catch (error) {

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -401,6 +401,61 @@ describe('App', () => {
     randomSpy.mockRestore();
   });
 
+  it('prefetches the next phrase while the current one is being read, and reuses it without an extra fetch', async () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    const getPhraseCallIds = [];
+    const phraseById = {
+      p1: { id: 'p1', category: 'Cat1', phrase: '読み札1' },
+      p2: { id: 'p2', category: 'Cat1', phrase: '読み札2' },
+    };
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }, { id: 'p2', category: 'Cat1' }] }),
+        };
+      }
+      if (url.includes('/get-phrase?')) {
+        const id = new URL(url).searchParams.get('id');
+        getPhraseCallIds.push(id);
+        return { ok: true, json: async () => ({ ...phraseById[id], audioData: 'dummy' }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+    await waitFor(() => screen.getByText('次の札'));
+    fireEvent.click(screen.getByText('次の札'));
+
+    // p1読み上げ中（isReading）にp2が先読みされるのを待つ
+    await waitFor(() => {
+      expect(getPhraseCallIds).toContain('p2');
+    }, { timeout: 4000 });
+
+    // p1の読み上げが完了する（次の札を再度押せる状態に戻る）のを待つ
+    await waitFor(() => expect(screen.getByText('次の札')).not.toBeDisabled(), { timeout: 8000 });
+
+    const callCountBeforeSecondClick = getPhraseCallIds.length;
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(screen.getByText('読み札2', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+    }, { timeout: 8000 });
+
+    // プリフェッチ済みのp2をそのまま使うため、/get-phraseの追加呼び出しは発生しない
+    expect(getPhraseCallIds.length).toBe(callCountBeforeSecondClick);
+    expect(getPhraseCallIds).toEqual(['p1', 'p2']);
+
+    randomSpy.mockRestore();
+  }, 15000);
+
   it('requests announceCategory=true for the detail-view replay when multiple categories are selected', async () => {
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     fetch.mockImplementation(async (url) => {


### PR DESCRIPTION
## Summary
- 現在の札を読み上げている間（`isReading`がtrueの間）に、次に読み上げる予定の札の音声を先読みしてキャッシュするようにした（Issue #215）
- 「次の札」ボタン押下時、キャッシュされた札が現在の未読み札集合に含まれ、かつ読み上げ設定（repeatCount/speechRate/lang/announceCategory/sortOrder）が取得時から変わっていなければ、キャッシュをそのまま使い取得待ちをスキップする
- 未読み札の選定ロジック（`pickTargetPhrase`）をプリフェッチと実際の選択で共有し、両者の選定基準を一致させた

Closes #215

## Test plan
- [x] backend: test 1134/1134 pass（本PRではbackendへの変更なし）
- [x] frontend: lint 0 errors、test 37/37 pass、build成功
- [x] 読み上げ中にプリフェッチが発生し、その後の「次の札」クリックで追加のget-phrase呼び出しなしにプリフェッチ済みデータが使われることを検証するテストを追加
- [x] Playwright（Chromium）で実際のネットワークリクエスト数（本体取得1回・プリフェッチ1回・利用時0回追加）を計測して確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj

---
_Generated by [Claude Code](https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj)_