### PR TITLE
refactor(release): .releaserc.cjsをdev-standardsの共有設定を使う構成に縮小

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,6 @@ jobs:
       enable_release: true
       enable_changelog_json: true
       changelog_json_output_path: frontend/src/changelog.json
+      enable_shared_release_config: true
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -1,68 +1,16 @@
-module.exports = {
-  // 実際の対象ブランチはCIの merge job から `--branches` で都度PRの作業ブランチに
-  // 上書きされる（`--no-ci` 実行のため、この静的な設定はドキュメント的な意味合いのみ）
-  branches: ["main"],
+// CIのmergeジョブが、dev-standardsのrelease-config.cjsをこのファイルと同じ
+// ディレクトリへコピーしてから semantic-release を実行する
+// （enable_shared_release_config: true。詳細はdev-standards/release-config.cjs参照）。
+// ローカルで直接 npx semantic-release を実行する場合は、事前に
+// `cp dev-standards/release-config.cjs .` を行うこと。
+const { buildReleaseConfig } = require("./release-config.cjs");
+
+module.exports = buildReleaseConfig({
   repositoryUrl: "https://github.com/bamiyanapp/karuta.git",
-  plugins: [
-    [
-      "@semantic-release/commit-analyzer",
-      {
-        preset: "conventionalcommits",
-        releaseRules: [
-          // 小文字（正規）
-          { type: "feat", release: "minor" },
-          { type: "fix", release: "patch" },
-
-          // 大文字対応
-          { type: "Feat", release: "minor" },
-          { type: "Fix", release: "patch" },
-          { type: "Refactor", release: "patch" },
-
-          // スラッシュ系（今ある履歴対応）
-          { type: "Feat/fix", release: "patch" },
-          { type: "Fix/tech", release: "patch" },
-
-          // 明示的にリリースしない
-          { type: "Docs", release: false },
-          { type: "Chore", release: false }
-        ],
-        defaultReleaseType: "patch"
-      }
-    ],
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
-    [
-      "@semantic-release/npm",
-      {
-        "npmPublish": false
-      }
-    ],
-    [
-      "@semantic-release/exec",
-      {
-        prepareCmd: "node scripts/convert-changelog-to-json.js"
-      }
-    ],
-    [
-      "@semantic-release/github",
-      {
-        "successComment": false,
-        "failCommentCondition": false,
-        "releasedLabels": false
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        assets: [
-          "CHANGELOG.md",
-          "frontend/src/changelog.json",
-          "package.json",
-          "package-lock.json"
-        ],
-        message:
-          "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ]
-  ]
-};
+  gitAssets: ["CHANGELOG.md", "frontend/src/changelog.json", "package.json", "package-lock.json"],
+  // 過去のコミット履歴対応（スラッシュ系のtype表記）
+  extraReleaseRules: [
+    { type: "Feat/fix", release: "patch" },
+    { type: "Fix/tech", release: "patch" },
+  ],
+});


### PR DESCRIPTION
## Summary

dev-standards側に切り出した共有semantic-release設定（`release-config.cjs`の`buildReleaseConfig()`、[dev-standards #40](https://github.com/bamiyanapp/dev-standards/pull/40)）を使うよう、本リポジトリの`.releaserc.cjs`を更新しました（issue #28関連）。

- `.releaserc.cjs`をプロダクト固有値（`repositoryUrl`、`gitAssets`、過去のコミット履歴対応の`extraReleaseRules`）のみを渡す16行に縮小（変更前は68行）
- `ci.yml`に`enable_shared_release_config: true`を追加し、`merge` jobがdev-standardsの`release-config.cjs`を本リポジトリへコピーしてから`.releaserc.cjs`が読み込む構成にした
- 生成されるsemantic-release設定自体は変更前と完全に等価（`releaseRules`の配列内順序のみ異なるが、型ごとに重複がないため判定結果に影響しない）

⚠️ dev-standards側の対応PR（#40）が先にマージされている必要があります（マージ済みを確認済み）。

## Test plan

- [x] `frontend`: lint（0エラー）
- [x] `backend`: lint（0エラー）
- [x] dev-standardsの`release-config.cjs`を実際に本リポジトリへコピーし、新しい`.releaserc.cjs`が正しく解決されることを確認
- [x] ローカルにインストール済みの`@semantic-release/*`プラグイン一式に対し`npx semantic-release --dry-run --no-ci`を実行し、全ライフサイクル（verifyConditions/analyzeCommits/verifyRelease/generateNotes/prepare/publish/addChannel/success/fail）でプラグインが重複なくちょうど1回ずつロードされることを確認
- [x] 変更前の`.releaserc.cjs`でも同一のdry-run結果（ローカル環境起因の同一エラー）になることを確認し、設定共有化による差分がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NYtSzvgvGHgxPT9dnXVPxn)_