### PR TITLE
feat(voice): 読み上げボイスを選択できるようにする

### DIFF
--- a/backend/handler.js
+++ b/backend/handler.js
@@ -71,6 +71,28 @@ function normalizeSpeechRate(rate) {
   return DEFAULT_SPEECH_RATE;
 }
 
+// 日本語で選択可能な声の許可リスト（キー: PollyのVoiceId、値: 対応するEngine）。
+// 任意の文字列をそのままPollyのVoiceIdへ渡すと存在しない値でのAPI呼び出しやコスト濫用の余地があるため、
+// 許可リストに無い値は既定のMizukiにフォールバックする
+const JAPANESE_VOICES = {
+  Mizuki: "standard",
+  Takumi: "standard",
+  Kazuha: "neural",
+  Tomoko: "neural",
+};
+const DEFAULT_JAPANESE_VOICE_ID = "Mizuki";
+
+// 英語は現状Ruth固定（声選択の対象外）
+function resolveVoice(lang, requestedVoiceId) {
+  if (lang === "en") {
+    return { voiceId: "Ruth", engine: "neural" };
+  }
+  if (requestedVoiceId && Object.prototype.hasOwnProperty.call(JAPANESE_VOICES, requestedVoiceId)) {
+    return { voiceId: requestedVoiceId, engine: JAPANESE_VOICES[requestedVoiceId] };
+  }
+  return { voiceId: DEFAULT_JAPANESE_VOICE_ID, engine: JAPANESE_VOICES[DEFAULT_JAPANESE_VOICE_ID] };
+}
+
 // タブを開いたまま放置する等で生じる異常値を統計に混入させないための経過時間の上限（秒）
 const MAX_ELAPSED_SECONDS = 300;
 
