### PR TITLE
docs(cicd): mainのブランチ保護に対応したリリースPRフォールバックを追記する

### DIFF
--- a/docs/cicd-pipeline-specification.md
+++ b/docs/cicd-pipeline-specification.md
@@ -18,7 +18,9 @@ graph TD
     G --> I[Deploy Backend to AWS];
 ```
 
-semantic-releaseの実行は`main`へのpush後（CD側の`release`ジョブ）で行われる。以前はPRの作業ブランチ上でマージ前に実行する方式だったが、GitHub Actionsの`pull_request`イベントで自動設定される`GITHUB_REF`（ワークフローYAMLの`env:`では上書き不可）により常にリリースが発行されない不具合があったため、`main`への実pushイベント上で実行する方式に修正した（[dev-standards#43](https://github.com/bamiyanapp/dev-standards/pull/43)）。詳細は[dev-standards側ドキュメント](../dev-standards/docs/cicd-pipeline-specification.md)を参照。
+semantic-releaseの実行は`main`へのpush後（CD側の`release`ジョブ）で行われる。以前はPRの作業ブランチ上でマージ前に実行する方式だったが、GitHub Actionsの`pull_request`イベントで自動設定される`GITHUB_REF`（ワークフローYAMLの`env:`では上書き不可）により常にリリースが発行されない不具合があったため、`main`への実pushイベント上で実行する方式に修正した（[dev-standards#43](https://github.com/bamiyanapp/dev-standards/pull/43)）。
+
+karutaの`main`は「変更は必ずPR経由」のリポジトリルールで保護されているため、`release`ジョブによる`main`への直接pushはそのままではGH013エラーで拒否される。この問題に対応するため、直接pushが失敗した場合はローカルに作成済みのリリースコミットを新しいブランチへpushし、`main`へのPRを作成してAPI経由でsquash mergeするフォールバックが追加されている（[dev-standards#44](https://github.com/bamiyanapp/dev-standards/pull/44)）。karuta運用者が意識する必要がある手順の違いはなく、`release`ジョブの結果として`new_release_published`が正しく出力されればデプロイジョブは通常どおり実行される。詳細は[dev-standards側ドキュメント](../dev-standards/docs/cicd-pipeline-specification.md#3-リリース運用)を参照。
 
 ## デプロイジョブ（`cd.yml` 固有）
 


### PR DESCRIPTION
## 概要
dev-standards#44（保護された`base_branch`でも`release`ジョブが動くようにする改修）を受け、karuta側の`docs/cicd-pipeline-specification.md`にも該当の挙動を追記する。

karutaの`main`は「変更は必ずPR経由」のリポジトリルールで保護されているため、`release`ジョブによる`main`への直接pushはGH013エラーで拒否される。dev-standards#44により、その場合は新しいブランチ経由でリリースPRを作成しAPI経由でsquash mergeするフォールバックが動作する。この挙動をドキュメントに反映した。

## 影響範囲
- `docs/cicd-pipeline-specification.md`（ドキュメントのみ、動作への影響なし）

## 副次的な目的
本PRは、dev-standards#44がマージされて以降で初めてkaruta側にpushされる変更でもある。このPRがマージされることで、更新されたCDワークフロー（リリースPRフォールバック機構）が実際にkaruta上でエンドツーエンドに動作するかを検証できる。

## テスト
- `npm run lint`（frontend / backend いずれもエラー0件）

---
_Generated by [Claude Code](https://claude.ai/code/session_0138Jv9BbR32fEVrbC5MTpAs)_