### PR TITLE
fix(ci): release同期時の無駄なCI再実行と無条件デプロイを解消

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      new_release_published: ${{ steps.check-release.outputs.new_release_published }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -60,12 +62,27 @@ jobs:
       # release への追従直後に実行することで、他のマージとの競合（semantic-release が
       # 「ローカルの release が remote より古い」と判定してリリースを黒くスキップする
       # 問題）が起きる時間差を最小化する
+      - name: Record pre-release commit
+        id: pre-release
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN != '' && secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
         run: npx semantic-release
+      # semantic-release は新バージョンを発行した場合のみ release ブランチに
+      # コミットを追加するため、実行前後のコミットを比較して新リリースの有無を判定する
+      - name: Check if a new release was published
+        id: check-release
+        run: |
+          AFTER_SHA=$(git rev-parse HEAD)
+          if [ "${{ steps.pre-release.outputs.sha }}" != "$AFTER_SHA" ]; then
+            echo "new_release_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "new_release_published=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Create PR from release to main
         id: sync-pr
+        if: steps.check-release.outputs.new_release_published == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.BOT_TOKEN }}
@@ -83,9 +100,13 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}
-        run: gh pr merge --auto --squash "${{ steps.sync-pr.outputs.pull-request-url }}"
+        run: |
+          gh pr merge --auto --squash \
+            --subject "chore: sync release branch into main (#${{ steps.sync-pr.outputs.pull-request-number }}) [skip ci]" \
+            "${{ steps.sync-pr.outputs.pull-request-url }}"
   build-and-deploy-frontend:
     needs: release
+    if: success() && needs.release.outputs.new_release_published == 'true'
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -121,6 +142,7 @@ jobs:
 
   deploy-backend:
     needs: release
+    if: success() && needs.release.outputs.new_release_published == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,14 +86,21 @@ jobs:
           script: |
             const prNumber = context.payload.pull_request.number;
             const branchName = context.payload.pull_request.head.ref;
+            const isSyncPR = branchName.startsWith('sync/release-to-main');
             console.log(`Attempting to merge PR #${prNumber}`);
             try {
-              await github.rest.pulls.merge({
+              const mergeParams = {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: prNumber,
                 merge_method: "squash"
-              });
+              };
+              // release→main同期PRのsquashコミットには [skip ci] を明示し、
+              // main への push で再度CIが走ることを防ぐ
+              if (isSyncPR) {
+                mergeParams.commit_title = `chore: sync release branch into main (#${prNumber}) [skip ci]`;
+              }
+              await github.rest.pulls.merge(mergeParams);
               console.log(`Successfully merged PR #${prNumber}`);
             } catch (error) {
               console.error(`Failed to merge PR #${prNumber}:`, error.message);


### PR DESCRIPTION
## 概要
`main`→`release`→`main`の自動同期構成で、release→main同期PR（`sync/release-to-main-*`）がマージされるたびに以下の无駄が発生していた問題を解消する。

1. 同期PR自体が実質差分のない内容に対してCI（`commitlint`/`frontend-test`/`backend-test`）を再実行してしまう
2. `build-and-deploy-frontend`/`deploy-backend`が、`semantic-release`が実際に新バージョンを発行したかどうかに関わらず毎回実行され、変更がなくてもDB再シード等の副作用が発生する

Closes #266

## 変更内容
- `cd.yml`の`release`ジョブに、Semantic Release実行前後のHEAD SHAを比較して`new_release_published`を判定するステップを追加
  - release→main同期PRの作成（`Create PR from release to main`）を`new_release_published == 'true'`の場合のみ実行するようにゲート
  - `build-and-deploy-frontend`/`deploy-backend`ジョブも同様に`new_release_published == 'true'`（かつ`success()`）の場合のみ実行するようにゲート
- 同期PRのsquashマージコミットタイトルに明示的に`[skip ci]`を付与し、マージ後の`main`へのpushで再度CIが走ることを防止
  - `ci.yml`の`merge`ジョブ（github-scriptによるsquash merge）
  - `cd.yml`の`gh pr merge --auto`（フォールバック経路）

## 自己レビューで発見・修正した問題
デプロイジョブに独自の`if`条件を追加すると、`needs:`が本来持つ暗黙の`success()`チェックが上書きされてしまい、`release`ジョブが後続ステップで失敗しても`new_release_published`が既にtrueであればデプロイが実行されてしまう可能性があった。`if: success() && ...`に修正済み。

## テスト
- `frontend`: lint / test（vitest, 60 tests） / build すべて成功
- `backend`: lint / test（vitest, 1134 tests）すべて成功（buildスクリプトなし）
- ルートの`commitlint`: 0件
- ワークフローYAMLの構文はPythonの`yaml`パーサーで検証済み
- 実際のCI/CD実行（release/mainへのpush起因のワークフロー）での動作確認はGitHub Actions上でのみ可能なため未実施


---
_Generated by [Claude Code](https://claude.ai/code/session_01HiVdaN6mp3PUzKChH5Z6bG)_