### PR TITLE
fix(cd): semantic-release関連inputをci.ymlからcd.ymlへ移す

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,6 +19,13 @@ concurrency:
 jobs:
   release:
     uses: bamiyanapp/dev-standards/.github/workflows/reusable-cd.yml@main
+    with:
+      enable_release: true
+      enable_changelog_json: true
+      changelog_json_output_path: frontend/src/changelog.json
+      enable_shared_release_config: true
+    secrets:
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
 
   build-and-deploy-frontend:
     needs: release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,5 @@ jobs:
     with:
       frontend_dir: frontend
       backend_dir: backend
-      base_branch: main
-      enable_release: true
-      enable_changelog_json: true
-      changelog_json_output_path: frontend/src/changelog.json
-      enable_shared_release_config: true
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Amazon Polly で生成した音声データのキャッシュ。
    - `answer`: 答え（取り札）のテキスト
    - `level`: 難易度（数値または `-`）
    - `group`: 対象区分（`kids`: こども向け / `engineer`: エンジニア向け）
-2. PRを作成し、CIのBot自動マージで `main` へマージします（人手でのマージは避けてください。理由は [docs/cicd-pipeline-specification.md](docs/cicd-pipeline-specification.md) を参照）。
+2. PRを作成し、`main` へマージします。
 3. GitHub Actions の CD ワークフローが自動的に実行され、DynamoDB のデータが更新されます。
    - 既存のアイテムの統計情報（読み上げ回数や平均時間）は維持されます。
    - CSV から削除されたアイテムは、データベースからも削除されます。

--- a/docs/cicd-pipeline-specification.md
+++ b/docs/cicd-pipeline-specification.md
@@ -10,20 +10,15 @@
 graph TD
     A[PR] --> B[CI Workflow];
     B --> C[frontend-test / backend-test];
-    C -->|Success| D[merge job: 作業ブランチ上でSemantic Release実行];
-    D --> E[merge job: mainへSquash merge、タグ付け替え];
-    E --> F[CD Workflow on main push];
-    F --> G{HEADのタグからリリース検知};
+    C -->|Success| D[merge job: mainへSquash merge];
+    D --> E[CD Workflow on main push];
+    E --> F[release job: main上でSemantic Release実行];
+    F --> G{新バージョンが発行されたか};
     G --> H[Deploy Frontend to GitHub Pages];
     G --> I[Deploy Backend to AWS];
 ```
 
-## ⚠️ PRは必ずCIのBot自動マージに任せること（人手でのマージ禁止）
-
-Semantic Releaseの実行は、CI（`reusable-ci.yml`の`merge`ジョブ）がPRの自動マージ処理の中で行う。このジョブは`pull_request`イベントでのみ起動するため、**人がGitHub UI上で直接「Merge pull request」を押してPRをマージすると、`merge`ジョブが実行される機会がなくなりSemantic Releaseが一切走らない**。その結果、リリースタグが作られずCD側の「HEADのタグからリリース検知」が常に空振りし、`build-and-deploy-frontend`・`deploy-backend`（DynamoDBの`seed.js`同期を含む）が黙ってスキップされ続ける。CIの各ジョブ自体は成功扱いになるため、この状態は気づきにくい。
-
-- PRのCIが通過したら、GitHub UI上で自分でマージボタンを押さず、CIのBot（`merge`ジョブ）による自動マージを待つこと。
-- 万一、人手マージによりリリースが滞留した場合は、（内容を問わない）任意の新規PRを作成しBot自動マージさせることで、そのマージ時点で未リリースの全コミットがまとめてリリースされ、デプロイが追いつく。
+semantic-releaseの実行は`main`へのpush後（CD側の`release`ジョブ）で行われる。以前はPRの作業ブランチ上でマージ前に実行する方式だったが、GitHub Actionsの`pull_request`イベントで自動設定される`GITHUB_REF`（ワークフローYAMLの`env:`では上書き不可）により常にリリースが発行されない不具合があったため、`main`への実pushイベント上で実行する方式に修正した（[dev-standards#43](https://github.com/bamiyanapp/dev-standards/pull/43)）。詳細は[dev-standards側ドキュメント](../dev-standards/docs/cicd-pipeline-specification.md)を参照。
 
 ## デプロイジョブ（`cd.yml` 固有）
 


### PR DESCRIPTION
## 概要
[dev-standards#43](``https://github.com/bamiyanapp/dev-standards/pull/43)（マージ済み）で、semantic-releaseの実行が'reusable-ci.yml'の'merge'ジョブから'reusable-cd.yml'の'release'ジョブへ移動した。根本原因は、'pull_request'イベントでGitHub`` Actionsが自動設定する`GITHUB_REF`がワークフローYAMLの`env:`では上書きできず、semantic-releaseのブランチ判定が常に失敗していたこと。この影響で7/4以降karutaのリリースが完全に停止しており、マージ済みの変更（モダン開発かるた追加を含む）が本番未反映のまま滞留していた。

**訂正**: 直前のPR（#350, #352）では「人手マージが原因」と誤って診断しドキュメントに記載していたが、実際の原因は上記の通りマージ方法に関係なくreusable-ci.yml側の実装不具合だった。本PRで誤った記述も修正する。

## 対応
dev-standards側の入力インターフェース変更に追従し、release関連の`with:`値（`enable_release` / `enable_changelog_json` / `changelog_json_output_path` / `enable_shared_release_config`）と`BOT_TOKEN`を、`ci.yml`から`cd.yml`の`release`ジョブ呼び出しへ移した。あわせて、誤った診断に基づく記述（Bot自動マージ必須の注意書き等）をREADME.md・docs/cicd-pipeline-specification.mdから修正した。

## ⚠️ 早急なマージが必要
dev-standards側の修正は既に`main`にマージ済みのため、karutaの次回`main`へのpushで新しい`release`ジョブが動く。しかし現在の`cd.yml`は`with:`が未設定のままのため、`enable_shared_release_config`/`enable_changelog_json`が既定値`false`のままとなり、semantic-release実行時に`release-config.cjs`が見つからず失敗する。本PRの早期マージで正しい`with:`を反映させる必要がある。

## 影響範囲
- `.github/workflows/ci.yml`
- `.github/workflows/cd.yml`
- `README.md`
- `docs/cicd-pipeline-specification.md`

## テスト
- frontend/backend: lintいずれもエラー0件（影響なし）
- ワークフローYAMLの構文はpython3の`yaml.safe_load`で検証済み
- 実際のGitHub Actions実行環境でのエンドツーエンド確認は、本PRのマージ・次回リリースの発行を待って行う


---
_Generated by [Claude Code](https://claude.ai/code/session_0138Jv9BbR32fEVrbC5MTpAs)_