### PR TITLE
chore(release): v1.16.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.16.0](https://github.com/bamiyanapp/karuta/compare/v1.15.0...v1.16.0) (2026-07-11)
+
+
+### Features
+
+* **print:** 絵札の文字サイズをさらに拡大する ([#367](https://github.com/bamiyanapp/karuta/issues/367)) ([02afa1a](https://github.com/bamiyanapp/karuta/commit/02afa1a0c91446413e35e5bd5b0ec61810343a08))
+
 # [1.15.0](https://github.com/bamiyanapp/karuta/compare/v1.14.0...v1.15.0) (2026-07-11)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
+    "version": "1.16.0",
+    "date": "2026/06/30 14:26",
+    "body": "### Features\n\n* **print:** 絵札の文字サイズをさらに拡大する ([#367](https://github.com/bamiyanapp/karuta/issues/367)) ([02afa1a](https://github.com/bamiyanapp/karuta/commit/02afa1a0c91446413e35e5bd5b0ec61810343a08))"
+  },
+  {
     "version": "1.15.0",
-    "date": "2026/06/29 14:12",
+    "date": "2026/07/11 09:34",
     "body": "### Features\n\n* **print:** 用紙案内にインクジェット用品番を追記する ([#366](https://github.com/bamiyanapp/karuta/issues/366)) ([347a7ad](https://github.com/bamiyanapp/karuta/commit/347a7ad9d7f2fbe780948094e370ada7c776ca84))"
   },
   {
@@ -151,7 +156,7 @@
   },
   {
     "version": "1.15.0",
-    "date": "2026/06/29 14:12",
+    "date": "2026/07/11 09:34",
     "body": "### Features\n\n* **frontend:** PWAの更新検知とプロンプトUIの追加 ([#162](https://github.com/bamiyanapp/karuta/issues/162)) ([dd45840](https://github.com/bamiyanapp/karuta/commit/dd458402cb8051d104ac7f389ae69e2545e11dbc))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.15.0"
+  "version": "1.16.0"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。