### PR TITLE
feat(print): 絵札印刷画面に裏面印刷を追加する

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -392,6 +392,30 @@ button:active:not(:disabled) {
   font-size: 9px;
 }
 
+/* 裏面（種別・レベル）：表面と同じカード枠内に中央揃えで表示する */
+.efuda-card-back {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3mm;
+  width: 100%;
+  color: #000;
+}
+
+.efuda-card-back-category {
+  font-weight: bold;
+  font-size: 7mm;
+  text-align: center;
+  word-break: break-word;
+}
+
+.efuda-card-back-level {
+  font-weight: bold;
+  font-size: 10mm;
+  color: #e44d26;
+}
+
 @media print {
   .no-print {
     display: none !important;

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -658,6 +658,52 @@ describe('App', () => {
     expect(document.querySelector('.efuda-card-category')).toHaveTextContent('Cat1');
   });
 
+  it('switches the efuda print view to show the back side (category and level) (issue #363)', async () => {
+    const phrases = [
+      { id: 'p0', category: 'Cat1', kana: 'あ', phrase: '読み札テキスト0', answer: '-', level: '3' },
+      { id: 'p1', category: 'Cat1', kana: 'い', phrase: '読み札テキスト1', answer: '回答1', level: '-' },
+    ];
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+    await waitFor(() => screen.getByText('絵札を印刷する'));
+    fireEvent.click(screen.getByText('絵札を印刷する'));
+
+    await waitFor(() => {
+      expect(screen.getByText('読み札テキスト0')).toBeInTheDocument();
+    });
+
+    // 表面ではレベルの数字は表示されない
+    expect(document.querySelector('.efuda-card-back')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '裏面' }));
+
+    // 裏面では表面の内容（読み札・回答）が消え、種別とレベルが中央に表示される
+    expect(screen.queryByText('読み札テキスト0')).not.toBeInTheDocument();
+    expect(screen.queryByText('回答1')).not.toBeInTheDocument();
+    const backCards = document.querySelectorAll('.efuda-card-back');
+    expect(backCards).toHaveLength(2);
+    expect(backCards[0].querySelector('.efuda-card-back-category')).toHaveTextContent('Cat1');
+    expect(backCards[0].querySelector('.efuda-card-back-level')).toHaveTextContent('3');
+    // レベル未設定（"-"）のカードには数字を表示しない
+    expect(backCards[1].querySelector('.efuda-card-back-level')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '表面' }));
+    expect(screen.getByText('読み札テキスト0')).toBeInTheDocument();
+    expect(document.querySelector('.efuda-card-back')).not.toBeInTheDocument();
+  });
+
   it('downloads a PDF of the printed efuda pages, hiding no-print elements in the capture (issue #199)', async () => {
     const phrases = Array.from({ length: 11 }, (_, i) => ({
       id: `p${i}`,
@@ -703,7 +749,7 @@ describe('App', () => {
     const jsPdfInstance = jsPDF.mock.results[0].value;
     expect(jsPdfInstance.addPage).toHaveBeenCalledTimes(1); // 2ページ目の追加分のみ
     expect(jsPdfInstance.addImage).toHaveBeenCalledTimes(2);
-    expect(jsPdfInstance.save).toHaveBeenCalledWith('Cat1_絵札.pdf');
+    expect(jsPdfInstance.save).toHaveBeenCalledWith('Cat1_絵札_表面.pdf');
   });
 
   it('packs printed efuda cards across categories onto the same page without breaking per category', async () => {

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -8,6 +8,9 @@ const A4_HEIGHT_MM = 297;
 
 function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrasesForCategory, efudaPages, efudaPerPage }) {
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
+  // 表面（読み札の内容）と裏面（種別・レベル）は用紙を裏返して2回に分けて印刷する運用を想定し、
+  // 同じページ構成をどちらの内容で描画するかだけをこのstateで切り替える
+  const [printSide, setPrintSide] = useState("front");
 
   const downloadPdf = async () => {
     setIsGeneratingPdf(true);
@@ -42,7 +45,8 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
         pdf.addImage(imageData, "PNG", 0, 0, A4_WIDTH_MM, A4_HEIGHT_MM);
       }
 
-      pdf.save(`${categoryLabel || "karuta"}_絵札.pdf`);
+      const sideLabel = printSide === "back" ? "裏面" : "表面";
+      pdf.save(`${categoryLabel || "karuta"}_絵札_${sideLabel}.pdf`);
     } catch (error) {
       console.error("Error generating PDF:", error);
       alert("PDFの生成に失敗しました。");
@@ -71,8 +75,25 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
             <p className="text-muted small mb-3">
               用紙（顔料インク用）: <a href="https://www.a-one.co.jp/product/search/detail.php?id=51677" target="_blank" rel="noopener noreferrer">エーワン マルチカード（マイクロミシン・厚口）A4・10面用</a><br />
               用紙（インクジェット用）: <a href="https://www.a-one.co.jp/product/search/detail.php?id=51604" target="_blank" rel="noopener noreferrer">エーワン マルチカード（マイクロミシン・厚口）A4・10面用</a><br />
-              印刷ダイアログで「用紙サイズ: A4」「余白: なし」「拡大縮小: 実際のサイズ(100%)」「ヘッダーとフッター: オフ」に設定してください。
+              印刷ダイアログで「用紙サイズ: A4」「余白: なし」「拡大縮小: 実際のサイズ(100%)」「ヘッダーとフッター: オフ」に設定してください。<br />
+              両面印刷する場合は、表面を印刷した用紙をそのまま裏返してセットし、裏面を印刷してください。
             </p>
+            <div className="btn-group mb-3" role="group" aria-label="印刷する面の切り替え">
+              <button
+                type="button"
+                onClick={() => setPrintSide("front")}
+                className={`btn btn-outline-dark ${printSide === "front" ? "active" : ""}`}
+              >
+                表面
+              </button>
+              <button
+                type="button"
+                onClick={() => setPrintSide("back")}
+                className={`btn btn-outline-dark ${printSide === "back" ? "active" : ""}`}
+              >
+                裏面
+              </button>
+            </div>
             <div className="d-flex gap-3 justify-content-center flex-wrap">
               <button onClick={() => window.print()} className="btn btn-lg px-5 py-2 fw-bold rounded-pill shadow btn-karuta">
                 印刷する
@@ -91,13 +112,18 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
                     const p = page.items[slotIndex];
                     return (
                       <div className="efuda-card" key={slotIndex}>
-                        {p && (
+                        {p && (printSide === "back" ? (
+                          <div className="efuda-card-back">
+                            <div className="efuda-card-back-category">{p.category}</div>
+                            {p.level !== "-" && <div className="efuda-card-back-level">{p.level}</div>}
+                          </div>
+                        ) : (
                           <>
                             <p className="no-print text-muted small efuda-card-category">{p.category}</p>
                             <div className="efuda-card-kana">{p.kana}</div>
                             <div className="efuda-card-text">{getEfudaText(p)}</div>
                           </>
-                        )}
+                        ))}
                       </div>
                     );
                   })}


### PR DESCRIPTION
## 概要
[#363](https://github.com/bamiyanapp/karuta/issues/363) の対応。絵札印刷画面に裏面印刷を追加する。

## 変更内容
- 「表面/裏面」の切り替えボタンを追加
- 裏面選択時は、カード内に種別（category）とレベル（level、未設定"-"の場合は非表示）を中央揃えで表示
- 両面印刷は「表面を印刷した用紙をそのまま裏返してセットし、裏面を印刷する」という2回に分けた運用を前提とし、用紙案内文にもその旨を追記
- PDFダウンロードのファイル名に表面/裏面のサフィックスを付与（例: `Cat1_絵札_表面.pdf`）

## テスト
- `npm run lint` / `npm test`（frontend 47件・backend 1274件、いずれも全件成功）
- 裏面切り替えでカード内容が種別・レベル表示に切り替わること、レベル未設定のカードには数字を表示しないこと、表面へ戻すと元の表示に戻ることを検証するテストを追加

---
_Generated by [Claude Code](https://claude.ai/code/session_0138Jv9BbR32fEVrbC5MTpAs)_