### PR TITLE
fix(backend): Serverless FrameworkをCIでサインイン不要なv3系に固定する

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -1,5 +1,12 @@
 service: karuta-app
 
+# Serverless Framework v4以降はCLI起動時にSaaSへのサインイン（serverless login/
+# SERVERLESS_ACCESS_KEY）が必須となり、CIにその認証情報を設定していないため
+# `npx serverless deploy`が「You must sign in or use a license key」で失敗する。
+# このリポジトリはv4固有の機能（httpApi等）を使用していないため、
+# サインイン不要なv3系に固定してこの問題を回避する。
+frameworkVersion: '3'
+
 provider:
   name: aws
   runtime: nodejs20.x


### PR DESCRIPTION
## 概要
CD/CDパイプライン（dev-standards#44〜#46）の一連の修正により、`release`ジョブと`build-and-deploy-frontend`ジョブが初めて完全に成功した（[run](````''https://github.com/bamiyanapp/karuta/actions/runs/29147924010)）。しかし'deploy-backend'ジョブが以下のエラーで失敗することが新たに判明した。''````

```
✖ Error: You must sign in or use a license key with Serverless Framework V.4 and later versions. Please use "serverless login".
```

## 根本原因
`npx serverless deploy`は、`frameworkVersion`が指定されていない場合、ローカルのnpmパッケージバージョン（`package.json`の`serverless: ^4.0.0`）に関わらず最新のv4系CLIバイナリを別途自動取得する。Serverless Framework v4以降はCLI起動時にSaaS（app.serverless.com）へのサインインが必須だが、CI環境にはその認証情報（`SERVERLESS_ACCESS_KEY`等）を設定していないため、デプロイの最初のステップで失敗していた。

## 対応
`backend/serverless.yml`に`frameworkVersion: '3'`を追加し、サインイン不要なv3系のCLIバイナリを使うよう固定した。本リポジトリはv4固有の機能（`httpApi`等）を使用しておらず、既存のリソース定義はv3でもそのまま動作する。

v4を使い続ける場合はapp.serverless.comでのアカウント作成・ライセンスキー発行というリポジトリ外の人手作業が必要になるため、今回は自動化可能な範囲でv3固定を選択した。

## テスト
- `npm run lint` / `npm test`（backend 1274件、全件成功）
- 実際のCD実行環境でのデプロイ成功確認は次回のCD実行で行う

---
_Generated by [Claude Code](https://claude.ai/code/session_0138Jv9BbR32fEVrbC5MTpAs)_