### PR TITLE
docs(cicd): タグ導出・GitHub Release冪等化の修正を追記する

### DIFF
--- a/docs/cicd-pipeline-specification.md
+++ b/docs/cicd-pipeline-specification.md
@@ -20,7 +20,7 @@ graph TD
 
 semantic-releaseの実行は`main`へのpush後（CD側の`release`ジョブ）で行われる。以前はPRの作業ブランチ上でマージ前に実行する方式だったが、GitHub Actionsの`pull_request`イベントで自動設定される`GITHUB_REF`（ワークフローYAMLの`env:`では上書き不可）により常にリリースが発行されない不具合があったため、`main`への実pushイベント上で実行する方式に修正した（[dev-standards#43](https://github.com/bamiyanapp/dev-standards/pull/43)）。
 
-karutaの`main`は「変更は必ずPR経由」のリポジトリルールで保護されているため、`release`ジョブによる`main`への直接pushはそのままではGH013エラーで拒否される。この問題に対応するため、直接pushが失敗した場合はローカルに作成済みのリリースコミットを新しいブランチへpushし、`main`へのPRを作成してAPI経由でsquash mergeするフォールバックが追加されている（[dev-standards#44](https://github.com/bamiyanapp/dev-standards/pull/44)）。karuta運用者が意識する必要がある手順の違いはなく、`release`ジョブの結果として`new_release_published`が正しく出力されればデプロイジョブは通常どおり実行される。詳細は[dev-standards側ドキュメント](../dev-standards/docs/cicd-pipeline-specification.md#3-リリース運用)を参照。
+karutaの`main`は「変更は必ずPR経由」のリポジトリルールで保護されているため、`release`ジョブによる`main`への直接pushはそのままではGH013エラーで拒否される。この問題に対応するため、直接pushが失敗した場合はローカルに作成済みのリリースコミットを新しいブランチへpushし、`main`へのPRを作成してAPI経由でsquash mergeするフォールバックが追加されている（[dev-standards#44](https://github.com/bamiyanapp/dev-standards/pull/44)、タグ名の導出方法の修正が[dev-standards#45](https://github.com/bamiyanapp/dev-standards/pull/45)、GitHub Release作成の冪等化が[dev-standards#46](https://github.com/bamiyanapp/dev-standards/pull/46)）。karuta運用者が意識する必要がある手順の違いはなく、`release`ジョブの結果として`new_release_published`が正しく出力されればデプロイジョブは通常どおり実行される。詳細は[dev-standards側ドキュメント](../dev-standards/docs/cicd-pipeline-specification.md#3-リリース運用)を参照。
 
 ## デプロイジョブ（`cd.yml` 固有）
 


### PR DESCRIPTION
## 概要
dev-standards#44のリリースPRフォールバックを実際にkarutaで動作検証した結果、#44単体では「タグの付け替え」ステップと「GitHub Release作成」ステップにそれぞれ別のバグがあり、[dev-standards#45](```''https://github.com/bamiyanapp/dev-standards/pull/45)・[dev-standards#46](https://github.com/bamiyanapp/dev-standards/pull/46)で順次修正した。この経緯をドキュメントに反映する。''```

## 副次的な目的
本PRは、dev-standards#46がマージされて以降で初めてkaruta側にpushされる変更でもある。karutaのmainは既に`v1.14.0`として正式にタグ付けされているため、このPRのマージによって新しいリリースサイクル（バージョン採番→タグ付け→GitHub Release作成→デプロイジョブ実行）が最初から最後まで正しく完走するかを、修正済みのパイプラインで改めて検証できる。

## テスト
- `npm run lint`（frontend / backend いずれもエラー0件）

---
_Generated by [Claude Code](https://claude.ai/code/session_0138Jv9BbR32fEVrbC5MTpAs)_