### PR TITLE
feat(score): プレイヤー別の取り札スコア記録機能を追加

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,9 @@ import changelogData from "./changelog.json";
 const API_BASE_URL = "https://akmnirkx3m.execute-api.ap-northeast-1.amazonaws.com/dev";
 
 const HISTORY_STORAGE_KEY = "historyByCategory";
+const PLAYERS_STORAGE_KEY = "players";
+const SCORES_STORAGE_KEY = "scoresByCategory";
+const MAX_PLAYERS = 6;
 
 const parseCategoriesParam = (value) => (value ? value.split(",").filter(Boolean).map(decodeURIComponent) : []);
 const serializeCategoriesParam = (categories) => categories.map(encodeURIComponent).join(",");
@@ -95,7 +98,25 @@ function App() {
       return {};
     }
   });
-  
+  const [players, setPlayers] = useState(() => {
+    try {
+      const stored = sessionStorage.getItem(PLAYERS_STORAGE_KEY);
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
+    }
+  });
+  const [newPlayerName, setNewPlayerName] = useState("");
+  const [scoresByCategory, setScoresByCategory] = useState(() => {
+    try {
+      const stored = sessionStorage.getItem(SCORES_STORAGE_KEY);
+      return stored ? JSON.parse(stored) : {};
+    } catch {
+      return {};
+    }
+  });
+  const [currentRoundTakenBy, setCurrentRoundTakenBy] = useState(null);
+
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [draftCategories, setDraftCategories] = useState([]);
 
@@ -134,6 +155,19 @@ function App() {
   const currentHistory = useMemo(() => {
     return categoryKey ? (historyByCategory[categoryKey] || []) : [];
   }, [categoryKey, historyByCategory]);
+
+  const currentScores = useMemo(() => {
+    return categoryKey ? (scoresByCategory[categoryKey] || {}) : {};
+  }, [categoryKey, scoresByCategory]);
+
+  // 読了時のスコア集計（参加者が1人以上登録されている場合のみ表示する）
+  const scoreSummary = useMemo(() => {
+    if (!isAllRead || division === "kids" || players.length === 0) return null;
+    const entries = players.map(name => ({ name, count: currentScores[name] || 0 }));
+    const maxCount = Math.max(0, ...entries.map(e => e.count));
+    const winners = maxCount > 0 ? entries.filter(e => e.count === maxCount).map(e => e.name) : [];
+    return { entries, winners };
+  }, [isAllRead, division, players, currentScores]);
 
   // 読了時のセッションサマリー（合計所要時間・最速/最遅の札）
   const sessionSummary = useMemo(() => {
@@ -870,6 +904,20 @@ function App() {
   }, [historyByCategory]);
 
   useEffect(() => {
+    sessionStorage.setItem(PLAYERS_STORAGE_KEY, JSON.stringify(players));
+  }, [players]);
+
+  useEffect(() => {
+    sessionStorage.setItem(SCORES_STORAGE_KEY, JSON.stringify(scoresByCategory));
+  }, [scoresByCategory]);
+
+  // ラウンドが切り替わったら「取った人」の選択状態をリセットする
+  // （もう一度再生（phraseDataなしのキュー投入）ではcurrentPhraseが変わらないため反応しない）
+  useEffect(() => {
+    setCurrentRoundTakenBy(null);
+  }, [currentPhrase]);
+
+  useEffect(() => {
     document.documentElement.setAttribute("data-bs-theme", resolvedTheme);
   }, [resolvedTheme]);
 
@@ -897,10 +945,50 @@ function App() {
       ...prev,
       [categoryKey]: []
     }));
+    setScoresByCategory(prev => ({
+      ...prev,
+      [categoryKey]: {}
+    }));
     setCurrentPhrase(null);
     setDisplayContent({ type: "initial" });
     setIsAllRead(false);
     setIsFadingOut(false);
