### PR TITLE
feat(print): 用紙案内にインクジェット用品番を追記する

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -640,10 +640,13 @@ describe('App', () => {
       expect(screen.getByText('回答1')).toBeInTheDocument();
     });
 
-    // 用紙情報に商品ページへのリンクが設定されている
-    const paperLink = screen.getByRole('link', { name: /エーワン マルチカード/ });
-    expect(paperLink).toHaveAttribute('href', 'https://www.a-one.co.jp/product/search/detail.php?id=51677');
-    expect(paperLink).toHaveAttribute('target', '_blank');
+    // 用紙情報に顔料インク用・インクジェット用それぞれの商品ページへのリンクが設定されている
+    const paperLinks = screen.getAllByRole('link', { name: /エーワン マルチカード/ });
+    expect(paperLinks).toHaveLength(2);
+    expect(paperLinks[0]).toHaveAttribute('href', 'https://www.a-one.co.jp/product/search/detail.php?id=51677');
+    expect(paperLinks[0]).toHaveAttribute('target', '_blank');
+    expect(paperLinks[1]).toHaveAttribute('href', 'https://www.a-one.co.jp/product/search/detail.php?id=51604');
+    expect(paperLinks[1]).toHaveAttribute('target', '_blank');
 
     // 11枚 → 10面/ページなので2ページ生成される
     expect(document.querySelectorAll('.efuda-page').length).toBe(2);

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -69,7 +69,8 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
         <>
           <div className="no-print text-center mb-4">
             <p className="text-muted small mb-3">
-              用紙: <a href="https://www.a-one.co.jp/product/search/detail.php?id=51677" target="_blank" rel="noopener noreferrer">エーワン マルチカード（マイクロミシン・厚口）A4・10面用</a><br />
+              用紙（顔料インク用）: <a href="https://www.a-one.co.jp/product/search/detail.php?id=51677" target="_blank" rel="noopener noreferrer">エーワン マルチカード（マイクロミシン・厚口）A4・10面用</a><br />
+              用紙（インクジェット用）: <a href="https://www.a-one.co.jp/product/search/detail.php?id=51604" target="_blank" rel="noopener noreferrer">エーワン マルチカード（マイクロミシン・厚口）A4・10面用</a><br />
               印刷ダイアログで「用紙サイズ: A4」「余白: なし」「拡大縮小: 実際のサイズ(100%)」「ヘッダーとフッター: オフ」に設定してください。
             </p>
             <div className="d-flex gap-3 justify-content-center flex-wrap">


### PR DESCRIPTION
## 概要
[#364](https://github.com/bamiyanapp/karuta/issues/364) の対応。絵札印刷画面の用紙案内は顔料インク向け品番（51677）のみだったため、インクジェット向け品番（51604）を追記する。

## 変更内容
- 顔料インク用（51677）: 既存のまま
- インクジェット用（[51604](https://www.a-one.co.jp/product/search/detail.php?id=51604)）: 新規追加

## テスト
- `npm run lint` / `npm test`（frontend 46件・backend 1274件、いずれも全件成功）

---
_Generated by [Claude Code](https://claude.ai/code/session_0138Jv9BbR32fEVrbC5MTpAs)_