### PR TITLE
feat(result): 読了時のリザルト画面にセッションサマリーと紙吹雪演出を追加

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -195,6 +195,42 @@
   background-color: #e44d26;
 }
 
+/* 読了時の紙吹雪演出：画面全体に固定表示し、下方向へ落ちながらフェードアウトする */
+.confetti-container {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 1050;
+}
+
+.confetti-piece {
+  position: absolute;
+  top: -40px;
+  font-size: 1.8rem;
+  animation-name: confetti-fall;
+  animation-timing-function: ease-in;
+  animation-fill-mode: forwards;
+}
+
+@keyframes confetti-fall {
+  0% {
+    transform: translateY(0) rotate(0deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(110vh) rotate(360deg);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .confetti-piece {
+    animation: none;
+    opacity: 0;
+  }
+}
+
 .modal-overlay {
   background-color: rgba(0, 0, 0, 0.5);
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -135,6 +135,32 @@ function App() {
     return categoryKey ? (historyByCategory[categoryKey] || []) : [];
   }, [categoryKey, historyByCategory]);
 
+  // 読了時のセッションサマリー（合計所要時間・最速/最遅の札）
+  const sessionSummary = useMemo(() => {
+    if (!isAllRead) return null;
+    const timedEntries = currentHistory.filter(p => p.elapsedTime && isFinite(parseFloat(p.elapsedTime)));
+    if (timedEntries.length === 0) return null;
+
+    const totalTime = timedEntries.reduce((sum, p) => sum + parseFloat(p.elapsedTime), 0);
+    const fastest = timedEntries.reduce((a, b) => (parseFloat(b.elapsedTime) < parseFloat(a.elapsedTime) ? b : a));
+    const slowest = timedEntries.reduce((a, b) => (parseFloat(b.elapsedTime) > parseFloat(a.elapsedTime) ? b : a));
+
+    return { totalTime, fastest, slowest };
+  }, [isAllRead, currentHistory]);
+
+  // 読了時の紙吹雪演出（isAllReadになった時点の1回だけ生成し、以降の再レンダーでは揺れ動かさない）
+  const confettiPieces = useMemo(() => {
+    if (!isAllRead) return [];
+    const emojis = ["🎉", "✨", "🎊", "⭐"];
+    return Array.from({ length: 24 }, (_, i) => ({
+      id: i,
+      emoji: emojis[i % emojis.length],
+      left: Math.random() * 100,
+      delay: Math.random() * 0.6,
+      duration: 2.2 + Math.random() * 1.2,
+    }));
+  }, [isAllRead]);
+
   const EFUDA_PER_PAGE = 10;
   const efudaPages = useMemo(() => {
     const pages = [];
@@ -1421,11 +1447,50 @@ function App() {
 
       <main className="text-center">
         {isAllRead ? (
-          <div className="alert alert-success py-5 mb-5 shadow-sm rounded-4 border-0">
-            <h2 className="display-5 fw-bold mb-3">🎉 おめでとう！ 🎉</h2>
-            <p className="lead mb-4">すべての札を読み上げました！</p>
-            <button onClick={restartCategory} className="btn btn-primary btn-lg px-5 rounded-pill shadow">もう一度最初から遊ぶ</button>
-          </div>
+          <>
+            {confettiPieces.length > 0 && (
+              <div className="confetti-container" aria-hidden="true">
+                {confettiPieces.map(c => (
+                  <span
+                    key={c.id}
+                    className="confetti-piece"
+                    style={{ left: `${c.left}%`, animationDelay: `${c.delay}s`, animationDuration: `${c.duration}s` }}
+                  >
+                    {c.emoji}
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="alert alert-success py-5 mb-5 shadow-sm rounded-4 border-0">
+              <h2 className="display-5 fw-bold mb-3">🎉 おめでとう！ 🎉</h2>
+              <p className="lead mb-4">すべての札を読み上げました！</p>
+              {sessionSummary && (
+                <div className="row justify-content-center g-3 mb-4 text-dark">
+                  <div className="col-6 col-md-4">
+                    <div className="bg-white rounded-3 shadow-sm p-3 h-100">
+                      <div className="text-muted small">合計所要時間</div>
+                      <div className="h4 fw-bold mb-0">{sessionSummary.totalTime.toFixed(2)}秒</div>
+                    </div>
+                  </div>
+                  <div className="col-6 col-md-4">
+                    <div className="bg-white rounded-3 shadow-sm p-3 h-100">
+                      <div className="text-muted small">最速の札</div>
+                      <div className="fw-bold text-truncate">{sessionSummary.fastest.phrase}</div>
+                      <div className="small text-muted">{sessionSummary.fastest.elapsedTime}秒</div>
+                    </div>
+                  </div>
+                  <div className="col-6 col-md-4">
+                    <div className="bg-white rounded-3 shadow-sm p-3 h-100">
+                      <div className="text-muted small">最も時間がかかった札</div>
+                      <div className="fw-bold text-truncate">{sessionSummary.slowest.phrase}</div>
+                      <div className="small text-muted">{sessionSummary.slowest.elapsedTime}秒</div>
+                    </div>
+                  </div>
+                </div>
+              )}
+              <button onClick={restartCategory} className="btn btn-primary btn-lg px-5 rounded-pill shadow">もう一度最初から遊ぶ</button>
+            </div>
+          </>
         ) : (
           <>     
             <div className={`yomifuda-container mb-4 ${isFadingOut ? 'fade-out' : 'fade-in'}`}>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import App from './App';
 
@@ -1315,4 +1315,75 @@ describe('App', () => {
     consoleErrorSpy.mockRestore();
   }, 15000);
 
+  it('shows a session summary with total/fastest/slowest time and confetti when all phrases are read', async () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0); // 常に未読の先頭（p1→p2の順）を選ばせる
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      }
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({
+            phrases: [
+              { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-' },
+              { id: 'p2', category: 'Cat1', kana: 'い', phrase: '読み札2', level: '-' },
+            ],
+          }),
+        };
+      }
+      if (url.includes('/get-phrase?')) {
+        const id = new URL(url).searchParams.get('id');
+        return { ok: true, json: async () => ({ id, category: 'Cat1', kana: 'あ', phrase: `読み札${id === 'p1' ? '1' : '2'}`, level: '-', audioData: 'dummy' }) };
+      }
+      if (url.includes('/record-time')) {
+        return { ok: true, json: async () => ({ message: 'ok' }) };
+      }
+      if (url.includes('get-congratulation-audio')) {
+        return { ok: true, json: async () => ({ audioData: 'dummy' }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+    await waitFor(() => screen.getByText('次の札'));
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(screen.getByText('読み札1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+    }, { timeout: 8000 });
+
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(screen.getByText('読み札2', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+    }, { timeout: 8000 });
+
+    // 2枚目の待機時間を1枚目より意図的に長くし、最速/最遅の判定を決定的にする
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(screen.getByText('🎉 おめでとう！ 🎉')).toBeInTheDocument();
+    }, { timeout: 8000 });
+
+    expect(screen.getByText('合計所要時間')).toBeInTheDocument();
+
+    const fastestCard = screen.getByText('最速の札').parentElement;
+    expect(within(fastestCard).getByText('読み札1')).toBeInTheDocument();
+
+    const slowestCard = screen.getByText('最も時間がかかった札').parentElement;
+    expect(within(slowestCard).getByText('読み札2')).toBeInTheDocument();
+
+    expect(document.querySelectorAll('.confetti-piece').length).toBeGreaterThan(0);
+
+    randomSpy.mockRestore();
+  }, 20000);
 });


### PR DESCRIPTION
## 概要

全札読了時の表示を、シンプルな成功アラートのみから、セッションサマリー（合計所要時間・最速の札・最も時間がかかった札）と軽量な紙吹雪演出付きの画面に拡張します（#219）。

- `currentHistory` に蓄積された各札の `elapsedTime` から、合計所要時間・最速/最遅の札を算出して表示
- CSSのkeyframesアニメーションのみで実装した紙吹雪演出（外部ライブラリは追加せず、`prefers-reduced-motion` にも対応）
- 「もう一度最初から遊ぶ」ボタン（`restartCategory`）への導線は変更なし、既存の動作を維持
- 所要時間データが1件もない場合はサマリー部分を表示せず、従来通りのテキストのみの表示にフォールバック

## テスト

- `frontend`: `npm run lint` / `npx vitest run`（39/39件成功） / `npm run build` すべて成功
- `backend`: `npm run lint` / `npx vitest run`（1134/1134件成功、変更なし）
- 2枚の札を読み上げて読了状態に到達させ、合計所要時間・最速/最遅の札が正しく表示されることを検証するテストを追加
- 実ブラウザ（Playwright, `npm run build && npm run preview`）で実際の値（合計9.08秒、最速3.55秒、最遅5.53秒）が正しく表示されることを確認済み（このサンドボックス環境ではBootstrap CDNが遮断されているため、見た目のスタイリングそのものは目視確認できていません）

Closes #219


---
_Generated by [Claude Code](https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj)_