### PR TITLE
docs(claude-md): 全プロジェクト共通のルールをdev-standardsへ移管

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,15 +5,3 @@
 ### 対象パッケージ（静的チェック関連）
 
 静的チェック（lint / test / build）の対象パッケージは `frontend` と `backend` の両方とする。両方でエラー0件を確認するまで、コミット作成や完了報告に進んではならない。
-
-### CI・自動マージ（PR（MR）承認・マージ禁止関連）
-
-このリポジトリはCIでのテスト等の通過を条件に自動マージされる仕組みを採用している。この仕組みの有無にかかわらず、共通ルール「PR（MR）承認・マージ禁止」（dev-standards/CLAUDE.md参照）を厳守し、PR（MR）の承認・マージは行わないこと。
-
-### PR（MR）自動作成
-
-git-workflow Skillの定めるとおり、作業ブランチの変更をpushした後のPR作成はユーザーへ都度確認せず自動で行う。「PRを作成してよいか」を尋ねる必要はない。既に同一の作業ブランチに対応するPRが存在する場合は新規作成せずpushのみで更新する。PR作成後の承認・マージは共通ルール「PR（MR）承認・マージ禁止」のとおり行わない。
-
-### dev-standards submodule更新
-
-`dev-standards`は特定コミットに固定したgit submoduleとして参照しているため、dev-standards側の変更は自動反映されない。Renovate（`renovate.json`の`git-submodules`設定）がdev-standards mainの更新を検知し、submodule参照コミットを更新するPRを自動作成する。このPRについても上記のCI・自動マージ規則（承認・マージ禁止）が適用される。


### PR DESCRIPTION
## Summary
- 「karuta固有ルール」から、内容自体がkaruta固有ではなく参照側リポジトリ全般に共通する3項目（CI・自動マージ、PR（MR）自動作成、dev-standards submodule更新PRの承認・マージ禁止）を削除し、「対象パッケージ」のみを残した
- 上記3項目はcompanion PR（bamiyanapp/dev-standards#38）でdev-standards/CLAUDE.mdの新規セクション「PR（MR）承認・マージ禁止」に集約済み
- あわせて、現行のdev-standards/CLAUDE.mdには存在しない旧番号付きセクション（「10. PR（MR）承認・マージ禁止」等）への参照切れも解消（見出しの番号「## 11. karuta固有ルール」等も削除）

## Test plan
- [x] frontend: `npm run lint` / `npx vitest run --coverage` / `npm run build` すべてエラー0件
- [x] backend: `npm run lint` / `npx vitest run --coverage` すべてエラー0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiTEkhocnEJnjYf8Yftz5s

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiTEkhocnEJnjYf8Yftz5s)_