### PR TITLE
fix(print): 絵札印刷カードの文字色を黒固定にする

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -380,6 +380,8 @@ button:active:not(:disabled) {
   text-align: center;
   line-height: 1.3;
   word-break: break-word;
+  /* カードは常に白背景の紙面を模すため、ダークモードのbody文字色（薄灰色）を継承させず黒固定にする */
+  color: #000;
 }
 
 .efuda-card-category {


### PR DESCRIPTION
## 概要
絵札印刷画面で、カード本文の文字が灰色で見えにくい問題を修正する。

## 原因
`.efuda-card-text`（読み仮名の答え/フレーズ表示）に文字色の明示指定がなく、`body`の色（`--app-fg`）を継承していた。カード自体は常に白背景の紙面を模す意匠だが、ダークモードでは`--app-fg`が`#e4e4e4`（薄灰色）になり、白背景上でほぼ読めない状態になっていた。

## 対応
`frontend/src/App.css`の`.efuda-card-text`に`color: #000`を明示指定し、テーマに関わらず黒固定にした。

## 影響範囲
- `frontend/src/App.css`（`.efuda-card-text`のみ）
- 絵札印刷カードの文字色がライト/ダークいずれのテーマでも黒(#000)になる
- 他の要素（`.efuda-card-kana`の朱色、`.efuda-card-category`のtext-muted）は変更なし

## テスト
- frontend: lint / test(65件) / build いずれもエラー0件
- backend: lint / test(1267件) いずれもエラー0件
- 見た目のみの変更のため、テスト追加は不要と判断


---
_Generated by [Claude Code](https://claude.ai/code/session_0138Jv9BbR32fEVrbC5MTpAs)_