### PR TITLE
dev-standards submoduleのRenovate自動更新を設定

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,7 @@
 ### CI・自動マージ（「10. PR（MR）承認・マージ禁止」関連）
 
 このリポジトリはCIでのテスト等の通過を条件に自動マージされる仕組みを採用している。この仕組みの有無にかかわらず、共通ルール「10. PR（MR）承認・マージ禁止」を厳守し、PR（MR）の承認・マージは行わないこと。
+
+### dev-standards submodule更新
+
+`dev-standards`は特定コミットに固定したgit submoduleとして参照しているため、dev-standards側の変更は自動反映されない。Renovate（`renovate.json`の`git-submodules`設定）がdev-standards mainの更新を検知し、submodule参照コミットを更新するPRを自動作成する。このPRについても上記のCI・自動マージ規則（承認・マージ禁止）が適用される。

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "git-submodules": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
## Summary
- `dev-standards`はgit submoduleとして特定コミットに固定参照しているため、dev-standards側の変更（例: CLAUDE.mdの出力言語指示追加）が自動的にkaruta側へ反映されない問題があった
- `renovate.json`を追加し、`git-submodules`マネージャーを有効化することで、dev-standards mainの更新を検知して自動でsubmodule更新PRが作成されるようにした
- CLAUDE.mdの「11. karuta固有ルール」にこの運用を追記。Renovateが作成するsubmodule更新PRも、既存の「PR承認・マージ禁止」ルールの対象であることを明記

## Test plan
- [ ] Renovate GitHub Appがこのリポジトリに対して有効化されていることを確認（未インストールの場合は別途インストールが必要）
- [ ] dev-standards mainが更新された際に、Renovateからsubmodule更新PRが自動作成されることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_016KL1hqzSM85w8KsLbc1y5a)_