### PR TITLE
feat(ci): マージ前バージョン更新方式への追従

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ run-name: CD ${{ github.event.head_commit.message }}
 on:
   push:
     branches:
-      - release
+      - main
 permissions:
   contents: write
   issues: write
@@ -19,15 +19,6 @@ concurrency:
 jobs:
   release:
     uses: bamiyanapp/dev-standards/.github/workflows/reusable-cd.yml@main
-    with:
-      base_branch: main
-      release_branch: release
-      sync_branch_prefix: sync/release-to-main
-      merge_ours_paths: frontend/src/changelog.json
-      enable_changelog_json: true
-      changelog_json_output_path: frontend/src/changelog.json
-    secrets:
-      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
 
   build-and-deploy-frontend:
     needs: release
@@ -40,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: release # Checkout the release branch for deployment
+          ref: ${{ github.sha }} # CDをトリガーしたコミットを確実にデプロイする
           fetch-depth: 0
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -73,7 +64,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: release # Checkout the release branch for deployment
+          ref: ${{ github.sha }} # CDをトリガーしたコミットを確実にデプロイする
           fetch-depth: 0
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
       frontend_dir: frontend
       backend_dir: backend
       base_branch: main
-      release_branch: release
-      sync_branch_prefix: sync/release-to-main
-      merge_ours_paths: frontend/src/changelog.json
+      enable_release: true
+      enable_changelog_json: true
+      changelog_json_output_path: frontend/src/changelog.json
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -1,5 +1,7 @@
 module.exports = {
-  branches: ["release"],
+  // 実際の対象ブランチはCIの merge job から `--branches` で都度PRの作業ブランチに
+  // 上書きされる（`--no-ci` 実行のため、この静的な設定はドキュメント的な意味合いのみ）
+  branches: ["main"],
   repositoryUrl: "https://github.com/bamiyanapp/karuta.git",
   plugins: [
     [

--- a/docs/cicd-pipeline-specification.md
+++ b/docs/cicd-pipeline-specification.md
@@ -2,19 +2,20 @@
 
 本プロジェクトの CI/CD は [dev-standards の共通パイプライン仕様](../dev-standards/docs/cicd-pipeline-specification.md)（`reusable-ci.yml` / `reusable-cd.yml`）をベースに構築されている。
 
-ワークフローの共通ジョブ構成、リリース運用、および同期PR運用のためのブランチ保護設定については上記ドキュメントを参照すること。本ドキュメントには karuta 固有の内容のみを記載する。
+ワークフローの共通ジョブ構成およびリリース運用については上記ドキュメントを参照すること。本ドキュメントには karuta 固有の内容のみを記載する。
 
 ## Architecture
 
 ```mermaid
 graph TD
     A[PR] --> B[CI Workflow];
-    B -->|Success| C[Auto Merge to main];
-    C --> D[sync-release job: main を release へ push];
-    D --> E[CD Workflow on release branch];
-    E --> F{Semantic Release};
-    F --> G[Deploy Frontend to GitHub Pages];
-    F --> H[Deploy Backend to AWS];
+    B --> C[frontend-test / backend-test];
+    C -->|Success| D[merge job: 作業ブランチ上でSemantic Release実行];
+    D --> E[merge job: mainへSquash merge、タグ付け替え];
+    E --> F[CD Workflow on main push];
+    F --> G{HEADのタグからリリース検知};
+    G --> H[Deploy Frontend to GitHub Pages];
+    G --> I[Deploy Backend to AWS];
 ```
 
 ## デプロイジョブ（`cd.yml` 固有）


### PR DESCRIPTION
## Summary
- dev-standardsの`reusable-ci.yml`/`reusable-cd.yml`の新方式（PRマージ前の作業ブランチ上でのバージョン更新、詳細は bamiyanapp/dev-standards#20）に追従
- `ci.yml`: `release_branch`/`sync_branch_prefix`/`merge_ours_paths`を廃止し、`enable_release: true`・`enable_changelog_json: true`を指定
- `cd.yml`: トリガーを`release`ブランチへのpushから`main`へのpushに変更し、`release`ジョブの入力を削除。デプロイジョブのcheckout先を`release`ブランチから、CDをトリガーしたコミット（`github.sha`）に変更
- `.releaserc.cjs`: `branches`を`["release"]`から`["main"]`に変更（実行時はCI側で作業ブランチに一時上書きされる）
- `docs/cicd-pipeline-specification.md`: Architecture図・説明を新方式に更新

## 影響
- 既存の`release`ブランチはこの仕組みでは今後使用しない（削除するかは別途判断）

## Test plan
- [x] frontend: lint・test（vitest）・buildが全て成功
- [x] backend: lint・test（vitest）が全て成功
- [x] `ci.yml`/`cd.yml`のYAML構文をpythonの`yaml`モジュールで検証
- [ ] GitHub Actions上での実際のCI/CD実行（squash merge・タグ付け替え・デプロイまでの一連の流れ）は未検証


---
_Generated by [Claude Code](https://claude.ai/code/session_01BnxdYejMcSn3NdpSm216E8)_