### PR TITLE
fix(backend): frameworkVersionの指定形式をバージョン解決エラーから修正する

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -5,7 +5,9 @@ service: karuta-app
 # `npx serverless deploy`が「You must sign in or use a license key」で失敗する。
 # このリポジトリはv4固有の機能（httpApi等）を使用していないため、
 # サインイン不要なv3系に固定してこの問題を回避する。
-frameworkVersion: '3'
+# '3'のようなメジャーバージョンのみの指定は「No version found for 3」でCLIの
+# バージョン解決に失敗したため、実在するv3最終リリースの完全なバージョン番号を指定する。
+frameworkVersion: '3.40.0'
 
 provider:
   name: aws


### PR DESCRIPTION
## 概要
[#371](https://github.com/bamiyanapp/karuta/pull/371)（Serverless Frameworkをv3系に固定）マージ後の実際のCD実行で、`deploy-backend`ジョブが以下のエラーで即座に失敗した。

```
No version found for 3
```

## 根本原因
`frameworkVersion: '3'`のようなメジャーバージョンのみの指定は、`npx serverless`のバージョン解決処理では受理されない。

## 対応
実在するv3最終リリースの完全なバージョン番号`3.40.0`を指定するよう修正した。

## テスト
- `npm run lint` / `npm test`（backend 1274件、全件成功）
- 実際のCD実行環境でのデプロイ成功確認は次回のCD実行で行う

---
_Generated by [Claude Code](https://claude.ai/code/session_0138Jv9BbR32fEVrbC5MTpAs)_