### PR TITLE
changelog変換のsubmodule依存を解消

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,6 +24,8 @@ jobs:
       release_branch: release
       sync_branch_prefix: sync/release-to-main
       merge_ours_paths: frontend/src/changelog.json
+      enable_changelog_json: true
+      changelog_json_output_path: frontend/src/changelog.json
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
 

--- a/scripts/convert-changelog-to-json.js
+++ b/scripts/convert-changelog-to-json.js
@@ -1,1 +1,0 @@
-../dev-standards/scripts/convert-changelog-to-json.js


### PR DESCRIPTION
## Summary
- `scripts/convert-changelog-to-json.js` のシンボリックリンクを削除し、`cd.yml` の `reusable-cd.yml` 呼び出しに `enable_changelog_json: true` / `changelog_json_output_path: frontend/src/changelog.json` を追加
- `.releaserc.cjs` の `prepareCmd`（`node scripts/convert-changelog-to-json.js`）は変更なし

## 背景
先行PR（#284）で `scripts/convert-changelog-to-json.js` を dev-standards へのシンボリックリンクにしましたが、`reusable-cd.yml` の checkout は submodule を取得しないため、次回リリース時に semantic-release の `prepareCmd` がシンボリックリンク切れで失敗する構造的なリスクがあることが判明しました。bamiyanapp/dev-standards#13 でこのスクリプトを `reusable-cd.yml` 側がジョブ内で生成する方式に変更したため、本PRは参照側（karuta）をそれに追従させるものです。

## Test plan
- [x] frontend: `npm run lint` / `npx vitest run --coverage` / `npm run build` がすべてエラー0件で成功
- [x] backend: `npm run lint` / `npx vitest run --coverage` がすべてエラー0件で成功
- [ ] 実際のリリース（`release_branch` へのpush経由の `cd.yml` 実行）でのCHANGELOG.md変換確認は次回リリース時に実施

## マージ順序について
bamiyanapp/dev-standards#13 が先にmainへマージされている必要があります（`enable_changelog_json` inputが存在しないと本PRの `cd.yml` 呼び出しは無視されるだけで壊れませんが、実際の効果を得るには先行マージが必要です）。

Depends on: bamiyanapp/dev-standards#13

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019uJ2nRHDLC7hYWc4Wst5sz)_