### PR TITLE
chore(renovate): eslint/viteグループでメジャー/非メジャー更新の分離を止める

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,8 @@
   "packageRules": [
     {
       "groupName": "vite",
-      "matchPackageNames": ["vite", "@vitejs/plugin-react"]
+      "matchPackageNames": ["vite", "@vitejs/plugin-react"],
+      "separateMajorMinor": false
     },
     {
       "groupName": "eslint",
@@ -16,7 +17,8 @@
         "@eslint/js",
         "eslint-plugin-react-hooks",
         "eslint-plugin-react-refresh"
-      ]
+      ],
+      "separateMajorMinor": false
     }
   ]
 }


### PR DESCRIPTION
## 概要
PR #344でvite/eslint関連パッケージを`groupName`でグループ化したが、Renovateの既定挙動によりメジャー更新と非メジャー更新は`groupName`が同じでも別PRに分離されることが判明した。

実際に以下の状態が発生している。

- [#346](https://github.com/bamiyanapp/karuta/pull/346): `eslint`/`@eslint/js` を v10 に更新（メジャー）→ `ci / frontend-test`失敗
- [#345](https://github.com/bamiyanapp/karuta/pull/345): `eslint-plugin-react-hooks` を `7.0.1` → `7.1.1`（**ESLint v10対応が追加されたバージョン**）に更新（非メジャー）

`eslint-plugin-react-hooks@7.0.1`はESLint v10のpeer依存を満たさないため、#346単独では`npm ci`が`ERESOLVE`で失敗する。

## 対応
`renovate.json`のvite/eslint両グループに`separateMajorMinor: false`を追加し、メジャー/非メジャー更新も含めて同一グループのパッケージが常に単一PRにまとめて提案されるようにした。

## 影響範囲
- `renovate.json`のみ

## 既存PRへの対応（要手動対応）
本設定だけでは既存の#345・#346は自動統合されない。以下のいずれかの対応が必要。

- #345（`eslint-plugin-react-hooks` v7.1.1、CI通過見込み）を先にマージし、その後#346をrebaseする
- Renovateの次回スキャンで本設定を検知し、自動的にrebase・統合されるのを待つ

## テスト
- `npx -p renovate renovate-config-validator renovate.json` でJSONスキーマ・構文の検証を実施し成功を確認
- frontend/backend: lint いずれもエラー0件（設定ファイルのみの変更のため影響なし）


---
_Generated by [Claude Code](https://claude.ai/code/session_0138Jv9BbR32fEVrbC5MTpAs)_