### PR TITLE
refactor(cd): GitHub Pagesデプロイをdev-standardsの共通複合actionに置き換える

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,35 +33,23 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deploy.outputs.page-url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }} # CDをトリガーしたコミットを確実にデプロイする
           fetch-depth: 0
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-      - name: Install dependencies
-        working-directory: frontend
-        run: npm ci
-      - name: Build
-        working-directory: frontend
-        run: npm run build
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: frontend/dist
       - name: 🚀 Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+        id: deploy
+        uses: bamiyanapp/dev-standards/.github/actions/deploy-github-pages@main
+        with:
+          working-directory: frontend
+          node-version: 24
+          artifact-path: frontend/dist
       - name: Show GitHub Pages URL
         run: |
-          echo "Pages URL: ${{ steps.deployment.outputs.page_url }}"
+          echo "Pages URL: ${{ steps.deploy.outputs.page-url }}"
 
   deploy-backend:
     needs: release


### PR DESCRIPTION
## 概要

dev-standards側に新規追加されたGitHub Pagesデプロイ用の複合action（`bamiyanapp/dev-standards#33`）を使うよう、`build-and-deploy-frontend` job を置き換えました。

Refs bamiyanapp/dev-standards#33

## 設計

- frontendのビルド〜デプロイ手順（setup-node→npm ci→build→upload-pages-artifact→deploy-pages）を、`uses: bamiyanapp/dev-standards/.github/actions/deploy-github-pages@main` の呼び出しに置き換え
- job単位の`environment:`・`permissions:`はそのまま維持（複合actionからは設定できないため）
- 出力名が`page_url`→`page-url`（複合actionの出力名）に変わったため、`environment.url`・ログ出力の参照箇所を追従

## 影響

- デプロイ手順自体は変更なし（同じステップを複合action内部で実行する）

## テスト

- frontend: lint・test（75件）・build がいずれも問題なし
- backend: lint・test（1274件）が問題なし（本変更の対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NYtSzvgvGHgxPT9dnXVPxn)_