### PR TITLE
feat(claude): dev-standardsの残り9スキルをシンボリックリンクで同期

### DIFF
--- a/.claude/skills/code-review
+++ b/.claude/skills/code-review
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/code-review

--- a/.claude/skills/commit
+++ b/.claude/skills/commit
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/commit

--- a/.claude/skills/development-loop
+++ b/.claude/skills/development-loop
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/development-loop

--- a/.claude/skills/git-workflow
+++ b/.claude/skills/git-workflow
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/git-workflow

--- a/.claude/skills/loop-budget
+++ b/.claude/skills/loop-budget
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/loop-budget

--- a/.claude/skills/loop-triage
+++ b/.claude/skills/loop-triage
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/loop-triage

--- a/.claude/skills/loop-verifier
+++ b/.claude/skills/loop-verifier
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/loop-verifier

--- a/.claude/skills/minimal-fix
+++ b/.claude/skills/minimal-fix
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/minimal-fix

--- a/.claude/skills/verifier
+++ b/.claude/skills/verifier
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/verifier


### PR DESCRIPTION
## Summary
- CLAUDE.mdは `development-loop` / `git-workflow` / `verifier` / `commit` / `code-review` / `git-conventions` / `safe-bash-commands` の7スキルの呼び出しを指示しているが、`.claude/skills/` に実際にシンボリックリンクが存在していたのは `git-conventions` と `safe-bash-commands` の2つのみだった
- `code-review` / `commit` / `development-loop` / `git-workflow` / `verifier` に加え、dev-standards側に新設されていた `loop-budget` / `loop-triage` / `loop-verifier` / `minimal-fix` の計9スキルを、既存2スキルと同様の相対シンボリックリンク（`../../dev-standards/.claude/skills/<name>`）で追加
- これによりdev-standardsで用意された全11スキルがkaruta側からも過不足なく利用可能になる
- 併せて companion PR [bamiyanapp/dev-standards#35](https://github.com/bamiyanapp/dev-standards/pull/35) で、CLAUDE.mdの「Skills」節に不足していた4スキルの案内を追記

## Test plan
- [x] frontend: `npm run lint` / `npx vitest run --coverage` / `npm run build` すべてエラー0件
- [x] backend: `npm run lint` / `npx vitest run --coverage` すべてエラー0件
- [x] 追加した全11個のシンボリックリンクの参照先に `SKILL.md` が存在することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiTEkhocnEJnjYf8Yftz5s

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiTEkhocnEJnjYf8Yftz5s)_