@@ -231,15 +253,10 @@ exports.getCongratulationAudio = async (event) => {
     const speechRate = normalizeSpeechRate(rawSpeechRate);
     const lang = params.lang || "ja";
 
-    let speechText = "おめでとう、全て読み終わりました";
-    let voiceId = "Mizuki";
-    let engine = "standard";
-
-    if (lang === "en") {
-      speechText = "Congratulations! You have finished all the cards.";
-      voiceId = "Ruth";
-      engine = "neural";
-    }
+    const speechText = lang === "en"
+      ? "Congratulations! You have finished all the cards."
+      : "おめでとう、全て読み終わりました";
+    const { voiceId, engine } = resolveVoice(lang, params.voiceId);
 
     const pollyParams = {
       Text: `<speak><prosody rate="${speechRate}">${speechText}</prosody></speak>`,
@@ -344,9 +361,10 @@ exports.getPhrase = async (event) => {
     const speechPhrase = lang === "en"
       ? (selectedItem.phrase_en || selectedItem.phrase)
       : selectedItem.phrase;
+    const { voiceId, engine } = resolveVoice(lang, params.voiceId);
 
     const cacheId = crypto.createHash("sha256").update(
-      `${targetId}-${repeatCount}-${speechRate}-${lang}-${announceCategory}-${JSON.stringify([level, speechPhrase, selectedItem.category])}`
+      `${targetId}-${repeatCount}-${speechRate}-${lang}-${announceCategory}-${voiceId}-${JSON.stringify([level, speechPhrase, selectedItem.category])}`
     ).digest("hex");
 
     if (pollyCacheTableName) {
@@ -361,15 +379,7 @@ exports.getPhrase = async (event) => {
     }
 
     if (!audioData) {
-      let voiceId = "Mizuki";
-      let engine = "standard";
-      let levelPrefix = "レベル";
-
-      if (lang === "en") {
-        voiceId = "Ruth";
-        engine = "neural";
-        levelPrefix = "Level";
-      }
+      const levelPrefix = lang === "en" ? "Level" : "レベル";
 
       const hasLevel = level !== "-" && level !== null && level !== undefined && String(level).trim() !== "";
       const escapedPhrase = escapeSsml(speechPhrase);

--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -443,6 +443,34 @@ describe('getCongratulationAudio', () => {
         const pollyParams = pollyMock.calls()[0].args[0].input;
         expect(pollyParams.Text).toContain('<prosody rate="slow">');
     });
+
+    it('should use the requested Japanese voiceId when it is on the allowlist (issue #217)', async () => {
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { lang: 'ja', voiceId: 'Takumi' } };
+        await getCongratulationAudio(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.VoiceId).toBe('Takumi');
+        expect(pollyParams.Engine).toBe('standard');
+    });
+
+    it('should ignore voiceId and always use Ruth for English', async () => {
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { lang: 'en', voiceId: 'Kazuha' } };
+        await getCongratulationAudio(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.VoiceId).toBe('Ruth');
+        expect(pollyParams.Engine).toBe('neural');
+    });
 });
 
 describe('getPhrase', () => {
@@ -498,6 +526,111 @@ describe('getPhrase', () => {
         const event = { queryStringParameters: { id: 'p1' } };
         const response = await getPhrase(event);
         expect(response.statusCode).toBe(404);
+    });
+
+    it('should default to Mizuki (standard) when no voiceId is given (issue #217)', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', level: '1' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        ddbMock.on(PutCommand).resolves({});
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1' } };
+        await getPhrase(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.VoiceId).toBe('Mizuki');
+        expect(pollyParams.Engine).toBe('standard');
+    });
+
+    it('should use the requested Japanese voiceId when it is on the allowlist (issue #217)', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', level: '1' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        ddbMock.on(PutCommand).resolves({});
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1', voiceId: 'Kazuha' } };
+        await getPhrase(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.VoiceId).toBe('Kazuha');
+        expect(pollyParams.Engine).toBe('neural');
+    });
+
+    it('should fall back to Mizuki when the requested voiceId is not on the allowlist', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', level: '1' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        ddbMock.on(PutCommand).resolves({});
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1', voiceId: 'NotARealVoice' } };
+        await getPhrase(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.VoiceId).toBe('Mizuki');
+        expect(pollyParams.Engine).toBe('standard');
+    });
+
+    it('should ignore voiceId and always use Ruth for English', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', phrase_en: 'phrase one', level: '1' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        ddbMock.on(PutCommand).resolves({});
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1', lang: 'en', voiceId: 'Kazuha' } };
+        await getPhrase(event);
+
+        const pollyParams = pollyMock.calls()[0].args[0].input;
+        expect(pollyParams.VoiceId).toBe('Ruth');
+        expect(pollyParams.Engine).toBe('neural');
+    });
+
+    it('should cache different voiceId requests for the same phrase separately (issue #217)', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', level: '1' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        ddbMock.on(PutCommand).resolves({});
+
+        // ストリームは一度読み取ると再利用できないため、呼び出しごとに新しいStreamを返す
+        pollyMock.on(SynthesizeSpeechCommand).callsFake(() => {
+            const s = new Readable();
+            s.push('audio data');
+            s.push(null);
+            return { AudioStream: s };
+        });
+
+        await getPhrase({ queryStringParameters: { id: 'p1', voiceId: 'Mizuki' } });
+        await getPhrase({ queryStringParameters: { id: 'p1', voiceId: 'Takumi' } });
+
+        // GetCommandはPollyキャッシュの確認用（この呼び出しではidはScanCommand経由で取得するためGetCommandを使わない）。
+        // voiceIdが異なれば別のキャッシュキーで問い合わせるはず
+        const cacheGetKeys = ddbMock.commandCalls(GetCommand).map((call) => call.args[0].input.Key.id);
+        expect(cacheGetKeys).toHaveLength(2);
+        expect(new Set(cacheGetKeys).size).toBe(2);
     });
 
     it('should handle errors', async () => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -78,6 +78,7 @@ function App() {
   const [repeatCount, setRepeatCount] = useLocalStorageState("repeatCount", 2, (v) => parseInt(v, 10));
   const [speechRate, setSpeechRate] = useLocalStorageState("speechRate", "80%");
   const [lang, setLang] = useLocalStorageState("lang", "ja");
+  const [voiceId, setVoiceId] = useLocalStorageState("voiceId", "Mizuki");
   const [sortOrder, setSortOrder] = useLocalStorageState("sortOrder", "random");
   const [autoAdvance, setAutoAdvance] = useLocalStorageState("autoAdvance", false, (v) => v === "true");
   const [autoAdvanceInterval, setAutoAdvanceInterval] = useLocalStorageState("autoAdvanceInterval", 10, (v) => parseInt(v, 10));
@@ -330,7 +331,7 @@ function App() {
       const fetchDetail = async () => {
         try {
           const categoryParam = detailPhraseCategory ? `&category=${encodeURIComponent(detailPhraseCategory)}` : "";
-          const response = await fetch(`${API_BASE_URL}/get-phrase?id=${detailPhraseId}${categoryParam}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}&announceCategory=${isMultiCategorySelection}`);
+          const response = await fetch(`${API_BASE_URL}/get-phrase?id=${detailPhraseId}${categoryParam}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}&voiceId=${encodeURIComponent(voiceId)}&announceCategory=${isMultiCategorySelection}`);
           const data = await response.json();
           if (response.ok) {
             setDetailPhrase(data);
@@ -343,7 +344,7 @@ function App() {
     } else {
       setDetailPhrase(null);
     }
-  }, [detailPhraseId, detailPhraseCategory, repeatCount, speechRate, lang, isMultiCategorySelection]);
+  }, [detailPhraseId, detailPhraseCategory, repeatCount, speechRate, lang, voiceId, isMultiCategorySelection]);
 
   // 指摘一覧の取得
   useEffect(() => {
@@ -519,7 +520,7 @@ function App() {
     }
 
     const announceCategory = isMultiCategorySelection;
-    const settingsSignature = JSON.stringify({ repeatCount, speechRate, lang, announceCategory, sortOrder });
+    const settingsSignature = JSON.stringify({ repeatCount, speechRate, lang, voiceId, announceCategory, sortOrder });
 
     const alreadyPrefetched = prefetchedNextRef.current;
     if (
@@ -533,7 +534,7 @@ function App() {
     const nextTargetPhrase = pickTargetPhrase(unreadPhrases, sortOrder);
     let cancelled = false;
 
-    const apiUrl = `${API_BASE_URL}/get-phrase?id=${nextTargetPhrase.id}&category=${encodeURIComponent(nextTargetPhrase.category)}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}&announceCategory=${announceCategory}`;
+    const apiUrl = `${API_BASE_URL}/get-phrase?id=${nextTargetPhrase.id}&category=${encodeURIComponent(nextTargetPhrase.category)}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}&voiceId=${encodeURIComponent(voiceId)}&announceCategory=${announceCategory}`;
 
     fetch(apiUrl)
       .then(response => response.json().then(data => ({ ok: response.ok, data })))
@@ -548,7 +549,7 @@ function App() {
     return () => {
       cancelled = true;
     };
-  }, [isReading, selectedCategories, allPhrasesForCategory, currentHistory, sortOrder, repeatCount, speechRate, lang, isMultiCategorySelection]);
+  }, [isReading, selectedCategories, allPhrasesForCategory, currentHistory, sortOrder, repeatCount, speechRate, lang, voiceId, isMultiCategorySelection]);
 
   // 自動読み上げモード：札の読み上げが完了し「次の札」を待っている状態
   // （手動なら次の札ボタンを押すタイミング）で一定時間経過したら自動で次へ進む。
@@ -678,7 +679,7 @@ function App() {
       }
 
       const announceCategory = isMultiCategorySelection;
-      const settingsSignature = JSON.stringify({ repeatCount, speechRate, lang, announceCategory, sortOrder });
+      const settingsSignature = JSON.stringify({ repeatCount, speechRate, lang, voiceId, announceCategory, sortOrder });
       const prefetched = prefetchedNextRef.current;
       let targetPhrase;
       let data;
@@ -695,7 +696,7 @@ function App() {
       } else {
         targetPhrase = pickTargetPhrase(unreadPhrases, sortOrder);
 
-        const apiUrl = `${API_BASE_URL}/get-phrase?id=${targetPhrase.id}&category=${encodeURIComponent(targetPhrase.category)}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}&announceCategory=${announceCategory}`;
+        const apiUrl = `${API_BASE_URL}/get-phrase?id=${targetPhrase.id}&category=${encodeURIComponent(targetPhrase.category)}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}&voiceId=${encodeURIComponent(voiceId)}&announceCategory=${announceCategory}`;
         const response = await fetch(apiUrl);
         data = await response.json();
 
@@ -757,7 +758,7 @@ function App() {
 
   const playCongratulationAudio = async () => {
     try {
-      const response = await fetch(`${API_BASE_URL}/get-congratulation-audio?speechRate=${encodeURIComponent(speechRate)}&lang=${lang}`);
+      const response = await fetch(`${API_BASE_URL}/get-congratulation-audio?speechRate=${encodeURIComponent(speechRate)}&lang=${lang}&voiceId=${encodeURIComponent(voiceId)}`);
       const data = await response.json();
       if (response.ok) {
         await playAudio(data.audioData);
@@ -1392,6 +1393,17 @@ function App() {
               <button onClick={() => setLang("en")} className={`btn ${lang === "en" ? 'btn-dark' : 'btn-outline-dark'}`}>English</button>
             </div>
           </div>
+          {lang === "ja" && (
+            <div className="mb-3 d-flex align-items-center justify-content-center gap-3 border-bottom pb-2 flex-wrap">
+              <span className="fw-bold text-dark small">声:</span>
+              <div className="btn-group btn-group-sm" role="group">
+                <button onClick={() => setVoiceId("Mizuki")} className={`btn ${voiceId === "Mizuki" ? 'btn-dark' : 'btn-outline-dark'}`}>Mizuki</button>
+                <button onClick={() => setVoiceId("Takumi")} className={`btn ${voiceId === "Takumi" ? 'btn-dark' : 'btn-outline-dark'}`}>Takumi</button>
+                <button onClick={() => setVoiceId("Kazuha")} className={`btn ${voiceId === "Kazuha" ? 'btn-dark' : 'btn-outline-dark'}`}>Kazuha</button>
+                <button onClick={() => setVoiceId("Tomoko")} className={`btn ${voiceId === "Tomoko" ? 'btn-dark' : 'btn-outline-dark'}`}>Tomoko</button>
+              </div>
+            </div>
+          )}
           <div className="mb-3 d-flex align-items-center justify-content-center gap-3 border-bottom pb-2">
             <span className="fw-bold text-dark small">順番:</span>
             <div className="btn-group btn-group-sm" role="group">

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -984,6 +984,57 @@ describe('App', () => {
     localStorage.removeItem('autoAdvanceInterval');
   });
 
+  it('shows the voice selector only for Japanese, updates the setting, and includes voiceId in the phrase request (issue #217)', async () => {
+    // 直前のテストがlocalStorageにlang='en'を残す場合があるため、日本語から始まることを明示する
+    localStorage.setItem('lang', 'ja');
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) {
+        return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-' }] }) };
+      }
+      if (url.includes('/get-phrase?')) {
+        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', audioData: 'dummy' }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+    // 日本語（デフォルト）では声選択が表示され、既定値はMizuki
+    expect(screen.getByText('声:')).toBeInTheDocument();
+    expect(localStorage.getItem('voiceId')).toBe('Mizuki');
+
+    fireEvent.click(screen.getByText('Kazuha'));
+    expect(localStorage.getItem('voiceId')).toBe('Kazuha');
+
+    // Englishでは声選択欄自体が表示されなくなる（英語はRuth固定のため対象外）
+    fireEvent.click(screen.getByText('English'));
+    expect(screen.queryByText('声:')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('日本語'));
+    expect(screen.getByText('声:')).toBeInTheDocument();
+
+    await waitFor(() => screen.getByText('次の札'));
+    fetch.mockClear();
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      const getPhraseCall = fetch.mock.calls.find(([url]) => url.includes('/get-phrase?'));
+      expect(getPhraseCall).toBeDefined();
+      expect(getPhraseCall[0]).toContain('voiceId=Kazuha');
+    });
+
+    localStorage.removeItem('voiceId');
+    localStorage.removeItem('lang');
+    randomSpy.mockRestore();
+  });
+
   it('automatically advances to the next phrase after the configured interval when auto-advance is on', async () => {
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     // UIが提示する最短の間隔（10秒）だと実時間のかかるテストになってしまうため、


### PR DESCRIPTION
## 概要
Closes #217

読み上げ音声が日本語Mizuki・英語Ruthに固定されており、選べるようにしてほしいという要望を解消する。Amazon Pollyは日本語だけでもTakumi（男性）やニューラル音声のKazuha・Tomoko等が利用可能なため、これらを選択肢として追加する。

## 対応
- `backend/handler.js`に日本語音声の許可リスト（`Mizuki`/`Takumi`=standard、`Kazuha`/`Tomoko`=neural）と`resolveVoice(lang, requestedVoiceId)`を追加
- `/get-phrase`・`/get-congratulation-audio`が`voiceId`クエリパラメータを受け取り、許可リストで検証した上でPollyの`VoiceId`/`Engine`に反映（未指定・不正値は従来通りMizuki/standardにフォールバック）
- Pollyキャッシュのキーに`voiceId`を含め、異なる声のキャッシュが衝突しないようにする
- 英語は現状通りRuth固定（Issue本文のスコープ外のため変更していません）
- フロントエンドの設定フッターに「言語」行の直下、日本語選択時のみ「声」の選択UIを追加。選択はlocalStorageに永続化し、既存のspeechRate/lang同様に各APIリクエストへ付与する

## 影響範囲
- `backend/handler.js`
- `frontend/src/App.jsx`

## テスト
- `backend/handler.test.js`: 許可リスト内/外のvoiceId・英語での無視・キャッシュキー分離を検証するテストを追加
- `frontend/src/App.test.jsx`: 日本語限定の表示切り替え・設定変更・APIリクエストへの反映を検証するテストを追加
- frontend: lint / test(66件) / build いずれもエラー0件
- backend: lint / test(1274件) いずれもエラー0件


---
_Generated by [Claude Code](https://claude.ai/code/session_0138Jv9BbR32fEVrbC5MTpAs)_