### PR TITLE
chore(renovate): vite/eslint関連パッケージをグループ化し依存関係競合を防ぐ

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,20 @@
   "extends": ["config:recommended"],
   "git-submodules": {
     "enabled": true
-  }
+  },
+  "packageRules": [
+    {
+      "groupName": "vite",
+      "matchPackageNames": ["vite", "@vitejs/plugin-react"]
+    },
+    {
+      "groupName": "eslint",
+      "matchPackageNames": [
+        "eslint",
+        "@eslint/js",
+        "eslint-plugin-react-hooks",
+        "eslint-plugin-react-refresh"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## 概要
オープンなRenovate PRのうち [#313](https://github.com/bamiyanapp/karuta/pull/313)（`@vitejs/plugin-react` v6）と [#319](https://github.com/bamiyanapp/karuta/pull/319)（`eslint` v10）で `ci / frontend-test` が失敗している。原因はいずれも、Renovateが関連パッケージを個別のPRとして提案しており、片方だけを上げるとpeer依存の要求を満たせず `npm ci` が `ERESOLVE` エラーになるため。

- #313: `@vitejs/plugin-react@6` は `vite@^8.0.0` をpeer依存に要求するが、`vite`は別PR（[#318](https://github.com/bamiyanapp/karuta/pull/318)）で個別に提案されたまま
- #319: `eslint@10` に対して `eslint-plugin-react-hooks` 等の周辺プラグインが追従できておらずpeer依存が競合

## 対応
`renovate.json` の `packageRules` に以下2グループを追加し、関連パッケージが常に単一PRにまとめて提案されるようにした。

- `vite` グループ: `vite`, `@vitejs/plugin-react`
- `eslint` グループ: `eslint`, `@eslint/js`, `eslint-plugin-react-hooks`, `eslint-plugin-react-refresh`

## 影響範囲
- `renovate.json` のみ
- 既存のPR #313・#319 は本設定だけでは自動的に修正されない。Renovateの次回スキャンでのrebase/統合、または手動でのrebase・close対応が別途必要

## テスト
- `npx -p renovate renovate-config-validator renovate.json` でJSONスキーマ・構文の検証を実施し成功を確認
- frontend/backend: lint / test / build いずれもエラー0件（設定ファイルのみの変更のため影響なし）


---
_Generated by [Claude Code](https://claude.ai/code/session_0138Jv9BbR32fEVrbC5MTpAs)_