### PR TITLE
fix(deploy): LambdaランタイムをEOL間近のnodejs18.xからnodejs20.xへ更新

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -2,7 +2,7 @@ service: karuta-app
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   region: ap-northeast-1
   environment:
     TABLE_NAME: ${self:custom.tableName}


### PR DESCRIPTION
## 概要

`serverless.yml`のLambdaランタイムがサポート終了に向かっている`nodejs18.x`に固定されていたため、更新します（#187）。

- `provider.runtime`を`nodejs18.x`から`nodejs20.x`（LTS）へ更新

## nodejs22.xではなくnodejs20.xを選んだ理由

Issue本文では最新LTS（nodejs22.x等）への更新が提案されていましたが、現在インストールされているServerless Framework（v3.40.0）は`provider.runtime`の値をJSON Schemaのenumで検証しており、そのallowlistが`nodejs20.x`までしか含んでいないことを`npx serverless print`で実際に確認しました。`nodejs22.x`を指定すると以下の警告が出ます。

```
Warning: Invalid configuration encountered
  at 'provider.runtime': must be equal to one of the allowed values [... nodejs18.x, nodejs20.x, ...]
```

AWS自体はnodejs22.xランタイムをサポートしているため警告止まりで実際のデプロイは通る可能性が高いですが、本番デプロイパイプライン（cd.yml、実AWS環境へのデプロイ）でこの挙動を確認する手段がこの環境には無いため、警告が一切出ないことを確実に保証できる`nodejs20.x`を採用しました。Serverless Framework自体をv4へ上げる案は、ライセンス体系の変更を伴う大きな変更であり、本Issueの意図（EOLが近い`nodejs18.x`からの脱却）を超える範囲のため見送っています。

## テスト

- `backend`: `npm run lint` / `npx vitest run`（1134/1134件成功、変更なし） / `npx serverless print`で設定検証エラー・警告が出ないことを確認
- `frontend`: 変更なし。`npm run lint` / `npm run build`成功を確認
- アプリケーションコード（`handler.js`等）はAWS SDK v3系のみに依存しており、テストコードの追加は不要と判断
- 実際のAWS環境への再デプロイ後の動作確認は、この環境からは実施できないため、CI/CDの`deploy-backend`ジョブでのデプロイ結果を確認する必要があります

Closes #187


---
_Generated by [Claude Code](https://claude.ai/code/session_0179CM44ritPnwgofTSjQsbj)_