### PR TITLE
test(frontend): 複数札を連続読了させる滞留防止の回帰テストを追加

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1286,6 +1286,61 @@ describe('App', () => {
     }
   }, 15000);
 
+  it('reads many phrases back-to-back without ever stalling, all the way through to the session summary (issue #262 regression coverage)', async () => {
+    // 未読み札から常に先頭（p1→p2→...の順）を選ばせ、カードの出現順を固定する
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    const CARD_COUNT = 5;
+
+    const phrases = Array.from({ length: CARD_COUNT }, (_, i) => ({
+      id: `p${i + 1}`,
+      category: 'Cat1',
+      kana: 'あ',
+      phrase: `読み札${i + 1}`,
+      level: '-',
+    }));
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases }) };
+      if (url.includes('/get-phrase?')) {
+        const id = new URL(url).searchParams.get('id');
+        return { ok: true, json: async () => ({ id, category: 'Cat1', kana: 'あ', phrase: `読み札${id.slice(1)}`, level: '-', audioData: `dummy-${id}` }) };
+      }
+      if (url.includes('/record-time')) return { ok: true, json: async () => ({ message: 'ok' }) };
+      if (url.includes('get-congratulation-audio')) return { ok: true, json: async () => ({ audioData: 'dummy' }) };
+      return { ok: false };
+    });
+
+    try {
+      await act(async () => {
+        render(<App />);
+      });
+
+      fireEvent.click(await screen.findByText('こども向け'));
+      fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+      for (let i = 1; i <= CARD_COUNT; i++) {
+        await waitFor(() => screen.getByText('次の札'));
+        fireEvent.click(screen.getByText('次の札'));
+
+        // 1枚でも滞留していれば、ここでタイムアウトして失敗する
+        await waitFor(() => {
+          expect(screen.getByText(`読み札${i}`, { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+        }, { timeout: 8000 });
+      }
+
+      // 最後の札を読み終えた後も「次の札」が機能し、読了サマリーまで到達できる
+      // （＝どこかで読み上げ不能に固定されていない）ことを確認する
+      fireEvent.click(screen.getByText('次の札'));
+
+      await waitFor(() => {
+        expect(screen.getByText('🎉 おめでとう！ 🎉')).toBeInTheDocument();
+      }, { timeout: 8000 });
+    } finally {
+      randomSpy.mockRestore();
+    }
+  }, 40000);
+
   it('does not reset the elapsed-time start point when the card is replayed before advancing', async () => {
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) {


### PR DESCRIPTION
## Summary
- クローズ済みIssue #262（停止操作後にisReadingが固定され読み上げ不能になる不具合）について、既存の再発防止テスト（PR #270）だけで十分か検証した
- 検証の結果、修正前コード（`setIsReading(false)`を3箇所除去した状態）に対して既存テストおよび当初作成した「停止操作を繰り返すループ」テストを複数回実行しても、この環境では一度も失敗せず、回帰を確実には検知できないことを実証した（`stopReading`自体が停止ボタン押下時に無条件で`isReading`をfalseへ戻すため、ループ内の「停止ボタンが無効化される」検証だけでは修正の有無を区別できない。また実際の競合はリアルタイム300ms待機に依存する環境依存のレースコンディションで、fake timersによる決定的な再現もreact-testing-libraryの内部ポーリングとの相性の問題でコストが見合わないと判断し断念）
- 代わりに、ユーザー提案の「かるたを一定回数読み上げさせ、滞留しないか確認する」方針を採用し、5枚の札を連続して最後まで読み切り読了サマリー画面に到達することを検証する、完全に決定的な回帰テストを追加した（既存テストは最大2枚までしか連続読了を検証していなかった）

## Test plan
- [x] frontend: `npx vitest run` で61/61件成功（新規テストを含む）
- [x] frontend: `npm run lint` エラー0件
- [x] frontend: `npm run build` 成功
- [x] backend: `npx vitest run` で1134/1134件成功（今回変更なし）
- [x] backend: `npm run lint` エラー0件
- [x] 新規テストをローカルで3回連続実行し、安定して成功することを確認
- [x] `/code-review` スキルによる自己レビューを実施し、指摘（テストの誤検知しやすさ、最後のアサーションの不安定さ）を修正済み

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01C5NHGZ274d8p3Eph2K5Q6F)_