### PR TITLE
fix(frontend): 停止操作後にisReadingが固定され読み上げ不能になる不具合を修正

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -433,6 +433,7 @@ function App() {
       // 停止ボタンが押されていたら、次のフェーズ（本編読み上げ）に進まず打ち切る
       if (stopRequestedRef.current) {
         stopRequestedRef.current = false;
+        setIsReading(false);
         return;
       }
 
@@ -461,12 +462,14 @@ function App() {
       await playAudio(audioData).catch(e => console.error("Audio playback failed:", e));
       if (stopRequestedRef.current) {
         stopRequestedRef.current = false;
+        setIsReading(false);
         return;
       }
 
       await animationPromise;
       if (stopRequestedRef.current) {
         stopRequestedRef.current = false;
+        setIsReading(false);
         return;
       }
 

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1204,6 +1204,88 @@ describe('App', () => {
     window.Audio = originalAudio;
   }, 10000);
 
+  it('recovers isReading (does not get stuck) after stopping mid-intro-sound and starting the next card (issue #262)', async () => {
+    const originalAudio = window.Audio;
+    const pauseMock = vi.fn();
+    // カード1のイントロ音の再生中に停止ボタンを確実に捕まえられるよう、
+    // 通常のテスト用モック（onendedを即座に自動発火させる）とは異なり、
+    // onendedを意図的に発火させないモックに一時的に差し替える。
+    window.Audio = vi.fn().mockImplementation((url) => {
+      const audio = {
+        play: vi.fn().mockResolvedValue(),
+        pause: pauseMock,
+        load: vi.fn(),
+        set src(_url) {
+          // onendedを意図的に発火させない
+        },
+      };
+      if (url) audio.src = url;
+      return audio;
+    });
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({
+            phrases: [
+              { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-' },
+              { id: 'p2', category: 'Cat1', kana: 'い', phrase: '読み札2', level: '-' },
+            ],
+          }),
+        };
+      }
+      if (url.includes('/get-phrase?id=p1')) return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', audioData: 'dummy1' }) };
+      if (url.includes('/get-phrase?id=p2')) return { ok: true, json: async () => ({ id: 'p2', category: 'Cat1', kana: 'い', phrase: '読み札2', level: '-', audioData: 'dummy2' }) };
+      if (url.includes('/record-time')) return { ok: true, json: async () => ({ message: 'ok' }) };
+      return { ok: false };
+    });
+
+    try {
+      await act(async () => {
+        render(<App />);
+      });
+
+      fireEvent.click(await screen.findByText('こども向け'));
+      fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+      await waitFor(() => screen.getByText('次の札'));
+      fireEvent.click(screen.getByText('次の札'));
+
+      // イントロ音（たいこの音）再生中に停止ボタンを押す
+      const stopButton = await screen.findByRole('button', { name: '停止' });
+      await waitFor(() => expect(stopButton).not.toBeDisabled(), { timeout: 4000 });
+      fireEvent.click(stopButton);
+
+      expect(pauseMock).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: '停止' })).toBeDisabled();
+      });
+
+      // 以降のカードは通常のテスト用モック（onendedが自動発火する）に戻し、
+      // カード2の読み上げが自然に完了できるようにする。
+      window.Audio = originalAudio;
+
+      // 停止直後に「次の札」を押しても、isReadingが真に固定されて以降ずっと
+      // 読み上げできなくなってはいけない（停止ボタンがいずれ押せなくなること＝
+      // isReadingがfalseに戻ることを確認する）。
+      fireEvent.click(screen.getByText('次の札'));
+
+      await waitFor(
+        () => {
+          expect(screen.getByRole('button', { name: '停止' })).toBeDisabled();
+        },
+        { timeout: 8000 }
+      );
+
+      // カード2が実際に履歴へ記録され、次のカードへ進めることも確認する
+      expect(screen.getAllByText('読み札2').length).toBeGreaterThan(0);
+    } finally {
+      window.Audio = originalAudio;
+    }
+  }, 15000);
+
   it('does not reset the elapsed-time start point when the card is replayed before advancing', async () => {
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) {


### PR DESCRIPTION
## Summary
- `playNextInQueue` 内の3箇所の早期return（停止フラグ検知時）で `setIsReading(false)` を呼んでいなかったため、停止操作に起因する中断後に `isReading` が `true` のまま固定され、以降「次の札」を押しても読み上げが一切進まなくなる不具合を修正
- 40枚中37枚目で読み上げが止まり、停止→次の札を押しても「たいこの音」だけ再生されて本編が読み上げられないという再現報告（#262）と一致する原因

## Test plan
- [x] `frontend`: lint / test（60件）/ build すべてパス
- [x] `backend`: lint / test（1134件）パス（変更なし）
- [x] 停止直後に次の札へ進んでも読み上げ不能に固定されないことを検証する回帰テストを追加（修正前のコードでは約4割の頻度で失敗することを確認済み、修正後は複数回連続でパス）
- [x] `/code-review` による自己レビュー実施、指摘事項はすべて修正済み

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EGXmLK3Kp8vdbuirfduSNX)_