### PR TITLE
feat(detail): 詳細画面にその札への既存の指摘一覧を表示する

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -345,10 +345,10 @@ function App() {
     }
   }, [detailPhraseId, detailPhraseCategory, repeatCount, speechRate, lang, isMultiCategorySelection]);
 
-  // 指摘一覧の取得
+  // 指摘一覧の取得（指摘一覧画面のほか、詳細画面で既存の指摘を表示するためにも使う）
   useEffect(() => {
     const fetchComments = async () => {
-      if (view === "comments") {
+      if (view === "comments" || detailPhraseId) {
         try {
           const response = await fetch(`${API_BASE_URL}/get-comments`);
           const data = await response.json();
@@ -361,7 +361,12 @@ function App() {
       }
     };
     fetchComments();
-  }, [view]);
+  }, [view, detailPhraseId]);
+
+  const detailPhraseComments = useMemo(() => {
+    if (!detailPhrase) return [];
+    return allComments.filter(c => c.phraseId === detailPhrase.id);
+  }, [allComments, detailPhrase]);
 
   // 全札一覧の取得
   useEffect(() => {
@@ -969,6 +974,7 @@ function App() {
         setCommentText={setCommentText}
         postComment={postComment}
         postingComment={postingComment}
+        detailPhraseComments={detailPhraseComments}
       />
     );
   }

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -550,6 +550,7 @@ describe('App', () => {
       if (url.includes('get-phrases-list') && url.includes('category=Cat1')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-' }] }) };
       if (url.includes('get-phrases-list') && url.includes('category=Cat2')) return { ok: true, json: async () => ({ phrases: [{ id: 'p2', category: 'Cat2', kana: 'い', phrase: '読み札2', level: '-' }] }) };
       if (url.includes('/get-phrase?')) return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', audioData: 'dummy' }) };
+      if (url.includes('get-comments')) return { ok: true, json: async () => ({ comments: [] }) };
       return { ok: false };
     });
 
@@ -867,6 +868,7 @@ describe('App', () => {
         };
         return { ok: true, json: async () => ({ ...phraseById[id], audioData: 'dummy' }) };
       }
+      if (url.includes('get-comments')) return { ok: true, json: async () => ({ comments: [] }) };
       return { ok: false };
     });
 
@@ -1103,6 +1105,63 @@ describe('App', () => {
     // 読み札列・答え列の幅バランスが崩れないよう、同じ幅指定クラスを共有していることを確認する
     expect(screen.getByText('読み札', { selector: 'th' })).toHaveClass('all-phrases-col-balanced');
     expect(screen.getByText('答え', { selector: 'th' })).toHaveClass('all-phrases-col-balanced');
+  });
+
+  it('shows existing comments for the phrase on the detail screen (issue #223)', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ categories: [] }),
+    });
+    await act(async () => {
+      render(<App />);
+    });
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        return { ok: true, json: async () => ({ categories: [] }) };
+      }
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({
+            phrases: [
+              { id: 'p1', category: 'Cat1', phrase: '読み札A', level: '-', answer: '-' },
+            ],
+          }),
+        };
+      }
+      if (url.includes('get-phrase?')) {
+        return {
+          ok: true,
+          json: async () => ({ id: 'p1', category: 'Cat1', phrase: '読み札A', kana: 'よ', level: '-', answer: '-' }),
+        };
+      }
+      if (url.includes('get-comments')) {
+        return {
+          ok: true,
+          json: async () => ({
+            comments: [
+              { id: 'c1', phraseId: 'p1', category: 'Cat1', phrase: '読み札A', comment: 'かなが間違っています', createdAt: '2026-01-01T00:00:00.000Z' },
+              { id: 'c2', phraseId: 'p2', category: 'Cat1', phrase: '読み札B', comment: '別の札への指摘', createdAt: '2026-01-01T00:00:00.000Z' },
+            ],
+          }),
+        };
+      }
+      return { ok: false };
+    });
+
+    fireEvent.click(screen.getByText(/全札一覧を見る/i));
+    await waitFor(() => {
+      expect(screen.getByText('読み札A')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('読み札A'));
+
+    await waitFor(() => {
+      expect(screen.getByText('これまでの指摘（1件）')).toBeInTheDocument();
+      expect(screen.getByText('かなが間違っています')).toBeInTheDocument();
+      expect(screen.queryByText('別の札への指摘')).not.toBeInTheDocument();
+    });
   });
 
   it('supports keyboard sorting and exposes aria-sort on the all-phrases table headers (issue #195)', async () => {

--- a/frontend/src/views/DetailView.jsx
+++ b/frontend/src/views/DetailView.jsx
@@ -8,6 +8,7 @@ function DetailView({
   setCommentText,
   postComment,
   postingComment,
+  detailPhraseComments,
 }) {
   return (
     <div className="container py-4 mx-auto">
@@ -54,6 +55,20 @@ function DetailView({
                 読み上げる
               </button>
             </div>
+
+          {detailPhraseComments && detailPhraseComments.length > 0 && (
+            <section className="text-start mb-4">
+              <h2 className="h6 fw-bold mb-3 text-muted">これまでの指摘（{detailPhraseComments.length}件）</h2>
+              <div className="d-flex flex-column gap-2">
+                {detailPhraseComments.map(c => (
+                  <div key={c.id} className="p-3 bg-light rounded-3 border-start border-4 border-danger">
+                    <small className="text-muted d-block mb-1">{new Date(c.createdAt).toLocaleString()}</small>
+                    <p className="mb-0 text-dark">{c.comment}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
 
           <section className="comment-form-container text-start p-4 bg-light rounded-4 shadow-sm border">
             <h2 className="h5 fw-bold mb-3 text-dark">かるたの誤りを指摘する</h2>


### PR DESCRIPTION
## 概要
Closes #223

指摘（コメント）は詳細画面の投稿フォームから送信できるが、投稿済みの指摘は「指摘一覧」画面でしか確認できず、詳細画面上では見えないため、既存の指摘に気づかずに重複投稿してしまう可能性があった問題を解消する。

## 対応
- 既存の`/get-comments`はフィルタ引数を持たないため、Issue本文の対応案の通りクライアント側でフィルタする方式を採用
- コメント取得effectの発火条件を「指摘一覧画面表示中」から「詳細画面表示中（`detailPhraseId`設定済み）」も含むよう拡張
- `detailPhrase.id`に一致するコメントを`useMemo`で抽出し、`DetailView`の投稿フォーム上部に一覧表示（該当なしの場合は何も表示しない）

## 影響範囲
- `frontend/src/App.jsx`
- `frontend/src/views/DetailView.jsx`

## テスト
- `frontend/src/App.test.jsx`: 対象の札への指摘のみが表示され、他の札への指摘は表示されないことを検証するテストを追加
- frontend: lint / test(66件) / build いずれもエラー0件
- backend: lint / test(1267件) いずれもエラー0件（変更なし）


---
_Generated by [Claude Code](https://claude.ai/code/session_0138Jv9BbR32fEVrbC5MTpAs)_