### PR TITLE
feat(game): ゲーム画面表示中はWake Lock APIで画面スリープを防止する

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import karutaImage from "./assets/karuta_inubou.png";
 import { useLocalStorageState } from "./hooks/useLocalStorageState";
 import { useSessionStorageState } from "./hooks/useSessionStorageState";
 import { useUrlQuerySync, parseCategoriesParam } from "./hooks/useUrlQuerySync";
+import { useWakeLock } from "./hooks/useWakeLock";
 import DetailView from "./views/DetailView";
 import PrintEfudaView from "./views/PrintEfudaView";
 import AllPhrasesView from "./views/AllPhrasesView";
@@ -807,6 +808,8 @@ function App() {
     setDetailPhraseId,
     setView,
   });
+
+  useWakeLock(view === "game" && selectedCategories.length > 0);
 
   useEffect(() => {
     if (view === "comments") {

--- a/frontend/src/hooks/useWakeLock.js
+++ b/frontend/src/hooks/useWakeLock.js
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from "react";
+
+// activeがtrueの間、画面のスリープを防止する。Wake Lock API未対応環境では何もしない（フィーチャーディテクション）。
+// ブラウザはタブが非表示になると自動でロックを解放するため、releaseイベントでsentinelRefをクリアし、
+// visibilitychangeで可視状態に戻った際に再取得する。
+export function useWakeLock(active) {
+  const sentinelRef = useRef(null);
+
+  useEffect(() => {
+    if (!active || !("wakeLock" in navigator)) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    const requestWakeLock = async () => {
+      try {
+        const sentinel = await navigator.wakeLock.request("screen");
+        if (cancelled) {
+          sentinel.release();
+          return;
+        }
+        sentinel.addEventListener("release", () => {
+          sentinelRef.current = null;
+        });
+        sentinelRef.current = sentinel;
+      } catch {
+        // 端末のバッテリー状態や非アクティブタブなど、リクエストが拒否されるケースがあるため無視する
+      }
+    };
+
+    requestWakeLock();
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible" && sentinelRef.current === null) {
+        requestWakeLock();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      sentinelRef.current?.release();
+      sentinelRef.current = null;
+    };
+  }, [active]);
+}

--- a/frontend/src/hooks/useWakeLock.test.js
+++ b/frontend/src/hooks/useWakeLock.test.js
@@ -1,0 +1,80 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { useWakeLock } from "./useWakeLock";
+
+describe("useWakeLock", () => {
+  let originalWakeLock;
+
+  beforeEach(() => {
+    originalWakeLock = navigator.wakeLock;
+  });
+
+  afterEach(() => {
+    if (originalWakeLock === undefined) {
+      delete navigator.wakeLock;
+    } else {
+      Object.defineProperty(navigator, "wakeLock", { value: originalWakeLock, configurable: true });
+    }
+    vi.restoreAllMocks();
+  });
+
+  const mockSentinel = () => ({
+    release: vi.fn().mockResolvedValue(undefined),
+    addEventListener: vi.fn(),
+  });
+
+  it("activeがfalseの場合はwakeLockをリクエストしない", () => {
+    const request = vi.fn();
+    Object.defineProperty(navigator, "wakeLock", { value: { request }, configurable: true });
+
+    renderHook(() => useWakeLock(false));
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("Wake Lock API未対応の場合はエラーにならない", () => {
+    delete navigator.wakeLock;
+
+    expect(() => renderHook(() => useWakeLock(true))).not.toThrow();
+  });
+
+  it("activeがtrueの場合はscreenのwakeLockをリクエストする", async () => {
+    const sentinel = mockSentinel();
+    const request = vi.fn().mockResolvedValue(sentinel);
+    Object.defineProperty(navigator, "wakeLock", { value: { request }, configurable: true });
+
+    renderHook(() => useWakeLock(true));
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("screen"));
+  });
+
+  it("アンマウント時にsentinelをreleaseする", async () => {
+    const sentinel = mockSentinel();
+    const request = vi.fn().mockResolvedValue(sentinel);
+    Object.defineProperty(navigator, "wakeLock", { value: { request }, configurable: true });
+
+    const { unmount } = renderHook(() => useWakeLock(true));
+    await vi.waitFor(() => expect(request).toHaveBeenCalled());
+
+    unmount();
+
+    expect(sentinel.release).toHaveBeenCalled();
+  });
+
+  it("可視状態に戻った際、sentinelが失われていれば再取得する", async () => {
+    const sentinel = mockSentinel();
+    const request = vi.fn().mockResolvedValue(sentinel);
+    Object.defineProperty(navigator, "wakeLock", { value: { request }, configurable: true });
+
+    renderHook(() => useWakeLock(true));
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+
+    // ブラウザがタブ非表示時に自動解放したケースを模して、releaseハンドラを呼ぶ
+    const releaseHandler = sentinel.addEventListener.mock.calls.find(([event]) => event === "release")[1];
+    releaseHandler();
+
+    Object.defineProperty(document, "visibilityState", { value: "visible", configurable: true });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+  });
+});


### PR DESCRIPTION
## 概要
Closes #216

ゲーム中は読み上げを聞くだけで端末に触れない時間が長く、画面が消灯すると体験が損なわれる問題を解消する。

## 対応
- `useWakeLock(active)` カスタムフックを新設し、`navigator.wakeLock.request("screen")` でロックを取得・保持する
- `App.jsx` で `view === "game" && selectedCategories.length > 0` の間アクティブにする
- Wake Lock API未対応ブラウザではフィーチャーディテクションにより何もしない（エラーにしない）
- タブが非表示になりブラウザが自動でロックを解放した場合、`visibilitychange` で可視状態に戻った際に再取得する

## 影響範囲
- `frontend/src/App.jsx`（フック呼び出し追加のみ）
- `frontend/src/hooks/useWakeLock.js`（新規）

## テスト
- `frontend/src/hooks/useWakeLock.test.js`: 未対応環境でのフィーチャーディテクション、リクエスト発行、アンマウント時のrelease、可視復帰時の再取得を含む5件を追加
- frontend: lint / test(70件) / build いずれもエラー0件
- backend: lint / test(1267件) いずれもエラー0件（変更なし）
- 実機ブラウザでの画面消灯有無の目視確認は未実施（Wake Lock APIはハードウェア依存の挙動のためvitest環境ではシミュレートできない）


---
_Generated by [Claude Code](https://claude.ai/code/session_0138Jv9BbR32fEVrbC5MTpAs)_