### PR TITLE
feat(pwa): ホーム画面追加導線をSafari/Android向けに追加

### DIFF
--- a/frontend/src/AddToHomeScreenPrompt.css
+++ b/frontend/src/AddToHomeScreenPrompt.css
@@ -1,0 +1,36 @@
+.a2hs-prompt {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  width: calc(100vw - 2rem);
+  max-width: 420px;
+  padding: 0.75rem 1rem;
+  background-color: #333;
+  color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  font-size: 0.9rem;
+  text-align: center;
+  box-sizing: border-box;
+}
+
+.a2hs-prompt-buttons {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.a2hs-prompt-button {
+  padding: 0.4rem 0.8rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #fff;
+  color: #333;
+  font-weight: bold;
+  cursor: pointer;
+}

--- a/frontend/src/AddToHomeScreenPrompt.jsx
+++ b/frontend/src/AddToHomeScreenPrompt.jsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+import "./AddToHomeScreenPrompt.css";
+
+const DISMISSED_STORAGE_KEY = "a2hsPromptDismissed";
+
+const isStandalone = () => {
+  return Boolean(window.matchMedia?.("(display-mode: standalone)").matches || window.navigator.standalone === true);
+};
+
+// iOSのChrome/Firefox/EdgeはUAに専用トークン（CriOS/FxiOS/EdgiOS）を含むため、
+// それらを除外することでiOS Safari（ホーム画面追加の案内が必要な対象）のみを判定する
+const isIosSafari = () => {
+  const ua = navigator.userAgent;
+  const isIos = /iphone|ipad|ipod/i.test(ua);
+  const isOtherIosBrowser = /crios|fxios|edgios/i.test(ua);
+  return isIos && /safari/i.test(ua) && !isOtherIosBrowser;
+};
+
+function AddToHomeScreenPrompt() {
+  const [dismissed, setDismissed] = useState(() => localStorage.getItem(DISMISSED_STORAGE_KEY) === "true");
+  const [installed, setInstalled] = useState(isStandalone);
+  const [deferredPrompt, setDeferredPrompt] = useState(null);
+  const [showIosGuide] = useState(isIosSafari);
+
+  useEffect(() => {
+    const handleBeforeInstallPrompt = (e) => {
+      e.preventDefault();
+      setDeferredPrompt(e);
+    };
+    const handleAppInstalled = () => {
+      setInstalled(true);
+      setDeferredPrompt(null);
+    };
+    window.addEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
+    window.addEventListener("appinstalled", handleAppInstalled);
+    return () => {
+      window.removeEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
+      window.removeEventListener("appinstalled", handleAppInstalled);
+    };
+  }, []);
+
+  const dismiss = () => {
+    localStorage.setItem(DISMISSED_STORAGE_KEY, "true");
+    setDismissed(true);
+  };
+
+  const handleInstallClick = async () => {
+    if (!deferredPrompt) return;
+    deferredPrompt.prompt();
+    await deferredPrompt.userChoice;
+    setDeferredPrompt(null);
+    dismiss();
+  };
+
+  if (installed || dismissed) return null;
+
+  if (deferredPrompt) {
+    return (
+      <div className="a2hs-prompt" role="alert">
+        <span>ホーム画面に追加できます</span>
+        <div className="a2hs-prompt-buttons">
+          <button type="button" className="a2hs-prompt-button" onClick={handleInstallClick}>
+            追加する
+          </button>
+          <button type="button" className="a2hs-prompt-button" onClick={dismiss}>
+            閉じる
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (showIosGuide) {
+    return (
+      <div className="a2hs-prompt" role="alert">
+        <span>共有ボタンから「ホーム画面に追加」を選ぶとアプリのように使えます</span>
+        <div className="a2hs-prompt-buttons">
+          <button type="button" className="a2hs-prompt-button" onClick={dismiss}>
+            閉じる
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+export default AddToHomeScreenPrompt;

--- a/frontend/src/AddToHomeScreenPrompt.test.jsx
+++ b/frontend/src/AddToHomeScreenPrompt.test.jsx
@@ -1,0 +1,121 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import AddToHomeScreenPrompt from "./AddToHomeScreenPrompt.jsx";
+
+const IOS_SAFARI_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/604.1";
+const IOS_CHROME_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.6099.119 Mobile/15E148 Safari/604.1";
+const ANDROID_CHROME_UA = "Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Mobile Safari/537.36";
+const DESKTOP_CHROME_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36";
+
+const setUserAgent = (ua) => {
+  Object.defineProperty(window.navigator, "userAgent", { value: ua, configurable: true });
+};
+
+const setStandalone = (matches) => {
+  window.matchMedia = vi.fn().mockImplementation((query) => ({
+    matches: query === "(display-mode: standalone)" ? matches : false,
+    media: query,
+  }));
+};
+
+describe("AddToHomeScreenPrompt", () => {
+  const originalUA = window.navigator.userAgent;
+
+  beforeEach(() => {
+    localStorage.clear();
+    setStandalone(false);
+  });
+
+  afterEach(() => {
+    setUserAgent(originalUA);
+  });
+
+  it("すでにホーム画面に追加済み（standalone）の場合は何も表示しない", () => {
+    setUserAgent(IOS_SAFARI_UA);
+    setStandalone(true);
+
+    const { container } = render(<AddToHomeScreenPrompt />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("iOS Safariの場合はホーム画面追加の案内を表示する", () => {
+    setUserAgent(IOS_SAFARI_UA);
+
+    render(<AddToHomeScreenPrompt />);
+
+    expect(screen.getByText(/ホーム画面に追加」を選ぶ/)).toBeInTheDocument();
+  });
+
+  it("iOSでもSafari以外（CriOSを含むUA）の場合は案内を表示しない", () => {
+    setUserAgent(IOS_CHROME_UA);
+
+    const { container } = render(<AddToHomeScreenPrompt />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("Android/iOSどちらの条件にも当てはまらない場合は何も表示しない", () => {
+    setUserAgent(DESKTOP_CHROME_UA);
+
+    const { container } = render(<AddToHomeScreenPrompt />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("iOSの案内を閉じると非表示になり、localStorageに保存されて再訪時も表示されない", () => {
+    setUserAgent(IOS_SAFARI_UA);
+
+    render(<AddToHomeScreenPrompt />);
+    fireEvent.click(screen.getByRole("button", { name: "閉じる" }));
+
+    expect(screen.queryByText(/ホーム画面に追加」を選ぶ/)).not.toBeInTheDocument();
+    expect(localStorage.getItem("a2hsPromptDismissed")).toBe("true");
+
+    const { container } = render(<AddToHomeScreenPrompt />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("beforeinstallpromptイベントを受け取ると独自の追加ボタンを表示し、クリックでprompt()を呼ぶ", async () => {
+    setUserAgent(ANDROID_CHROME_UA);
+    render(<AddToHomeScreenPrompt />);
+
+    const promptFn = vi.fn();
+    const event = new Event("beforeinstallprompt", { cancelable: true });
+    event.prompt = promptFn;
+    event.userChoice = Promise.resolve({ outcome: "accepted" });
+
+    await act(async () => {
+      window.dispatchEvent(event);
+    });
+
+    expect(screen.getByText("ホーム画面に追加できます")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "追加する" }));
+      await event.userChoice;
+    });
+
+    expect(promptFn).toHaveBeenCalled();
+    expect(localStorage.getItem("a2hsPromptDismissed")).toBe("true");
+  });
+
+  it("appinstalledイベントを受け取ると案内を非表示にする", async () => {
+    setUserAgent(ANDROID_CHROME_UA);
+    render(<AddToHomeScreenPrompt />);
+
+    const event = new Event("beforeinstallprompt", { cancelable: true });
+    event.prompt = vi.fn();
+    event.userChoice = Promise.resolve({ outcome: "accepted" });
+    await act(async () => {
+      window.dispatchEvent(event);
+    });
+    expect(screen.getByText("ホーム画面に追加できます")).toBeInTheDocument();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("appinstalled"));
+    });
+
+    expect(screen.queryByText("ホーム画面に追加できます")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,10 +3,12 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 import PwaUpdatePrompt from './PwaUpdatePrompt.jsx'
+import AddToHomeScreenPrompt from './AddToHomeScreenPrompt.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />
     <PwaUpdatePrompt />
+    <AddToHomeScreenPrompt />
   </StrictMode>,
 )


### PR DESCRIPTION
## 概要

PWAのホーム画面追加導線をブラウザごとに実装します（#197）。

- **iOS Safari**: `beforeinstallprompt`が存在しないため、UA判定（Safari以外のiOSブラウザを除外）で「共有ボタンから『ホーム画面に追加』を選ぶと...」という案内バナーを表示
- **Android/Chromium系**: `beforeinstallprompt`イベントを捕捉してデフォルトのプロンプトを抑止し、独自の「追加する」ボタンから`prompt()`を呼び出してワンタップインストール
- 既にインストール済み（`display-mode: standalone` / `navigator.standalone`）の場合は何も表示しない
- 一度閉じた場合はlocalStorageに記録し、以後再表示しない
- 既存の`PwaUpdatePrompt.jsx`と同じ「独立コンポーネントをmain.jsxで並列マウントする」パターンを踏襲

実ブラウザ（Playwright）での確認時に、案内文言とボタン幅の合計がコンテナ幅とほぼ一致してテキストが1文字ずつ縦に折り返される表示崩れを発見したため、テキストとボタン群を縦に積むレイアウトに修正済みです。

## テスト

- `frontend`: `npm run lint` / `npx vitest run`（48/48件成功） / `npm run build` すべて成功
- `backend`: `npm run lint` / `npx vitest run`（1134/1134件成功、変更なし）
- standalone判定・iOS Safari判定（Safari以外のiOSブラウザの除外含む）・閉じた後の再訪時非表示・`beforeinstallprompt`捕捉と`prompt()`呼び出し・`appinstalled`イベントでの非表示化を検証するテストを追加
- 実ブラウザ（Playwright, `npm run build && npm run preview`）で、Android向け独自ボタンとiOS Safari向け案内の両方の表示崩れがないことを確認済み

Closes #197


---
_Generated by [Claude Code](https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj)_