+  };
+
+  const addPlayer = () => {
+    const trimmed = newPlayerName.trim();
+    if (!trimmed || players.includes(trimmed) || players.length >= MAX_PLAYERS) return;
+    setPlayers(prev => [...prev, trimmed]);
+    setNewPlayerName("");
+  };
+
+  const removePlayer = (name) => {
+    setPlayers(prev => prev.filter(p => p !== name));
+    setScoresByCategory(prev => {
+      const next = {};
+      for (const [catKey, scores] of Object.entries(prev)) {
+        const catScores = { ...scores };
+        delete catScores[name];
+        next[catKey] = catScores;
+      }
+      return next;
+    });
+  };
+
+  // 取った人を記録する（同じ人を再度タップした場合は取り消し扱いにする）
+  const recordTaken = (name) => {
+    if (!currentPhrase) return;
+    setScoresByCategory(prev => {
+      const catScores = { ...(prev[categoryKey] || {}) };
+      if (currentRoundTakenBy) {
+        catScores[currentRoundTakenBy] = Math.max(0, (catScores[currentRoundTakenBy] || 0) - 1);
+      }
+      if (name !== currentRoundTakenBy) {
+        catScores[name] = (catScores[name] || 0) + 1;
+      }
+      return { ...prev, [categoryKey]: catScores };
+    });
+    setCurrentRoundTakenBy(prev => (prev === name ? null : name));
   };
 
   const selectDivision = (div) => {
@@ -1348,6 +1436,41 @@ function App() {
                   <h3 className="h5 mb-4 fw-bold">
                     {draftCategories.map(cat => `「${cat}」`).join("")}をお手元に持っていますか？
                   </h3>
+
+                  <div className="mb-4 text-start">
+                    <h4 className="h6 fw-bold mb-2">取った人を記録する参加者（任意）</h4>
+                    {players.length > 0 && (
+                      <div className="d-flex flex-wrap gap-2 mb-2">
+                        {players.map(name => (
+                          <span key={name} className="badge bg-secondary d-flex align-items-center gap-1 py-2 px-3 fs-6">
+                            {name}
+                            <button
+                              type="button"
+                              onClick={() => removePlayer(name)}
+                              className="btn-close btn-close-white"
+                              style={{ fontSize: "0.6rem" }}
+                              aria-label={`${name}を削除`}
+                            ></button>
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                    {players.length < MAX_PLAYERS && (
+                      <div className="d-flex gap-2">
+                        <input
+                          type="text"
+                          value={newPlayerName}
+                          onChange={(e) => setNewPlayerName(e.target.value)}
+                          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addPlayer(); } }}
+                          placeholder="名前を入力"
+                          className="form-control"
+                          maxLength={20}
+                        />
+                        <button type="button" onClick={addPlayer} disabled={!newPlayerName.trim()} className="btn btn-outline-primary">追加</button>
+                      </div>
+                    )}
+                  </div>
+
                   <div className="d-flex gap-2 justify-content-center">
                     <button onClick={confirmCategory} className="btn btn-primary btn-lg px-4 rounded-pill shadow-sm fs-6">はい</button>
                     <button onClick={cancelCategory} className="btn btn-outline-secondary btn-lg px-4 rounded-pill fs-6">いいえ</button>
@@ -1488,17 +1611,52 @@ function App() {
                   </div>
                 </div>
               )}
+              {scoreSummary && (
+                <div className="mb-4 text-dark">
+                  <h3 className="h5 fw-bold mb-3">
+                    {scoreSummary.winners.length === 1
+                      ? `🏆 優勝: ${scoreSummary.winners[0]}`
+                      : scoreSummary.winners.length > 1
+                      ? `🏆 優勝: ${scoreSummary.winners.join('・')}（同点）`
+                      : "取った札の記録はありません"}
+                  </h3>
+                  <div className="d-flex flex-wrap gap-2 justify-content-center">
+                    {scoreSummary.entries.map(e => (
+                      <div key={e.name} className="bg-white rounded-3 shadow-sm px-3 py-2">
+                        <span className="fw-bold">{e.name}</span>: {e.count}枚
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
               <button onClick={restartCategory} className="btn btn-primary btn-lg px-5 rounded-pill shadow">もう一度最初から遊ぶ</button>
             </div>
           </>
         ) : (
-          <>     
+          <>
             <div className={`yomifuda-container mb-4 ${isFadingOut ? 'fade-out' : 'fade-in'}`}>
               {displayContent.type === 'phrase' && renderPhrase(displayContent.content)}
               {displayContent.type === 'result' && renderResult(displayContent.content)}
               {displayContent.type === 'initial' && renderInitial()}
             </div>
-            
+
+            {displayContent.type === 'phrase' && division !== "kids" && players.length > 0 && (
+              <div className="mb-4">
+                <div className="text-muted small mb-2">取った人:</div>
+                <div className="d-flex flex-wrap gap-2 justify-content-center">
+                  {players.map(name => (
+                    <button
+                      key={name}
+                      onClick={() => recordTaken(name)}
+                      className={`btn btn-sm rounded-pill px-3 ${currentRoundTakenBy === name ? 'btn-dark' : 'btn-outline-dark'}`}
+                    >
+                      {name}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
             <div className="d-flex flex-wrap gap-3 justify-content-center mb-5">
               <button onClick={playKaruta} disabled={loading} className="btn btn-lg px-4 py-3 fw-bold rounded-pill shadow btn-karuta">
                 {loading && <span className="spinner-border spinner-border-sm me-2"></span>}

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1386,4 +1386,85 @@ describe('App', () => {
 
     randomSpy.mockRestore();
   }, 20000);
+
+  it('registers players, records who took each card, and shows the winner on the result screen', async () => {
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1', phrase: '読み札1' }] }) };
+      if (url.includes('/get-phrase?')) return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', phrase: '読み札1', audioData: 'dummy' }) };
+      if (url.includes('/record-time')) return { ok: true, json: async () => ({ message: 'ok' }) };
+      if (url.includes('get-congratulation-audio')) return { ok: true, json: async () => ({ audioData: 'dummy' }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('エンジニア向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    fireEvent.click(screen.getByText(/決定/));
+
+    await waitFor(() => screen.getByText(/「Cat1」をお手元に持っていますか？/));
+
+    const nameInput = screen.getByPlaceholderText('名前を入力');
+    fireEvent.change(nameInput, { target: { value: 'たろう' } });
+    fireEvent.click(screen.getByText('追加'));
+    fireEvent.change(nameInput, { target: { value: 'はなこ' } });
+    fireEvent.click(screen.getByText('追加'));
+
+    expect(screen.getByText('たろう')).toBeInTheDocument();
+    expect(screen.getByText('はなこ')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('はい'));
+
+    await waitFor(() => screen.getByText('次の札'));
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(screen.getByText('読み札1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+    }, { timeout: 8000 });
+
+    expect(screen.getByText('取った人:')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'たろう' }));
+
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(screen.getByText('🎉 おめでとう！ 🎉')).toBeInTheDocument();
+    }, { timeout: 8000 });
+
+    expect(screen.getByText('🏆 優勝: たろう')).toBeInTheDocument();
+    const taroCard = screen.getByText('たろう', { selector: 'span.fw-bold' }).parentElement;
+    expect(within(taroCard).getByText(/1枚/)).toBeInTheDocument();
+    const hanakoCard = screen.getByText('はなこ', { selector: 'span.fw-bold' }).parentElement;
+    expect(within(hanakoCard).getByText(/0枚/)).toBeInTheDocument();
+  }, 15000);
+
+  it('does not show player registration or the taken-by buttons in kids mode even if players are already registered', async () => {
+    sessionStorage.setItem('players', JSON.stringify(['たろう']));
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1', phrase: '読み札1' }] }) };
+      if (url.includes('/get-phrase?')) return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', phrase: '読み札1', audioData: 'dummy' }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+    await waitFor(() => screen.getByText('次の札'));
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(screen.getByText('読み札1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+    }, { timeout: 8000 });
+
+    expect(screen.queryByText('取った人:')).not.toBeInTheDocument();
+  }, 15000);
 });


### PR DESCRIPTION
## 概要

「誰が何枚取ったか」を記録できるプレイヤー別スコア機能を追加します（#220）。バックエンド永続化は行わず、フロントエンドのローカル状態（sessionStorage）のみで完結します。

- カテゴリ確定モーダル（「お手元に持っていますか？」）に参加者登録UI（最大6名、任意）を追加
- 読み上げ画面で、現在表示中の札について「取った人:」ボタンをワンタップで記録
- 読了時のリザルト画面（#219）にプレイヤーごとの取得枚数と勝者（同点時は複数名）を表示
- 参加者を1人も登録しない場合は表示・挙動とも従来通り変化なし
- こども向け（kids）モードは、#196で意図的に設計されたシンプルな1タップ導線を維持するため、スコア関連UIを一律非表示に

## テスト

- `frontend`: `npm run lint` / `npx vitest run`（41/41件成功） / `npm run build` すべて成功
- `backend`: `npm run lint` / `npx vitest run`（1134/1134件成功、変更なし）
- 参加者2名を登録し、各札で「取った人」を記録し、読了時に正しい勝者とスコアが表示されることを検証するテストを追加
- こどもモードでは参加者が登録済みでも関連UIが表示されないことを検証するテストを追加
- 実ブラウザ（Playwright, `npm run build && npm run preview`）で、2名登録→2ラウンド分の記録→同点時に両者が勝者として表示されることまで一連の流れを確認済み

Closes #220


---
_Generated by [Claude Code](https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj)_