### PR TITLE
chore(release): v1.17.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.17.0](https://github.com/bamiyanapp/karuta/compare/v1.16.0...v1.17.0) (2026-07-11)
+
+
+### Features
+
+* **print:** 絵札印刷画面に裏面印刷を追加する ([#370](https://github.com/bamiyanapp/karuta/issues/370)) ([57010e6](https://github.com/bamiyanapp/karuta/commit/57010e61d4f4a0ba31a2605e790cc69da60b1f71))
+
 # [1.16.0](https://github.com/bamiyanapp/karuta/compare/v1.15.0...v1.16.0) (2026-07-11)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
+    "version": "1.17.0",
+    "date": "2026/06/30 15:55",
+    "body": "### Features\n\n* **print:** 絵札印刷画面に裏面印刷を追加する ([#370](https://github.com/bamiyanapp/karuta/issues/370)) ([57010e6](https://github.com/bamiyanapp/karuta/commit/57010e61d4f4a0ba31a2605e790cc69da60b1f71))"
+  },
+  {
     "version": "1.16.0",
-    "date": "2026/06/30 14:26",
+    "date": "2026/07/11 09:42",
     "body": "### Features\n\n* **print:** 絵札の文字サイズをさらに拡大する ([#367](https://github.com/bamiyanapp/karuta/issues/367)) ([02afa1a](https://github.com/bamiyanapp/karuta/commit/02afa1a0c91446413e35e5bd5b0ec61810343a08))"
   },
   {
@@ -146,7 +151,7 @@
   },
   {
     "version": "1.16.0",
-    "date": "2026/06/30 14:26",
+    "date": "2026/07/11 09:42",
     "body": "### Features\n\n* **test:** phrases.csvデータ整合性・かな整合・レベルユニーク性テストの追加とCSVデータ修正 ([#166](https://github.com/bamiyanapp/karuta/issues/166)) ([bd566f1](https://github.com/bamiyanapp/karuta/commit/bd566f1bc1a011041060ae7454b12fe477afaac2))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.16.0"
+  "version": "1.17.0"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。