### PR TITLE
test(frontend): issue262回帰テストの誤検知を防ぐ待機ステップを追加

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1268,23 +1268,25 @@ describe('App', () => {
       window.Audio = originalAudio;
 
       // 停止直後に「次の札」を押しても、isReadingが真に固定されて以降ずっと
-      // 読み上げできなくなってはいけない（停止ボタンがいずれ押せなくなること＝
-      // isReadingがfalseに戻ることを確認する）。
+      // 読み上げできなくなってはいけない。
       fireEvent.click(screen.getByText('次の札'));
 
-      await waitFor(
-        () => {
-          expect(screen.getByRole('button', { name: '停止' })).toBeDisabled();
-        },
-        { timeout: 8000 }
-      );
+      // まずカード2が実際に読み上げを開始した（isReadingがtrueになった）ことを
+      // 確認する。これを確認せずに次のtoBeDisabled()だけを見ると、カード2が
+      // そもそも開始できずに停止ボタンが無効のまま据え置かれているだけの状態
+      // （＝本来検知すべき回帰）を誤って合格させてしまう。
+      await waitFor(() => expect(screen.getByRole('button', { name: '停止' })).not.toBeDisabled(), { timeout: 8000 });
+
+      // その上で、カード2の読み上げが最後まで自然に完了し
+      // （＝停止ボタンがいずれ押せなくなる＝isReadingがfalseに戻る）ことを確認する。
+      await waitFor(() => expect(screen.getByRole('button', { name: '停止' })).toBeDisabled(), { timeout: 8000 });
 
       // カード2が実際に履歴へ記録され、次のカードへ進めることも確認する
       expect(screen.getAllByText('読み札2').length).toBeGreaterThan(0);
     } finally {
       window.Audio = originalAudio;
     }
-  }, 15000);
+  }, 25000);
 
   it('reads many phrases back-to-back without ever stalling, all the way through to the session summary (issue #262 regression coverage)', async () => {
     // 未読み札から常に先頭（p1→p2→...の順）を選ばせ、カードの出現順を固定する


### PR DESCRIPTION
## Summary
- マージ済みPR #274のCIで、PR #270由来の既存テスト「recovers isReading (does not get stuck) after stopping mid-intro-sound...」が一度失敗した（リトライで成功、自動マージ済み）
- CIログを確認したところ、カード2が履歴に記録されず「準備完了」画面のまま止まっており、カード2の読み上げがそもそも開始できていなかった
- 原因は、テスト側が「カード2の次の札をクリックした後、停止ボタンがdisabledになるか」だけを確認しており、カード2が一度も開始しない場合（停止ボタンが最初からdisabledのまま）でも即座に合格してしまう誤検知の余地があったこと
- まず停止ボタンが一度enabledになる（＝カード2が実際に読み上げを開始した）ことを確認してから、disabledになる（＝自然に完了する）ことを確認するよう変更した。あわせて2つのwaitForの合計待機時間がテスト全体のタイムアウトを超えていたため、タイムアウトを調整した
- `/code-review`スキルによる自己レビューで、App.jsx側の停止フラグ・Audio参照が単一の共有refである点について、より深い競合を引き起こしうるという指摘も得られたが、CI失敗の根本原因として確証が取れていないため、推測に基づくアプリ本体側の修正は見送った

## Test plan
- [x] frontend: 修正後のテストをローカルで10回連続実行し、安定して成功することを確認
- [x] frontend: `npx vitest run` で61/61件成功
- [x] frontend: `npm run lint` エラー0件
- [x] frontend: `npm run build` 成功
- [x] backend: 今回変更なし。`npx vitest run` 1134/1134件成功、`npm run lint` エラー0件を確認済み
- [x] `/code-review` スキルによる自己レビューを実施し、指摘（タイムアウト予算超過、既存コードスタイルとの不整合）を修正済み

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01C5NHGZ274d8p3Eph2K5Q6F)_