### PR TITLE
feat(voice): 音声認識で回答を判定する機能を追加する

### DIFF
--- a/backend/handler.js
+++ b/backend/handler.js
@@ -1,10 +1,14 @@
 const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
 const { DynamoDBDocumentClient, ScanCommand, GetCommand, PutCommand, UpdateCommand, QueryCommand } = require("@aws-sdk/lib-dynamodb");
 const { PollyClient, SynthesizeSpeechCommand } = require("@aws-sdk/client-polly");
+const { S3Client, PutObjectCommand, GetObjectCommand } = require("@aws-sdk/client-s3");
+const { TranscribeClient, StartTranscriptionJobCommand, GetTranscriptionJobCommand } = require("@aws-sdk/client-transcribe");
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
 const pollyClient = new PollyClient({ region: "ap-northeast-1" });
+const s3Client = new S3Client({ region: "ap-northeast-1" });
+const transcribeClient = new TranscribeClient({ region: "ap-northeast-1" });
 const crypto = require("crypto");
 
 // フロントエンド（GitHub Pages）およびローカル開発サーバーのオリジンのみ許可し、
@@ -549,6 +553,213 @@ exports.getCategories = async (event) => {
         "Access-Control-Allow-Credentials": true,
       },
       body: JSON.stringify({ categories }),
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      statusCode: 500,
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
+      body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
+    };
+  }
+};
+
+// 録音データ（data URI）の許容上限。数秒程度の発話であれば十分な余裕を持たせつつ、
+// 悪意あるリクエストによるS3/Transcribeの課金濫用を防ぐ
+const MAX_AUDIO_DATA_URI_LENGTH = 3_000_000; // 概ねbase64で3MB（デコード後2MB強）
+
+const AUDIO_DATA_URI_PATTERN = /^data:audio\/([a-zA-Z0-9.+-]+);base64,(.+)$/s;
+
+function decodeAudioDataUri(audioData) {
+  const match = typeof audioData === "string" ? audioData.match(AUDIO_DATA_URI_PATTERN) : null;
+  if (!match) {
+    return null;
+  }
+  const [, subtype, base64Body] = match;
+  return { mediaFormat: subtype.toLowerCase(), buffer: Buffer.from(base64Body, "base64") };
+}
+
+// 全角英数・カタカナを半角/ひらがなへ寄せ、記号・空白を除去する。
+// AWS Transcribeの認識結果とphrases.csv側の表記揺れ（カタカナ語の送り仮名等）を
+// 吸収するための簡易正規化であり、完全な表記統一を保証するものではない
+function normalizeJapaneseText(text) {
+  return String(text || "")
+    .normalize("NFKC")
+    .replace(/[ァ-ヶ]/g, (char) => String.fromCharCode(char.charCodeAt(0) - 0x60)) // カタカナ→ひらがな
+    .replace(/[\s、。！？「」『』・,.!?]/g, "")
+    .toLowerCase();
+}
+
+// 2文字列の編集距離（レーベンシュタイン距離）。認識結果が短い発話であることを踏まえ、
+// 外部ライブラリを追加せず素直なDP実装で十分とした
+function levenshteinDistance(a, b) {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const distances = Array.from({ length: rows }, (_, i) => [i, ...new Array(cols - 1).fill(0)]);
+  for (let j = 0; j < cols; j += 1) {
+    distances[0][j] = j;
+  }
+  for (let i = 1; i < rows; i += 1) {
+    for (let j = 1; j < cols; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      distances[i][j] = Math.min(
+        distances[i - 1][j] + 1,
+        distances[i][j - 1] + 1,
+        distances[i - 1][j - 1] + cost
+      );
+    }
+  }
+  return distances[rows - 1][cols - 1];
+}
+
+// answerが"-"（未設定）のカテゴリでは読み札そのものの聞き取り一致を見る必要があるため、
+// kanaへフォールバックする。しきい値は誤認識の揺れを吸収しつつ全くの別語を弾ける程度
+// （文字数の3割まで異なっていても許容）に経験的に設定している
+const MATCH_DISTANCE_RATIO_THRESHOLD = 0.3;
+
+function isAnswerMatch(transcript, phrase) {
+  const rawTarget = phrase?.answer && phrase.answer !== "-" ? phrase.answer : phrase?.kana;
+  const normalizedTarget = normalizeJapaneseText(rawTarget);
+  const normalizedTranscript = normalizeJapaneseText(transcript);
+
+  if (!normalizedTarget || !normalizedTranscript) {
+    return false;
+  }
+  if (normalizedTranscript.includes(normalizedTarget)) {
+    return true;
+  }
+  const distance = levenshteinDistance(normalizedTarget, normalizedTranscript);
+  return distance / normalizedTarget.length <= MATCH_DISTANCE_RATIO_THRESHOLD;
+}
+
+// 音声データをS3へアップロードし、AWS Transcribeの非同期ジョブを開始する。
+// ジョブ完了までは通常数秒〜十数秒かかるため、Lambda 1回の呼び出し内で待たず、
+// クライアントにjobNameを返してgetSpeechRecognitionResultでポーリングさせる方式にした
+// （API GatewayのLambda統合タイムアウト内で確実に完了する保証がないため）
+exports.startSpeechRecognition = async (event) => {
+  const allowedOrigin = resolveAllowedOrigin(event);
+  try {
+    const body = JSON.parse(event.body);
+    const { audioData, id, category, lang } = body;
+
+    if (!id || !category || !audioData || audioData.length > MAX_AUDIO_DATA_URI_LENGTH) {
+      return {
+        statusCode: 400,
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
+        body: JSON.stringify({ message: "Invalid input" }),
+      };
+    }
+
+    const decoded = decodeAudioDataUri(audioData);
+    if (!decoded) {
+      return {
+        statusCode: 400,
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
+        body: JSON.stringify({ message: "Invalid audio data" }),
+      };
+    }
+
+    const bucketName = process.env.VOICE_AUDIO_BUCKET_NAME;
+    const jobName = crypto.randomUUID();
+    const inputKey = `voice-input/${jobName}.${decoded.mediaFormat}`;
+    const outputKey = `voice-output/${jobName}.json`;
+
+    await s3Client.send(new PutObjectCommand({
+      Bucket: bucketName,
+      Key: inputKey,
+      Body: decoded.buffer,
+    }));
+
+    await transcribeClient.send(new StartTranscriptionJobCommand({
+      TranscriptionJobName: jobName,
+      LanguageCode: lang === "en" ? "en-US" : "ja-JP",
+      MediaFormat: decoded.mediaFormat,
+      Media: { MediaFileUri: `s3://${bucketName}/${inputKey}` },
+      OutputBucketName: bucketName,
+      OutputKey: outputKey,
+    }));
+
+    return {
+      statusCode: 200,
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
+      body: JSON.stringify({ jobName }),
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      statusCode: 500,
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
+      body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
+    };
+  }
+};
+
+exports.getSpeechRecognitionResult = async (event) => {
+  const allowedOrigin = resolveAllowedOrigin(event);
+  try {
+    const params = event.queryStringParameters || {};
+    const { jobName, id, category } = params;
+
+    if (!jobName || !id || !category) {
+      return {
+        statusCode: 400,
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
+        body: JSON.stringify({ message: "Invalid input" }),
+      };
+    }
+
+    const jobResult = await transcribeClient.send(new GetTranscriptionJobCommand({
+      TranscriptionJobName: jobName,
+    }));
+    const job = jobResult.TranscriptionJob;
+
+    if (job.TranscriptionJobStatus === "IN_PROGRESS" || job.TranscriptionJobStatus === "QUEUED") {
+      return {
+        statusCode: 200,
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
+        body: JSON.stringify({ status: "IN_PROGRESS" }),
+      };
+    }
+
+    if (job.TranscriptionJobStatus === "FAILED") {
+      return {
+        statusCode: 200,
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
+        body: JSON.stringify({ status: "FAILED", message: job.FailureReason }),
+      };
+    }
+
+    const bucketName = process.env.VOICE_AUDIO_BUCKET_NAME;
+    const outputKey = `voice-output/${jobName}.json`;
+    const outputObject = await s3Client.send(new GetObjectCommand({
+      Bucket: bucketName,
+      Key: outputKey,
+    }));
+    const outputBuffer = await streamToBuffer(outputObject.Body);
+    const transcriptJson = JSON.parse(outputBuffer.toString("utf-8"));
+    const transcript = transcriptJson?.results?.transcripts?.[0]?.transcript || "";
+
+    const getResult = await docClient.send(new GetCommand({
+      TableName: process.env.TABLE_NAME,
+      Key: { category, id },
+    }));
+
+    if (!getResult.Item) {
+      return {
+        statusCode: 404,
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
+        body: JSON.stringify({ message: "Phrase not found" }),
+      };
+    }
+
+    return {
+      statusCode: 200,
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
+      body: JSON.stringify({
+        status: "COMPLETED",
+        transcript,
+        isCorrect: isAnswerMatch(transcript, getResult.Item),
+      }),
     };
   } catch (error) {
     console.error(error);

--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -2,13 +2,24 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
 import { DynamoDBDocumentClient, ScanCommand, PutCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { PollyClient, SynthesizeSpeechCommand } from '@aws-sdk/client-polly';
-import { getCategories, getPhrasesList, getComments, postComment, getPhrase, getCongratulationAudio, recordTime } from './handler';
+import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { TranscribeClient, StartTranscriptionJobCommand, GetTranscriptionJobCommand } from '@aws-sdk/client-transcribe';
+import { getCategories, getPhrasesList, getComments, postComment, getPhrase, getCongratulationAudio, recordTime, startSpeechRecognition, getSpeechRecognitionResult } from './handler';
 import { Readable } from 'stream';
 import { UpdateCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import crypto from 'crypto';
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 const pollyMock = mockClient(PollyClient);
+const s3Mock = mockClient(S3Client);
+const transcribeMock = mockClient(TranscribeClient);
+
+function readableFromString(text) {
+    const stream = new Readable();
+    stream.push(text);
+    stream.push(null);
+    return stream;
+}
 
 vi.spyOn(crypto, 'randomUUID').mockReturnValue('mock-uuid');
 vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -1090,5 +1101,224 @@ describe('recordTime', () => {
         // readCountとtotalTimeが常に対応するサンプル数を保つよう、
         // 異常値のときはDB書き込み自体を行わない（部分更新はしない）
         expect(ddbMock.commandCalls(UpdateCommand).length).toBe(0);
+    });
+});
+
+describe('startSpeechRecognition', () => {
+    beforeEach(() => {
+        s3Mock.reset();
+        transcribeMock.reset();
+        process.env.VOICE_AUDIO_BUCKET_NAME = 'TestVoiceBucket';
+    });
+
+    it('should upload audio to S3, start a Transcribe job, and return the jobName', async () => {
+        s3Mock.on(PutObjectCommand).resolves({});
+        transcribeMock.on(StartTranscriptionJobCommand).resolves({});
+
+        const event = {
+            body: JSON.stringify({
+                audioData: 'data:audio/webm;base64,ZmFrZS1hdWRpby1kYXRh',
+                id: 'p1',
+                category: 'c1',
+                lang: 'ja',
+            }),
+        };
+        const response = await startSpeechRecognition(event);
+        expect(response.statusCode).toBe(200);
+        const body = JSON.parse(response.body);
+        expect(body.jobName).toBe('mock-uuid');
+
+        const putCall = s3Mock.commandCalls(PutObjectCommand)[0].args[0].input;
+        expect(putCall.Bucket).toBe('TestVoiceBucket');
+        expect(putCall.Key).toBe('voice-input/mock-uuid.webm');
+
+        const startCall = transcribeMock.commandCalls(StartTranscriptionJobCommand)[0].args[0].input;
+        expect(startCall.LanguageCode).toBe('ja-JP');
+        expect(startCall.Media.MediaFileUri).toBe('s3://TestVoiceBucket/voice-input/mock-uuid.webm');
+    });
+
+    it('should use en-US when lang is en', async () => {
+        s3Mock.on(PutObjectCommand).resolves({});
+        transcribeMock.on(StartTranscriptionJobCommand).resolves({});
+
+        const event = {
+            body: JSON.stringify({
+                audioData: 'data:audio/webm;base64,ZmFrZS1hdWRpby1kYXRh',
+                id: 'p1',
+                category: 'c1',
+                lang: 'en',
+            }),
+        };
+        await startSpeechRecognition(event);
+
+        const startCall = transcribeMock.commandCalls(StartTranscriptionJobCommand)[0].args[0].input;
+        expect(startCall.LanguageCode).toBe('en-US');
+    });
+
+    it('should return 400 when id/category/audioData are missing', async () => {
+        const event = { body: JSON.stringify({ id: 'p1' }) };
+        const response = await startSpeechRecognition(event);
+        expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 when audioData is not a valid audio data URI', async () => {
+        const event = {
+            body: JSON.stringify({
+                audioData: 'not-a-data-uri',
+                id: 'p1',
+                category: 'c1',
+            }),
+        };
+        const response = await startSpeechRecognition(event);
+        expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 when audioData exceeds the size limit', async () => {
+        const event = {
+            body: JSON.stringify({
+                audioData: `data:audio/webm;base64,${'A'.repeat(3_000_001)}`,
+                id: 'p1',
+                category: 'c1',
+            }),
+        };
+        const response = await startSpeechRecognition(event);
+        expect(response.statusCode).toBe(400);
+    });
+
+    it('should handle errors', async () => {
+        s3Mock.on(PutObjectCommand).rejects(new Error('S3 error'));
+        const event = {
+            body: JSON.stringify({
+                audioData: 'data:audio/webm;base64,ZmFrZS1hdWRpby1kYXRh',
+                id: 'p1',
+                category: 'c1',
+            }),
+        };
+        const response = await startSpeechRecognition(event);
+        expect(response.statusCode).toBe(500);
+    });
+});
+
+describe('getSpeechRecognitionResult', () => {
+    beforeEach(() => {
+        s3Mock.reset();
+        transcribeMock.reset();
+        ddbMock.reset();
+        process.env.VOICE_AUDIO_BUCKET_NAME = 'TestVoiceBucket';
+        process.env.TABLE_NAME = 'TestTable';
+    });
+
+    it('should return IN_PROGRESS while the job is still running', async () => {
+        transcribeMock.on(GetTranscriptionJobCommand).resolves({
+            TranscriptionJob: { TranscriptionJobStatus: 'IN_PROGRESS' },
+        });
+
+        const event = { queryStringParameters: { jobName: 'job1', id: 'p1', category: 'c1' } };
+        const response = await getSpeechRecognitionResult(event);
+        expect(response.statusCode).toBe(200);
+        expect(JSON.parse(response.body)).toEqual({ status: 'IN_PROGRESS' });
+    });
+
+    it('should return FAILED with the failure reason', async () => {
+        transcribeMock.on(GetTranscriptionJobCommand).resolves({
+            TranscriptionJob: { TranscriptionJobStatus: 'FAILED', FailureReason: 'boom' },
+        });
+
+        const event = { queryStringParameters: { jobName: 'job1', id: 'p1', category: 'c1' } };
+        const response = await getSpeechRecognitionResult(event);
+        expect(response.statusCode).toBe(200);
+        expect(JSON.parse(response.body)).toEqual({ status: 'FAILED', message: 'boom' });
+    });
+
+    it('should judge correct when the transcript matches the answer', async () => {
+        transcribeMock.on(GetTranscriptionJobCommand).resolves({
+            TranscriptionJob: { TranscriptionJobStatus: 'COMPLETED' },
+        });
+        s3Mock.on(GetObjectCommand).resolves({
+            Body: readableFromString(JSON.stringify({ results: { transcripts: [{ transcript: 'てんぐ' }] } })),
+        });
+        ddbMock.on(GetCommand).resolves({ Item: { id: 'p1', category: 'c1', answer: 'てんぐ', kana: 'た' } });
+
+        const event = { queryStringParameters: { jobName: 'job1', id: 'p1', category: 'c1' } };
+        const response = await getSpeechRecognitionResult(event);
+        expect(response.statusCode).toBe(200);
+        const body = JSON.parse(response.body);
+        expect(body.status).toBe('COMPLETED');
+        expect(body.transcript).toBe('てんぐ');
+        expect(body.isCorrect).toBe(true);
+    });
+
+    it('should judge correct on a fuzzy (near) match within the distance threshold', async () => {
+        transcribeMock.on(GetTranscriptionJobCommand).resolves({
+            TranscriptionJob: { TranscriptionJobStatus: 'COMPLETED' },
+        });
+        s3Mock.on(GetObjectCommand).resolves({
+            Body: readableFromString(JSON.stringify({ results: { transcripts: [{ transcript: 'てんぐう' }] } })),
+        });
+        ddbMock.on(GetCommand).resolves({ Item: { id: 'p1', category: 'c1', answer: 'てんぐ', kana: 'た' } });
+
+        const event = { queryStringParameters: { jobName: 'job1', id: 'p1', category: 'c1' } };
+        const response = await getSpeechRecognitionResult(event);
+        const body = JSON.parse(response.body);
+        expect(body.isCorrect).toBe(true);
+    });
+
+    it('should judge incorrect when the transcript does not match', async () => {
+        transcribeMock.on(GetTranscriptionJobCommand).resolves({
+            TranscriptionJob: { TranscriptionJobStatus: 'COMPLETED' },
+        });
+        s3Mock.on(GetObjectCommand).resolves({
+            Body: readableFromString(JSON.stringify({ results: { transcripts: [{ transcript: '全然違う言葉' }] } })),
+        });
+        ddbMock.on(GetCommand).resolves({ Item: { id: 'p1', category: 'c1', answer: 'てんぐ', kana: 'た' } });
+
+        const event = { queryStringParameters: { jobName: 'job1', id: 'p1', category: 'c1' } };
+        const response = await getSpeechRecognitionResult(event);
+        const body = JSON.parse(response.body);
+        expect(body.isCorrect).toBe(false);
+    });
+
+    it('should fall back to matching against kana when answer is "-"', async () => {
+        transcribeMock.on(GetTranscriptionJobCommand).resolves({
+            TranscriptionJob: { TranscriptionJobStatus: 'COMPLETED' },
+        });
+        s3Mock.on(GetObjectCommand).resolves({
+            Body: readableFromString(JSON.stringify({ results: { transcripts: [{ transcript: 'たんじょうびケーキがたおれてイチゴがころがった' }] } })),
+        });
+        ddbMock.on(GetCommand).resolves({
+            Item: { id: 'p1', category: 'c1', answer: '-', kana: 'たんじょうびケーキがたおれてイチゴがころがった' },
+        });
+
+        const event = { queryStringParameters: { jobName: 'job1', id: 'p1', category: 'c1' } };
+        const response = await getSpeechRecognitionResult(event);
+        const body = JSON.parse(response.body);
+        expect(body.isCorrect).toBe(true);
+    });
+
+    it('should return 404 when the phrase no longer exists', async () => {
+        transcribeMock.on(GetTranscriptionJobCommand).resolves({
+            TranscriptionJob: { TranscriptionJobStatus: 'COMPLETED' },
+        });
+        s3Mock.on(GetObjectCommand).resolves({
+            Body: readableFromString(JSON.stringify({ results: { transcripts: [{ transcript: 'てんぐ' }] } })),
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+        const event = { queryStringParameters: { jobName: 'job1', id: 'p1', category: 'c1' } };
+        const response = await getSpeechRecognitionResult(event);
+        expect(response.statusCode).toBe(404);
+    });
+
+    it('should return 400 when jobName/id/category are missing', async () => {
+        const event = { queryStringParameters: { jobName: 'job1' } };
+        const response = await getSpeechRecognitionResult(event);
+        expect(response.statusCode).toBe(400);
+    });
+
+    it('should handle errors', async () => {
+        transcribeMock.on(GetTranscriptionJobCommand).rejects(new Error('Transcribe error'));
+        const event = { queryStringParameters: { jobName: 'job1', id: 'p1', category: 'c1' } };
+        const response = await getSpeechRecognitionResult(event);
+        expect(response.statusCode).toBe(500);
     });
 });

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.958.0",
         "@aws-sdk/client-polly": "^3.958.0",
+        "@aws-sdk/client-s3": "^3.958.0",
+        "@aws-sdk/client-transcribe": "^3.958.0",
         "@aws-sdk/lib-dynamodb": "^3.958.0",
         "@aws-sdk/polly-request-presigner": "^3.958.0",
         "@aws-sdk/s3-request-presigner": "^3.958.0",
@@ -155,7 +157,6 @@
       "version": "3.1000.16",
       "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.16.tgz",
       "integrity": "sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -172,7 +173,6 @@
       "version": "3.975.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
       "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.0",
@@ -192,7 +192,6 @@
       "version": "3.974.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
       "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.0",
@@ -206,7 +205,6 @@
       "version": "3.972.34",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
       "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.0",
@@ -220,7 +218,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
       "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -2064,7 +2061,6 @@
       "version": "3.1085.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1085.0.tgz",
       "integrity": "sha512-O0xe8sR50AYkwxlvRRsV0qytEO2dtXQTQ1CF3YBBdE5xtVkbu27H0vGa1mjQi1/+fbYM80AWEIPai5jZmXyubw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/checksums": "^3.1000.16",
@@ -2087,7 +2083,6 @@
       "version": "3.975.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
       "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.0",
@@ -2107,7 +2102,6 @@
       "version": "3.972.57",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
       "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -2124,7 +2118,6 @@
       "version": "3.972.59",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
       "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -2143,7 +2136,6 @@
       "version": "3.973.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
       "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -2168,7 +2160,6 @@
       "version": "3.972.63",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
       "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -2186,7 +2177,6 @@
       "version": "3.972.66",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
       "integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "^3.972.57",
@@ -2209,7 +2199,6 @@
       "version": "3.972.57",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
       "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -2226,7 +2215,6 @@
       "version": "3.973.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
       "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -2245,7 +2233,6 @@
       "version": "3.972.63",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
       "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -2263,7 +2250,6 @@
       "version": "3.972.62",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.62.tgz",
       "integrity": "sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -2281,7 +2267,6 @@
       "version": "3.997.31",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
       "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -2301,7 +2286,6 @@
       "version": "3.996.39",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
       "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.0",
@@ -2317,7 +2301,6 @@
       "version": "3.1083.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
       "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",
@@ -2335,7 +2318,6 @@
       "version": "3.974.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
       "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.0",
@@ -2349,7 +2331,6 @@
       "version": "3.972.34",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
       "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.0",
@@ -2363,7 +2344,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
       "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -2702,6 +2682,278 @@
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
       "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
       "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe": {
+      "version": "3.1085.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-transcribe/-/client-transcribe-3.1085.0.tgz",
+      "integrity": "sha512-a5KqybDzsJhgnx/1e8nh8lrJU0LvcCkOlle/zqQrjT/eRMv3ZvXUsdoT43g3Ac7186jU/9Mo7Q7t9BPNzdrWtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-node": "^3.972.66",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe/node_modules/@aws-sdk/core": {
+      "version": "3.975.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
+      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.0",
+        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
+      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
+      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
+      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-login": "^3.972.63",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
+      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
+      "integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-ini": "^3.973.1",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
+      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
+      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/token-providers": "3.1083.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
+      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
+      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
+      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1083.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
+      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe/node_modules/@aws-sdk/types": {
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
+      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
+      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-transcribe/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,8 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.958.0",
     "@aws-sdk/client-polly": "^3.958.0",
+    "@aws-sdk/client-s3": "^3.958.0",
+    "@aws-sdk/client-transcribe": "^3.958.0",
     "@aws-sdk/lib-dynamodb": "^3.958.0",
     "@aws-sdk/polly-request-presigner": "^3.958.0",
     "@aws-sdk/s3-request-presigner": "^3.958.0",

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -8,6 +8,7 @@ provider:
     TABLE_NAME: ${self:custom.tableName}
     COMMENTS_TABLE_NAME: ${self:custom.commentsTableName}
     POLLY_CACHE_TABLE_NAME: ${self:custom.pollyCacheTableName} # 追加
+    VOICE_AUDIO_BUCKET_NAME: ${self:custom.voiceAudioBucketName}-${aws:accountId} # 追加
   iam:
     role:
       statements:
@@ -18,7 +19,7 @@ provider:
             - dynamodb:GetItem
             - dynamodb:PutItem
             - dynamodb:UpdateItem
-          Resource: 
+          Resource:
             - !GetAtt KarutaTable.Arn
             - !GetAtt CommentsTable.Arn
             - !GetAtt PollyCacheTable.Arn # 追加
@@ -26,11 +27,22 @@ provider:
           Action:
             - polly:SynthesizeSpeech
           Resource: "*"
+        - Effect: Allow # 追加（issue #382: 音声認識で回答を拾う機能）
+          Action:
+            - s3:PutObject
+            - s3:GetObject
+          Resource: !Sub "${VoiceAudioBucket.Arn}/*"
+        - Effect: Allow # 追加（issue #382: 音声認識で回答を拾う機能。Transcribeはリソースレベル制限に対応しないため*を許可）
+          Action:
+            - transcribe:StartTranscriptionJob
+            - transcribe:GetTranscriptionJob
+          Resource: "*"
 
 custom:
   tableName: karuta-phrases
   commentsTableName: karuta-comments
   pollyCacheTableName: karuta-polly-cache # 追加
+  voiceAudioBucketName: karuta-voice-audio # 追加。バケット名はグローバルに一意である必要があるためアカウントIDを付与する
   allowedOrigins:
     - https://bamiyanapp.github.io
     - http://localhost:5173 # npm run dev（Vite開発サーバー）
@@ -93,6 +105,22 @@ functions:
           method: post
           cors:
             origins: ${self:custom.allowedOrigins}
+  startSpeechRecognition: # 追加（issue #382: 音声認識で回答を拾う機能）
+    handler: handler.startSpeechRecognition
+    events:
+      - http:
+          path: start-speech-recognition
+          method: post
+          cors:
+            origins: ${self:custom.allowedOrigins}
+  getSpeechRecognitionResult: # 追加（issue #382: 音声認識で回答を拾う機能）
+    handler: handler.getSpeechRecognitionResult
+    events:
+      - http:
+          path: get-speech-recognition-result
+          method: get
+          cors:
+            origins: ${self:custom.allowedOrigins}
 
 resources:
   Resources:
@@ -142,3 +170,17 @@ resources:
         TimeToLiveSpecification: # キャッシュキーの組み合わせ分レコードが際限なく増加するのを防ぐため、一定期間後に自動削除する
           AttributeName: ttl
           Enabled: true
+    VoiceAudioBucket: # 追加（issue #382: 音声認識で回答を拾う機能）
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: ${self:custom.voiceAudioBucketName}-${aws:accountId}
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: true
+          BlockPublicPolicy: true
+          IgnorePublicAcls: true
+          RestrictPublicBuckets: true
+        LifecycleConfiguration: # 録音・認識結果は判定後不要になるため、取り違え時の保持コスト・情報漏洩リスクを抑えるべく短期間で自動削除する
+          Rules:
+            - Id: ExpireVoiceRecognitionObjects
+              Status: Enabled
+              ExpirationInDays: 1

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import { useLocalStorageState } from "./hooks/useLocalStorageState";
 import { useSessionStorageState } from "./hooks/useSessionStorageState";
 import { useUrlQuerySync, parseCategoriesParam } from "./hooks/useUrlQuerySync";
 import { useWakeLock } from "./hooks/useWakeLock";
+import { useVoiceAnswerRecognition } from "./hooks/useVoiceAnswerRecognition";
 import DetailView from "./views/DetailView";
 import PrintEfudaView from "./views/PrintEfudaView";
 import AllPhrasesView from "./views/AllPhrasesView";
@@ -84,6 +85,7 @@ function App() {
   const [sortOrder, setSortOrder] = useLocalStorageState("sortOrder", "random");
   const [autoAdvance, setAutoAdvance] = useLocalStorageState("autoAdvance", false, (v) => v === "true");
   const [autoAdvanceInterval, setAutoAdvanceInterval] = useLocalStorageState("autoAdvanceInterval", 10, (v) => parseInt(v, 10));
+  const [voiceJudgeEnabled, setVoiceJudgeEnabled] = useLocalStorageState("voiceJudgeEnabled", false, (v) => v === "true");
   const [themeSetting, setThemeSetting] = useLocalStorageState("theme", "system");
   const [systemPrefersDark, setSystemPrefersDark] = useState(() => {
     return window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
@@ -827,6 +829,22 @@ function App() {
 
   useWakeLock(view === "game" && selectedCategories.length > 0);
 
+  // 実験的機能（issue #382）: 読み上げ後の発話を録音し、AWS Transcribeでの認識結果が
+  // 正解と一致した場合に手動クリックと同じplayKaruta()を呼んで次の札へ進める。
+  // 誤認識・タイムアウト時は何もしない（従来通り手動での「次の札」操作にフォールバックする）。
+  const { status: voiceRecognitionStatus } = useVoiceAnswerRecognition({
+    listening: voiceJudgeEnabled && displayContent.type === "phrase" && !isReading && !loading && !isAllRead,
+    phraseId: currentPhrase?.id,
+    category: currentPhrase?.category,
+    apiBaseUrl: API_BASE_URL,
+    lang,
+    onResult: (result) => {
+      if (result.isCorrect) {
+        playKaruta();
+      }
+    },
+  });
+
   useEffect(() => {
     if (view === "comments") {
       document.title = "指摘一覧 | かるた読み上げアプリ";
@@ -1460,6 +1478,23 @@ function App() {
                 <button onClick={() => setAutoAdvanceInterval(20)} className={`btn ${autoAdvanceInterval === 20 ? 'btn-dark' : 'btn-outline-dark'}`}>20秒</button>
                 <button onClick={() => setAutoAdvanceInterval(30)} className={`btn ${autoAdvanceInterval === 30 ? 'btn-dark' : 'btn-outline-dark'}`}>30秒</button>
               </div>
+            )}
+          </div>
+          <div className="d-flex align-items-center justify-content-center gap-3 flex-wrap mt-3">
+            <span className="fw-bold text-dark small">音声で判定（実験的機能）:</span>
+            <div className="btn-group btn-group-sm" role="group">
+              <button onClick={() => setVoiceJudgeEnabled(false)} className={`btn ${!voiceJudgeEnabled ? 'btn-dark' : 'btn-outline-dark'}`}>オフ</button>
+              <button onClick={() => setVoiceJudgeEnabled(true)} className={`btn ${voiceJudgeEnabled ? 'btn-dark' : 'btn-outline-dark'}`}>オン</button>
+            </div>
+            {voiceJudgeEnabled && voiceRecognitionStatus !== "idle" && voiceRecognitionStatus !== "unsupported" && (
+              <span className="text-muted small">
+                {voiceRecognitionStatus === "recording" && "聞き取り中..."}
+                {voiceRecognitionStatus === "uploading" && "送信中..."}
+                {voiceRecognitionStatus === "processing" && "認識中..."}
+              </span>
+            )}
+            {voiceJudgeEnabled && voiceRecognitionStatus === "unsupported" && (
+              <span className="text-muted small">この端末・ブラウザでは利用できません</span>
             )}
           </div>
         </section>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1093,7 +1093,9 @@ describe('App', () => {
     // 自動で次への設定はデフォルトでオフで、間隔ボタンは表示されない
     expect(screen.queryByText('10秒')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByText('オン'));
+    // 「音声で判定」にも同じ表記のオン/オフボタンがあるため、getAllByTextの先頭
+    // （自動で次への設定）を明示的に選ぶ
+    fireEvent.click(screen.getAllByText('オン')[0]);
     expect(localStorage.getItem('autoAdvance')).toBe('true');
 
     fireEvent.click(await screen.findByText('20秒'));

--- a/frontend/src/hooks/useVoiceAnswerRecognition.js
+++ b/frontend/src/hooks/useVoiceAnswerRecognition.js
@@ -1,0 +1,158 @@
+import { useEffect, useRef, useState } from "react";
+
+// 録音の最大長（これ以上待たずに認識へ回す）。長すぎる録音はTranscribeの
+// 課金・レイテンシが増えるため、短い発話であるkarutaの回答に十分な範囲で区切る
+const MAX_RECORDING_MS = 8000;
+const POLL_INTERVAL_MS = 1500;
+const MAX_POLL_ATTEMPTS = 10; // 15秒（POLL_INTERVAL_MS×MAX_POLL_ATTEMPTS）待っても完了しない場合はタイムアウト扱いにする
+
+function blobToDataUri(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// listeningがtrueの間、マイクから音声を録音し、dev-standards側と同様のAWS構成
+// （S3アップロード→Transcribeジョブ）で解析する。結果（正誤・認識テキスト）は
+// onResultへコールバックする。MediaRecorder/getUserMedia未対応環境では
+// status: "unsupported" を返し、録音自体を行わない（フィーチャーディテクション）。
+//
+// phraseId/categoryは呼び出し側の再レンダーごとに新しいオブジェクトが渡されがちな
+// `phrase`をそのまま依存配列に使うと録音が意図せず再開してしまうため、
+// プリミティブ値として個別に受け取る。onResultは同様の理由でrefに退避し、
+// 依存配列には含めない（useWakeLockのactiveと同じ考え方）。
+export function useVoiceAnswerRecognition({ listening, phraseId, category, apiBaseUrl, lang, onResult }) {
+  const [status, setStatus] = useState("idle");
+  const onResultRef = useRef(onResult);
+  onResultRef.current = onResult;
+
+  useEffect(() => {
+    if (!listening || !phraseId || !category) {
+      return undefined;
+    }
+    if (typeof MediaRecorder === "undefined" || !navigator.mediaDevices?.getUserMedia) {
+      setStatus("unsupported");
+      return undefined;
+    }
+
+    let cancelled = false;
+    let stopTimeout = null;
+    let mediaRecorder = null;
+    let mediaStream = null;
+
+    const stopStream = () => {
+      mediaStream?.getTracks().forEach((track) => track.stop());
+    };
+
+    const run = async () => {
+      try {
+        mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        if (cancelled) {
+          stopStream();
+          return;
+        }
+
+        const chunks = [];
+        mediaRecorder = new MediaRecorder(mediaStream);
+        mediaRecorder.ondataavailable = (e) => {
+          if (e.data.size > 0) {
+            chunks.push(e.data);
+          }
+        };
+        const stopped = new Promise((resolve) => {
+          mediaRecorder.onstop = resolve;
+        });
+
+        setStatus("recording");
+        mediaRecorder.start();
+        stopTimeout = setTimeout(() => {
+          if (mediaRecorder.state !== "inactive") {
+            mediaRecorder.stop();
+          }
+        }, MAX_RECORDING_MS);
+
+        await stopped;
+        stopStream();
+        if (cancelled) {
+          return;
+        }
+
+        setStatus("uploading");
+        const blob = new Blob(chunks, { type: mediaRecorder.mimeType || "audio/webm" });
+        const audioData = await blobToDataUri(blob);
+
+        const startResponse = await fetch(`${apiBaseUrl}/start-speech-recognition`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ audioData, id: phraseId, category, lang }),
+        });
+        if (!startResponse.ok) {
+          throw new Error(`start-speech-recognition failed: ${startResponse.status}`);
+        }
+        const { jobName } = await startResponse.json();
+        if (cancelled) {
+          return;
+        }
+
+        setStatus("processing");
+        for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt += 1) {
+          await sleep(POLL_INTERVAL_MS);
+          if (cancelled) {
+            return;
+          }
+          const resultResponse = await fetch(
+            `${apiBaseUrl}/get-speech-recognition-result?jobName=${encodeURIComponent(jobName)}` +
+              `&id=${encodeURIComponent(phraseId)}&category=${encodeURIComponent(category)}`
+          );
+          if (!resultResponse.ok) {
+            throw new Error(`get-speech-recognition-result failed: ${resultResponse.status}`);
+          }
+          const result = await resultResponse.json();
+          if (cancelled) {
+            return;
+          }
+          if (result.status === "COMPLETED") {
+            setStatus("idle");
+            onResultRef.current?.({ isCorrect: result.isCorrect, transcript: result.transcript });
+            return;
+          }
+          if (result.status === "FAILED") {
+            setStatus("idle");
+            onResultRef.current?.({ error: result.message || "recognition failed" });
+            return;
+          }
+        }
+        setStatus("idle");
+        onResultRef.current?.({ error: "timeout" });
+      } catch (error) {
+        stopStream();
+        if (!cancelled) {
+          setStatus("idle");
+          onResultRef.current?.({ error: error.message });
+        }
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+      if (stopTimeout) {
+        clearTimeout(stopTimeout);
+      }
+      if (mediaRecorder && mediaRecorder.state !== "inactive") {
+        mediaRecorder.stop();
+      }
+      stopStream();
+    };
+  }, [listening, phraseId, category, apiBaseUrl, lang]);
+
+  return { status };
+}

--- a/frontend/src/hooks/useVoiceAnswerRecognition.test.js
+++ b/frontend/src/hooks/useVoiceAnswerRecognition.test.js
@@ -1,0 +1,135 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { useVoiceAnswerRecognition } from "./useVoiceAnswerRecognition";
+
+class FakeMediaRecorder {
+  constructor(stream) {
+    this.stream = stream;
+    this.state = "inactive";
+    this.mimeType = "audio/webm";
+    this.ondataavailable = null;
+    this.onstop = null;
+    FakeMediaRecorder.instances.push(this);
+  }
+
+  start() {
+    this.state = "recording";
+  }
+
+  stop() {
+    this.state = "inactive";
+    this.ondataavailable?.({ data: new Blob(["fake-audio"], { type: "audio/webm" }) });
+    this.onstop?.();
+  }
+}
+FakeMediaRecorder.instances = [];
+
+function fakeStream() {
+  return { getTracks: () => [{ stop: vi.fn() }] };
+}
+
+describe("useVoiceAnswerRecognition", () => {
+  let originalMediaRecorder;
+  let originalMediaDevices;
+  let getUserMedia;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    FakeMediaRecorder.instances = [];
+    originalMediaRecorder = window.MediaRecorder;
+    originalMediaDevices = navigator.mediaDevices;
+    window.MediaRecorder = FakeMediaRecorder;
+    getUserMedia = vi.fn().mockResolvedValue(fakeStream());
+    Object.defineProperty(navigator, "mediaDevices", { value: { getUserMedia }, configurable: true });
+    window.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    window.MediaRecorder = originalMediaRecorder;
+    Object.defineProperty(navigator, "mediaDevices", { value: originalMediaDevices, configurable: true });
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const baseProps = {
+    listening: true,
+    phraseId: "p1",
+    category: "c1",
+    apiBaseUrl: "https://api.example.com",
+    lang: "ja",
+  };
+
+  it("listeningがfalseの場合は録音を開始しない", () => {
+    renderHook(() => useVoiceAnswerRecognition({ ...baseProps, listening: false, onResult: vi.fn() }));
+    expect(getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it("MediaRecorder未対応の場合はunsupportedを返し録音しない", () => {
+    window.MediaRecorder = undefined;
+    const { result } = renderHook(() => useVoiceAnswerRecognition({ ...baseProps, onResult: vi.fn() }));
+    expect(result.current.status).toBe("unsupported");
+    expect(getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it("録音→アップロード→ポーリングを経て正解判定をonResultへ渡す", async () => {
+    window.fetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ jobName: "job1" }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: "IN_PROGRESS" }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: "COMPLETED", isCorrect: true, transcript: "てんぐ" }) });
+
+    const onResult = vi.fn();
+    renderHook(() => useVoiceAnswerRecognition({ ...baseProps, onResult }));
+
+    await vi.waitFor(() => expect(getUserMedia).toHaveBeenCalledWith({ audio: true }));
+    await vi.waitFor(() => expect(FakeMediaRecorder.instances.length).toBe(1));
+
+    // MAX_RECORDING_MS経過で自動的に録音を止める
+    await vi.advanceTimersByTimeAsync(8000);
+    await vi.waitFor(() => expect(window.fetch).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example.com/start-speech-recognition",
+      expect.objectContaining({ method: "POST" })
+    ));
+
+    // ポーリング間隔分進めてIN_PROGRESS→COMPLETEDへ
+    await vi.advanceTimersByTimeAsync(1500);
+    await vi.waitFor(() => expect(window.fetch).toHaveBeenCalledTimes(2));
+    await vi.advanceTimersByTimeAsync(1500);
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledWith({ isCorrect: true, transcript: "てんぐ" }));
+  });
+
+  it("FAILEDが返った場合はerrorとしてonResultへ渡す", async () => {
+    window.fetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ jobName: "job1" }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: "FAILED", message: "boom" }) });
+
+    const onResult = vi.fn();
+    renderHook(() => useVoiceAnswerRecognition({ ...baseProps, onResult }));
+
+    await vi.waitFor(() => expect(FakeMediaRecorder.instances.length).toBe(1));
+    await vi.advanceTimersByTimeAsync(8000);
+    await vi.advanceTimersByTimeAsync(1500);
+
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledWith({ error: "boom" }));
+  });
+
+  it("getUserMediaが拒否された場合はerrorとしてonResultへ渡す", async () => {
+    getUserMedia.mockRejectedValue(new Error("Permission denied"));
+    const onResult = vi.fn();
+    renderHook(() => useVoiceAnswerRecognition({ ...baseProps, onResult }));
+
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledWith({ error: "Permission denied" }));
+  });
+
+  it("アンマウント時に録音中のストリームを停止する", async () => {
+    const stopTrack = vi.fn();
+    getUserMedia.mockResolvedValue({ getTracks: () => [{ stop: stopTrack }] });
+
+    const { unmount } = renderHook(() => useVoiceAnswerRecognition({ ...baseProps, onResult: vi.fn() }));
+    await vi.waitFor(() => expect(FakeMediaRecorder.instances.length).toBe(1));
+
+    unmount();
+
+    expect(stopTrack).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要

音声認識（AWS Transcribe）で読み札の回答を拾い、正解時に自動で次の札へ進める実験的機能を追加しました。

Refs #382（設計メモをissueにコメント済み）

## 設計

- フロントは`MediaRecorder`で録音し、backendの新規エンドポイント`start-speech-recognition`へアップロード
- backendは音声をS3へ保存し、Transcribeの非同期ジョブを開始
- フロントは`get-speech-recognition-result`でジョブ完了をポーリング
- 認識結果は`answer`（未設定"-"の場合は`kana`にフォールバック）と正規化（NFKC・カタカナ→ひらがな・記号除去）＋レーベンシュタイン距離ベースのファジーマッチで照合
- フロントの設定に「音声で判定（実験的機能）」トグルを追加（既定オフ）。オンの場合のみマイク権限を要求し、正解と判定された場合のみ既存の「次の札」ボタンと同じ処理（`playKaruta()`）を呼ぶ。誤認識・タイムアウト時は何もせず従来の手動操作にフォールバックする
- S3の録音・認識結果オブジェクトはライフサイクルルールで1日後に自動削除される

却下した案（Web Speech API、エッジ側WASM音声認識、Transcribeストリーミング）とその理由はissue #382のコメントに記載しています。

## 影響

- 既定では無効（`voiceJudgeEnabled`既定false）のため、既存ユーザーの挙動に変更はありません
- 有効化した場合のみマイク権限の要求・録音・AWSへのアップロードが発生します

## テスト

- backend: aws-sdk-client-mockでS3/Transcribe/DynamoDBをモックした単体テスト9件を追加
- frontend: MediaRecorder/getUserMedia/fetchをモックしたフックの単体テスト6件を追加
- frontend/backendともにlint・test・build（backendはbuild対象外）が0件であることを確認
- 実機・実ブラウザでのマイク録音、AWS Transcribeへの実リクエストによるエンドツーエンドの動作確認は未実施（サンドボックス環境に実AWS認証情報がなく、マイク入力も利用できないため）。デプロイ後の実環境での動作確認が必要です

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NYtSzvgvGHgxPT9dnXVPxn)_