### PR TITLE
fix(frontend): 低優先度issue5件をまとめて解消

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Thumbs.db
 # Environment variables
 .env
 .env.*
+!.env.example
 
 # commit skill が下書きに使う一時ファイル
 commit_msg*.txt

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# APIのベースURL。未設定時はdevステージのURLにフォールバックする。
+VITE_API_BASE_URL=https://akmnirkx3m.execute-api.ap-northeast-1.amazonaws.com/dev

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -268,6 +268,9 @@ button:active:not(:disabled) {
    残り幅の均等割りで不自然に狭くならないよう、全列に明示的な幅を指定する */
 .all-phrases-table-container table {
   table-layout: fixed;
+  /* 画面幅が狭いとfixedレイアウトの各列が均等に縮んで読み札・答え列まで潰れるため、
+     最小幅を確保し、収まらない分はscroll-containerの横スクロールに委ねる */
+  min-width: 640px;
 }
 
 .all-phrases-col-balanced {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -997,6 +997,7 @@ function App() {
         filteredPhrases={filteredPhrases}
         renderSortArrow={renderSortArrow}
         handleSort={handleSort}
+        sortConfig={sortConfig}
         openDetail={openDetail}
         setView={setView}
         setSelectedCategories={setSelectedCategories}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -54,6 +54,10 @@ function App() {
     const params = new URLSearchParams(window.location.search);
     return params.get("view") || "game";
   });
+  const viewRef = useRef(view);
+  useEffect(() => {
+    viewRef.current = view;
+  }, [view]);
   const [allComments, setAllComments] = useState([]);
 
   const [allPhrasesForCategory, setAllPhrasesForCategory] = useState([]);
@@ -275,12 +279,13 @@ function App() {
           const availableCategories = data.categories || [];
           setCategories(availableCategories);
 
-          if (selectedCategories.length > 0 && availableCategories.length > 0 && view === "game") {
+          if (availableCategories.length > 0 && viewRef.current === "game") {
             const availableNames = availableCategories.map(cat => cat.name);
-            const stillValid = selectedCategories.filter(cat => availableNames.includes(cat));
-            if (stillValid.length !== selectedCategories.length) {
-              setSelectedCategories(stillValid);
-            }
+            setSelectedCategories(prev => {
+              if (prev.length === 0) return prev;
+              const stillValid = prev.filter(cat => availableNames.includes(cat));
+              return stillValid.length !== prev.length ? stillValid : prev;
+            });
           }
         }
     } catch {
@@ -288,7 +293,7 @@ function App() {
     }
     };
     fetchCategories();
-  }, [selectedCategories, view]);
+  }, []);
 
   // カテゴリが選択されたら、選択中の全カテゴリの札IDリストを取得して結合する
   useEffect(() => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,9 @@ import AllPhrasesView from "./views/AllPhrasesView";
 import CommentsView from "./views/CommentsView";
 import ChangelogView from "./views/ChangelogView";
 
-const API_BASE_URL = "https://akmnirkx3m.execute-api.ap-northeast-1.amazonaws.com/dev";
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ||
+  "https://akmnirkx3m.execute-api.ap-northeast-1.amazonaws.com/dev";
 
 const HISTORY_STORAGE_KEY = "historyByCategory";
 const PLAYERS_STORAGE_KEY = "players";

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1105,6 +1105,54 @@ describe('App', () => {
     expect(screen.getByText('答え', { selector: 'th' })).toHaveClass('all-phrases-col-balanced');
   });
 
+  it('supports keyboard sorting and exposes aria-sort on the all-phrases table headers (issue #195)', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ categories: [] }),
+    });
+    await act(async () => {
+      render(<App />);
+    });
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        return { ok: true, json: async () => ({ categories: [] }) };
+      }
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({
+            phrases: [
+              { id: 'p1', category: 'Cat1', phrase: 'あ', level: '-', answer: '-' },
+              { id: 'p2', category: 'Cat1', phrase: 'い', level: '-', answer: '-' },
+            ],
+          }),
+        };
+      }
+      return { ok: false };
+    });
+
+    fireEvent.click(screen.getByText(/全札一覧を見る/i));
+
+    const phraseHeader = await screen.findByText('読み札', { selector: 'th' });
+
+    // ソート前は方向が確定していないためaria-sortはnone
+    expect(phraseHeader).toHaveAttribute('aria-sort', 'none');
+    expect(phraseHeader).toHaveAttribute('tabIndex', '0');
+
+    fireEvent.keyDown(phraseHeader, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(phraseHeader).toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    fireEvent.keyDown(phraseHeader, { key: ' ' });
+
+    await waitFor(() => {
+      expect(phraseHeader).toHaveAttribute('aria-sort', 'descending');
+    });
+  });
+
   it('filters all-phrases table by category when a filter button is clicked', async () => {
     fetch.mockResolvedValueOnce({
       ok: true,

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -238,6 +238,35 @@ describe('App', () => {
     }, { timeout: 3000 });
   });
 
+  it('fetches get-categories only once, even after selecting a category (issue #193)', async () => {
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+
+    await waitFor(() => {
+      const elements = screen.queryAllByText('Cat1');
+      expect(elements.length).toBeGreaterThan(0);
+    });
+
+    const categoryButton = screen.getByRole('button', { name: /Cat1/ });
+    fireEvent.click(categoryButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Cat1' })).toBeInTheDocument();
+    });
+
+    const categoriesCalls = fetch.mock.calls.filter(([url]) => url.includes('get-categories'));
+    expect(categoriesCalls.length).toBe(1);
+  });
+
   it('starts game when category is selected', async () => {
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };

--- a/frontend/src/PwaUpdatePrompt.css
+++ b/frontend/src/PwaUpdatePrompt.css
@@ -6,6 +6,7 @@
   z-index: 1000;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.75rem;
   padding: 0.75rem 1rem;
   background-color: #333;
@@ -13,6 +14,10 @@
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   font-size: 0.9rem;
+  /* コンテンツ（文言＋ボタン2つ）が1行に収まる幅を確保しつつ、狭い画面では左右に余白を残す */
+  width: calc(100vw - 2rem);
+  max-width: 420px;
+  box-sizing: border-box;
 }
 
 .pwa-update-prompt-button {
@@ -23,4 +28,6 @@
   color: #333;
   font-weight: bold;
   cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
 }

--- a/frontend/src/views/AllPhrasesView.jsx
+++ b/frontend/src/views/AllPhrasesView.jsx
@@ -7,10 +7,23 @@ function AllPhrasesView({
   filteredPhrases,
   renderSortArrow,
   handleSort,
+  sortConfig,
   openDetail,
   setView,
   setSelectedCategories,
 }) {
+  const getAriaSort = (key) => {
+    if (sortConfig.key !== key) return 'none';
+    return sortConfig.direction === 'asc' ? 'ascending' : 'descending';
+  };
+
+  const handleHeaderKeyDown = (key) => (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleSort(key);
+    }
+  };
+
   return (
     <div className="container py-4 mx-auto">
       <header className="text-center mb-4 border-bottom pb-3">
@@ -48,25 +61,25 @@ function AllPhrasesView({
               <table className="table table-hover mb-0">
                 <thead className="table-light">
                   <tr>
-                    <th scope="col" className="ps-4" style={{ cursor: "pointer" }} onClick={() => handleSort('category')}>
+                    <th scope="col" className="ps-4" style={{ cursor: "pointer" }} tabIndex={0} role="button" aria-sort={getAriaSort('category')} onClick={() => handleSort('category')} onKeyDown={handleHeaderKeyDown('category')}>
                       カテゴリ{renderSortArrow('category')}
                     </th>
-                    <th scope="col" className="all-phrases-col-balanced" style={{ cursor: "pointer" }} onClick={() => handleSort('phrase')}>
+                    <th scope="col" className="all-phrases-col-balanced" style={{ cursor: "pointer" }} tabIndex={0} role="button" aria-sort={getAriaSort('phrase')} onClick={() => handleSort('phrase')} onKeyDown={handleHeaderKeyDown('phrase')}>
                       読み札{renderSortArrow('phrase')}
                     </th>
-                    <th scope="col" className="all-phrases-col-balanced" style={{ cursor: "pointer" }} onClick={() => handleSort('answer')}>
+                    <th scope="col" className="all-phrases-col-balanced" style={{ cursor: "pointer" }} tabIndex={0} role="button" aria-sort={getAriaSort('answer')} onClick={() => handleSort('answer')} onKeyDown={handleHeaderKeyDown('answer')}>
                       答え{renderSortArrow('answer')}
                     </th>
-                    <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('level')}>
+                    <th scope="col" style={{ cursor: "pointer" }} tabIndex={0} role="button" aria-sort={getAriaSort('level')} onClick={() => handleSort('level')} onKeyDown={handleHeaderKeyDown('level')}>
                       Lv{renderSortArrow('level')}
                     </th>
-                    <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('readCount')}>
+                    <th scope="col" style={{ cursor: "pointer" }} tabIndex={0} role="button" aria-sort={getAriaSort('readCount')} onClick={() => handleSort('readCount')} onKeyDown={handleHeaderKeyDown('readCount')}>
                       回数{renderSortArrow('readCount')}
                     </th>
-                    <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('averageTime')}>
+                    <th scope="col" style={{ cursor: "pointer" }} tabIndex={0} role="button" aria-sort={getAriaSort('averageTime')} onClick={() => handleSort('averageTime')} onKeyDown={handleHeaderKeyDown('averageTime')}>
                       平均時間{renderSortArrow('averageTime')}
                     </th>
-                    <th scope="col" style={{ cursor: "pointer" }} onClick={() => handleSort('averageDifficulty')}>
+                    <th scope="col" style={{ cursor: "pointer" }} tabIndex={0} role="button" aria-sort={getAriaSort('averageDifficulty')} onClick={() => handleSort('averageDifficulty')} onKeyDown={handleHeaderKeyDown('averageDifficulty')}>
                       難易度{renderSortArrow('averageDifficulty')}
                     </th>
                     <th scope="col" className="text-end pe-4">詳細</th>


### PR DESCRIPTION
## Summary

優先度low の frontend issue を5件解消しました。

- #189 API_BASE_URLをVITE環境変数（`VITE_API_BASE_URL`）で上書き可能にし、未設定時は既存のdevステージURLにフォールバック
- #193 カテゴリ一覧取得（`get-categories`）のuseEffectがカテゴリ選択のたびに再実行されていた不具合を修正し、初回マウント時のみ取得するよう変更
- #260 全札一覧テーブルにmin-widthを設定し、スマホ幅で全列が詰まって見にくい問題を解消（横スクロールに委譲）
- #261 PWA更新プロンプトの横幅を拡大し、文言・ボタンの折り返しを解消
- #195 全札一覧のソートヘッダーにキーボード操作（Enter/Space）と`aria-sort`属性を追加し、スクリーンリーダー・キーボード操作に対応

## Test plan

- [x] `frontend`: `npm run lint`（0エラー）
- [x] `frontend`: `npx vitest run --coverage`（65 tests pass、#193/#195向けの回帰テストを追加）
- [x] `frontend`: `npm run build`（成功）
- [x] `backend`: `npm run lint`（0エラー）
- [x] `backend`: `npx vitest run --coverage`（1267 tests pass、backendはコード変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NYtSzvgvGHgxPT9dnXVPxn)_