### PR TITLE
docs(cicd): PRの人手マージがSemantic Releaseを止める罠を明記する

### DIFF
--- a/docs/cicd-pipeline-specification.md
+++ b/docs/cicd-pipeline-specification.md
@@ -18,6 +18,13 @@ graph TD
     G --> I[Deploy Backend to AWS];
 ```
 
+## ⚠️ PRは必ずCIのBot自動マージに任せること（人手でのマージ禁止）
+
+Semantic Releaseの実行は、CI（`reusable-ci.yml`の`merge`ジョブ）がPRの自動マージ処理の中で行う。このジョブは`pull_request`イベントでのみ起動するため、**人がGitHub UI上で直接「Merge pull request」を押してPRをマージすると、`merge`ジョブが実行される機会がなくなりSemantic Releaseが一切走らない**。その結果、リリースタグが作られずCD側の「HEADのタグからリリース検知」が常に空振りし、`build-and-deploy-frontend`・`deploy-backend`（DynamoDBの`seed.js`同期を含む）が黙ってスキップされ続ける。CIの各ジョブ自体は成功扱いになるため、この状態は気づきにくい。
+
+- PRのCIが通過したら、GitHub UI上で自分でマージボタンを押さず、CIのBot（`merge`ジョブ）による自動マージを待つこと。
+- 万一、人手マージによりリリースが滞留した場合は、（内容を問わない）任意の新規PRを作成しBot自動マージさせることで、そのマージ時点で未リリースの全コミットがまとめてリリースされ、デプロイが追いつく。
+
 ## デプロイジョブ（`cd.yml` 固有）
 
 `release` ジョブ（共通、dev-standards の `reusable-cd.yml`）の成功後、`needs.release.outputs.new_release_published == 'true'` の場合のみ以下を実行する。


### PR DESCRIPTION
## 概要
「モダン開発かるたを追加したが選べない」という報告を調査した結果、原因はキャッシュではなく **7/4のv1.32.0を最後にリリースパイプラインが止まっていること** だった。

Semantic Releaseの実行はCIの`merge`ジョブ（`pull_request`イベントでのみ起動）が担っており、人がGitHub UI上で直接PRをマージすると、このジョブが実行されずSemantic Releaseが一切走らない。結果としてリリースタグが作られず、CDの「HEADのタグからリリース検知」が常に空振りし、`build-and-deploy-frontend`・`deploy-backend`（DynamoDBの`seed.js`同期を含む）が黙ってスキップされ続ける。CIの各ジョブ自体は成功扱いになるため非常に気づきにくい。

実際、7/4以降にマージされた全PR（`#288`のモダン開発かるた追加を含む）が、この影響で本番未反映のまま滞留していた。

## 対応
`docs/cicd-pipeline-specification.md`に、この罠と回復手順（任意の新規PRをBot自動マージさせれば、そのマージ時点で未リリースの全コミットがまとめてリリースされる）を明記した。

## ⚠️ 重要: このPRはBotの自動マージに任せてください
今回の滞留（モダン開発かるた追加、および直近実装した5機能を含む）を追いつかせるため、**このPRは人手でマージせず、CIのBot自動マージ完了をお待ちください**。Botがマージすることで、7/4以降の全未リリースコミットがまとめてリリースされ、DynamoDB同期とGitHub Pagesデプロイが実行されます。

## 影響範囲
- `docs/cicd-pipeline-specification.md`のみ（ドキュメント追記、動作への影響なし）

## テスト
- frontend/backend: lintいずれもエラー0件（ドキュメントのみの変更のため影響なし）


---
_Generated by [Claude Code](https://claude.ai/code/session_0138Jv9BbR32fEVrbC5MTpAs)_