### PR TITLE
feat(auto-advance): 自動読み上げモード（ハンズフリー進行）を追加

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -75,6 +75,12 @@ function App() {
   const [sortOrder, setSortOrder] = useState(() => {
     return localStorage.getItem("sortOrder") || "random";
   });
+  const [autoAdvance, setAutoAdvance] = useState(() => {
+    return localStorage.getItem("autoAdvance") === "true";
+  });
+  const [autoAdvanceInterval, setAutoAdvanceInterval] = useState(() => {
+    return parseInt(localStorage.getItem("autoAdvanceInterval") || "10", 10);
+  });
   const [themeSetting, setThemeSetting] = useState(() => {
     return localStorage.getItem("theme") || "system";
   });
@@ -102,6 +108,7 @@ function App() {
   const currentAudioRef = useRef(null);
   const stopRequestedRef = useRef(false);
   const prefetchedNextRef = useRef(null);
+  const autoAdvanceTimeoutRef = useRef(null);
 
   const resolvedTheme = useMemo(() => {
     return themeSetting === "system" ? (systemPrefersDark ? "dark" : "light") : themeSetting;
@@ -375,13 +382,13 @@ function App() {
       if (isReading || audioQueue.length === 0) {
         return;
       }
-  
+
       setIsReading(true);
       const { phraseData, audioData } = audioQueue[0];
-  
+
       if (phraseData) {
         setCurrentPhrase(phraseData);
-        
+
         setHistoryByCategory(prev => {
           const currentList = prev[categoryKey] || [];
           if (currentList.find(p => p.id === phraseData.id && p.category === phraseData.category)) {
@@ -393,7 +400,7 @@ function App() {
           };
         });
       }
-  
+
       await playIntroSound();
       // 停止ボタンが押されていたら、次のフェーズ（本編読み上げ）に進まず打ち切る
       if (stopRequestedRef.current) {
@@ -495,6 +502,56 @@ function App() {
     };
   }, [isReading, selectedCategories, allPhrasesForCategory, currentHistory, sortOrder, repeatCount, speechRate, lang, isMultiCategorySelection]);
 
+  // 自動読み上げモード：札の読み上げが完了し「次の札」を待っている状態
+  // （手動なら次の札ボタンを押すタイミング）で一定時間経過したら自動で次へ進む。
+  // このアプリでは「次の札」への1回の操作が、直前の札の結果表示と次の札の
+  // 読み上げ開始を両方まとめて行う設計になっているため、result表示中ではなく
+  // 直前の札のphrase表示中（読み上げ完了後の待機状態）を起点にする。
+  useEffect(() => {
+    if (autoAdvanceTimeoutRef.current) {
+      clearTimeout(autoAdvanceTimeoutRef.current);
+      autoAdvanceTimeoutRef.current = null;
+    }
+
+    if (!autoAdvance || isAllRead || isReading || loading || displayContent.type !== "phrase") {
+      return;
+    }
+
+    autoAdvanceTimeoutRef.current = setTimeout(() => {
+      autoAdvanceTimeoutRef.current = null;
+      playKaruta();
+    }, autoAdvanceInterval * 1000);
+
+    return () => {
+      if (autoAdvanceTimeoutRef.current) {
+        clearTimeout(autoAdvanceTimeoutRef.current);
+        autoAdvanceTimeoutRef.current = null;
+      }
+    };
+    // playKarutaは毎レンダーで再生成される関数であり、選択カテゴリや読み上げ設定
+    // （sortOrder/repeatCount/speechRate/lang等）をクロージャで参照している。
+    // playKaruta自体を依存配列に含めると無関係な再レンダーでもタイマーが
+    // 再設定されてしまうため、代わりにplayKarutaが参照する状態を依存配列に
+    // 列挙する（プリフェッチ用useEffectと同じ考え方）。これにより待機中に
+    // 設定が変わった場合も最新の設定でタイマーが張り直される
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    autoAdvance,
+    autoAdvanceInterval,
+    displayContent,
+    isReading,
+    loading,
+    isAllRead,
+    selectedCategories,
+    allPhrasesForCategory,
+    currentHistory,
+    sortOrder,
+    repeatCount,
+    speechRate,
+    lang,
+    isMultiCategorySelection,
+  ]);
+
   const playKaruta = async () => {
     const targetPhrase = currentPhrase;
     
@@ -530,8 +587,16 @@ function App() {
           type: "result",
           content: { time: elapsedTime, difficulty, isFast, answer: targetPhrase.answer },
         };
+
+        // 結果表示のフェード完了を待ってから次の札の取得・再生に進む。
+        // 待たずに次の札をすぐキューへ入れると、次の札側のフリップ完了待ち
+        // （animationResolveRef）をこの結果表示のフェード完了が誤って解決して
+        // しまい、次の札の表示が中断される不具合があったため、明示的に区切る。
+        const resultFadePromise = new Promise(resolve => {
+          animationResolveRef.current = resolve;
+        });
         setIsFadingOut(true);
-        
+
         fetch(`${API_BASE_URL}/record-time`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -544,6 +609,8 @@ function App() {
         }).catch((error) => {
           console.error("Error recording time:", error);
         });
+
+        await resultFadePromise;
       }
       startTimeRef.current = null;
     }
@@ -759,6 +826,14 @@ function App() {
   useEffect(() => {
     localStorage.setItem("sortOrder", sortOrder);
   }, [sortOrder]);
+
+  useEffect(() => {
+    localStorage.setItem("autoAdvance", autoAdvance.toString());
+  }, [autoAdvance]);
+
+  useEffect(() => {
+    localStorage.setItem("autoAdvanceInterval", autoAdvanceInterval.toString());
+  }, [autoAdvanceInterval]);
 
   useEffect(() => {
     localStorage.setItem("theme", themeSetting);
@@ -1424,12 +1499,26 @@ function App() {
               <button onClick={() => setSpeechRate("100%")} className={`btn ${speechRate === "100%" ? 'btn-dark' : 'btn-outline-dark'}`}>はやい</button>
             </div>
           </div>
-          <div className="d-flex align-items-center justify-content-center gap-3">
+          <div className="mb-3 d-flex align-items-center justify-content-center gap-3 border-bottom pb-2">
             <span className="fw-bold text-dark small">回数:</span>
             <div className="btn-group btn-group-sm" role="group">
               <button onClick={() => setRepeatCount(1)} className={`btn ${repeatCount === 1 ? 'btn-dark' : 'btn-outline-dark'}`}>1回</button>
               <button onClick={() => setRepeatCount(2)} className={`btn ${repeatCount === 2 ? 'btn-dark' : 'btn-outline-dark'}`}>2回</button>
             </div>
+          </div>
+          <div className="d-flex align-items-center justify-content-center gap-3 flex-wrap">
+            <span className="fw-bold text-dark small">自動で次へ:</span>
+            <div className="btn-group btn-group-sm" role="group">
+              <button onClick={() => setAutoAdvance(false)} className={`btn ${!autoAdvance ? 'btn-dark' : 'btn-outline-dark'}`}>オフ</button>
+              <button onClick={() => setAutoAdvance(true)} className={`btn ${autoAdvance ? 'btn-dark' : 'btn-outline-dark'}`}>オン</button>
+            </div>
+            {autoAdvance && (
+              <div className="btn-group btn-group-sm" role="group">
+                <button onClick={() => setAutoAdvanceInterval(10)} className={`btn ${autoAdvanceInterval === 10 ? 'btn-dark' : 'btn-outline-dark'}`}>10秒</button>
+                <button onClick={() => setAutoAdvanceInterval(20)} className={`btn ${autoAdvanceInterval === 20 ? 'btn-dark' : 'btn-outline-dark'}`}>20秒</button>
+                <button onClick={() => setAutoAdvanceInterval(30)} className={`btn ${autoAdvanceInterval === 30 ? 'btn-dark' : 'btn-outline-dark'}`}>30秒</button>
+              </div>
+            )}
           </div>
         </section>
       <p className="text-muted small mb-4">履歴はこのタブを閉じるまで保持されます（リロードしても消えません）。</p>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -882,7 +882,70 @@ describe('App', () => {
 
     fireEvent.click(screen.getByText('はやい'));
     expect(localStorage.getItem('speechRate')).toBe('100%');
+
+    // 自動で次への設定はデフォルトでオフで、間隔ボタンは表示されない
+    expect(screen.queryByText('10秒')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('オン'));
+    expect(localStorage.getItem('autoAdvance')).toBe('true');
+
+    fireEvent.click(await screen.findByText('20秒'));
+    expect(localStorage.getItem('autoAdvanceInterval')).toBe('20');
+
+    // 後続のテストに自動読み上げ設定が引き継がれないようにする
+    localStorage.removeItem('autoAdvance');
+    localStorage.removeItem('autoAdvanceInterval');
   });
+
+  it('automatically advances to the next phrase after the configured interval when auto-advance is on', async () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    // UIが提示する最短の間隔（10秒）だと実時間のかかるテストになってしまうため、
+    // 実際のUIには無い短い間隔をlocalStorageに直接設定して機構自体を検証する
+    localStorage.setItem('autoAdvance', 'true');
+    localStorage.setItem('autoAdvanceInterval', '1');
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }, { id: 'p2', category: 'Cat1' }] }),
+        };
+      }
+      if (url.includes('/get-phrase?')) {
+        const id = new URL(url).searchParams.get('id');
+        return { ok: true, json: async () => ({ id, category: 'Cat1', phrase: `読み札${id}`, audioData: 'dummy' }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+    await waitFor(() => screen.getByText('次の札'));
+    fireEvent.click(screen.getByText('次の札'));
+
+    // p1の読み上げが完了し「次の札」を待つ状態（自動読み上げの起点）になるまで待つ
+    // （プリフェッチ機能によりp2のget-phraseはこの時点で既に裏で呼ばれ得るため、
+    // 実際にp2の読み上げまで進むかどうかで自動読み上げ自体を検証する）
+    await waitFor(() => {
+      expect(screen.getByText('読み札p1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+    }, { timeout: 8000 });
+
+    // 「次の札」ボタンを一切押さずに、設定した間隔後の自動読み上げでp2の読み上げに進むのを待つ
+    await waitFor(() => {
+      expect(screen.getByText('読み札p2', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+    }, { timeout: 8000 });
+
+    randomSpy.mockRestore();
+    // 後続のテストに自動読み上げ設定が引き継がれないようにする
+    localStorage.removeItem('autoAdvance');
+    localStorage.removeItem('autoAdvanceInterval');
+  }, 15000);
 
   it('applies the selected theme to the document and persists it', async () => {
     fetch.mockImplementation(async (url) => {


### PR DESCRIPTION
## 概要

読み上げが完了して次の札を待っている状態から、設定した秒数（10/20/30秒）が経過すると自動で次の札に進む「自動読み上げモード」を追加します（#214）。

- 設定フッターに「自動で次へ」トグルと間隔（10秒/20秒/30秒）ボタンを追加
- ON/OFFと間隔はlocalStorageに永続化
- デフォルトはOFFで、既存の手動操作の挙動は変更なし

## 実装中に発見・修正した既存の不具合

自動読み上げの実装を通じて、`playKaruta()` を短時間に連続で呼び出す既存の経路すべてに内在していた潜在的な競合状態を発見しました。

このアプリでは「次の札」への1回の操作が、直前の札の結果表示フェードと次の札の読み上げ開始（フリップ表示）を両方まとめて行う設計になっています。これまで結果表示側のフェードは完了を待たない fire-and-forget でしたが、次の札側のフリップ表示は同じ `animationResolveRef` / `isFadingOut` / `nextContentRef` を共有した上で完了を `await` していました。そのため2つのフェードサイクルが時間的に重なると、結果表示側のフェード完了が誤って次の札側のフリップ待ちを解決してしまい、次の札の表示が中断されることがありました。

今回、結果表示のフェードも自身のPromiseを生成してawaitし、次の札の取得に進む前に完了を待つよう修正することで、2つのサイクルを直列化してこの問題を解消しています。

## テスト

- `frontend`: `npm run lint` / `npx vitest run`（38/38件成功） / `npm run build` すべて成功
- `backend`: `npm run lint` / `npx vitest run`（1134/1134件成功、既存分・変更なし）
- 自動読み上げが設定した間隔で次の札まで自動的に進むことを検証するテストを追加
- 実ブラウザ（Playwright, `npm run build && npm run preview`）で複数札の連続自動読み上げが正しく動作することを確認済み

Closes #214


---
_Generated by [Claude Code](https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj)_