### PR TITLE
fix(frontend): frontend-testの慢性的なタイムアウトFlakinessを緩和

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -331,10 +331,10 @@ describe('App', () => {
       const getPhraseCall = fetch.mock.calls.find(([url]) => url.includes('/get-phrase?'));
       expect(getPhraseCall).toBeDefined();
       expect(getPhraseCall[0]).toContain('announceCategory=true');
-    });
+    }, { timeout: 8000 });
 
     randomSpy.mockRestore();
-  });
+  }, 25000);
 
   it('requests announceCategory=false when reading with a single category selected', async () => {
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
@@ -361,10 +361,10 @@ describe('App', () => {
       const getPhraseCall = fetch.mock.calls.find(([url]) => url.includes('/get-phrase?'));
       expect(getPhraseCall).toBeDefined();
       expect(getPhraseCall[0]).toContain('announceCategory=false');
-    });
+    }, { timeout: 8000 });
 
     randomSpy.mockRestore();
-  });
+  }, 25000);
 
   it('shows a read/total progress counter that updates as phrases are read', async () => {
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
@@ -1423,7 +1423,7 @@ describe('App', () => {
 
     await waitFor(() => {
       expect(screen.getByText('読み札1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
-    }, { timeout: 15000 });
+    }, { timeout: 20000 });
 
     expect(screen.getByText('取った人:')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'たろう' }));
@@ -1432,14 +1432,14 @@ describe('App', () => {
 
     await waitFor(() => {
       expect(screen.getByText('🎉 おめでとう！ 🎉')).toBeInTheDocument();
-    }, { timeout: 15000 });
+    }, { timeout: 20000 });
 
     expect(screen.getByText('🏆 優勝: たろう')).toBeInTheDocument();
     const taroCard = screen.getByText('たろう', { selector: 'span.fw-bold' }).parentElement;
     expect(within(taroCard).getByText(/1枚/)).toBeInTheDocument();
     const hanakoCard = screen.getByText('はなこ', { selector: 'span.fw-bold' }).parentElement;
     expect(within(hanakoCard).getByText(/0枚/)).toBeInTheDocument();
-  }, 40000);
+  }, 50000);
 
   it('does not show player registration or the taken-by buttons in kids mode even if players are already registered', async () => {
     sessionStorage.setItem('players', JSON.stringify(['たろう']));

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,4 +1,9 @@
 import '@testing-library/jest-dom';
+import { configure } from '@testing-library/react';
+
+// CI環境ではローカルより実行が遅くなることがあり、waitFor系のデフォルトタイムアウト(1000ms)では
+// 音声再生・アニメーション待ちを伴うテストがまれにタイムアウトすることがあるため底上げする。
+configure({ asyncUtilTimeout: 3000 });
 
 // Node 22+ がフラグなしの `localStorage` グローバルを提供するが、
 // `--localstorage-file` 未指定だと getItem/setItem が機能せず jsdom の実装を覆ってしまう。

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -32,5 +32,9 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: './src/setupTests.js',
+    // setupTests.js で waitFor 系のデフォルトタイムアウトを底上げしているため、
+    // 個別に timeout を指定していないテストが vitest 側の既定値(5000ms)で
+    // 先に打ち切られないよう、テスト自体のタイムアウトも合わせて底上げする。
+    testTimeout: 10000,
   },
 })


### PR DESCRIPTION
設計:
- 選定内容: waitFor系のデフォルトタイムアウトを底上げ(configure({ asyncUtilTimeout: 3000 }))し、 vitestのテスト自体のタイムアウトもvite.config.jsでグローバルに底上げ(testTimeout: 10000)する。 加えて、他の同種テストと比べ明示的なタイムアウト指定が欠けていた announceCategory=true/falseの2テストに既存パターンと同じ指定を追加し、 すでに一度失敗実績のあった重量級テスト(読み上げ→勝者表示)のタイムアウトにも追加の余裕を持たせた。
- 却下内容: vi.useFakeTimers()導入によるタイマー処理の全面書き換え。Flakinessの根絶にはより効果的だが、 App.test.jsx(約1470行)の広範な改修が必要でリスクが高く、最小限の変更を優先する方針と合わない。
- 理由: CIランナーの負荷変動時、App.jsxの読み上げフロー(イントロ音声・3秒待機・フェード等の 実時間タイマー連鎖、合計約3.8秒)を伴うテストが、既存のタイムアウト値を超えてまれに失敗しており、 内容と無関係な複数PR(直近のPR #264, #263含む)で再発していたため、まずは低リスクな タイムアウト底上げで解消を図る。

影響:
- 影響モジュール: frontend/src/App.test.jsx, frontend/src/setupTests.js, frontend/vite.config.js
- 振る舞いの変更:
  - テスト実行時にwaitFor系アサーションの既定待機時間が1000ms→3000msへ延長される。
  - vitestの各テスト既定タイムアウトが5000ms→10000msへ延長される(個別に指定済みのテストは 従来通りその値が優先される)。
  - announceCategory=true/falseテスト、および読み上げ→勝者表示テストのタイムアウトを 実測の累積待ち時間に対して十分な余裕を持つ値に調整。
  - アプリ本体(frontend/src/App.jsx等)のロジックは変更していない。

テスト:
- 追加済み: なし(新規テストケースの追加は不要と判断。既存テストのタイムアウト調整のみ)。
- 未追加: frontend lint(0件)/test(59件成功)/build成功、backend lint(0件)/test(1134件成功)を ローカルで確認済み。


Claude-Session: https://claude.ai/code/session_01Ah1oJetiPz6ch3eT6Dxuj1