### PR TITLE
feat(print): 絵札の文字サイズをさらに拡大する

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -376,7 +376,7 @@ button:active:not(:disabled) {
 
 .efuda-card-text {
   font-weight: bold;
-  font-size: 6mm;
+  font-size: 7mm;
   text-align: center;
   line-height: 1.3;
   word-break: break-word;


### PR DESCRIPTION
## 概要
絵札印刷画面のカード文字をもう一回り大きくしてほしいというユーザー要望に対応する。

## 変更内容
- `.efuda-card-text`の`font-size`を`6mm`から`7mm`に変更

## 影響範囲
- `frontend/src/App.css`（絵札印刷画面の`.efuda-card-text`のみ）
- カード内側の余白（91mm×55mmから枠線5mm・padding4mmを引いた実効エリア）に7mmでも収まることを確認済み

## テスト
- `npm run lint` / `npm test`（frontend 74件・backend 1274件、いずれも全件成功）

---
_Generated by [Claude Code](https://claude.ai/code/session_0138Jv9BbR32fEVrbC5MTpAs)_