### PR TITLE
fix(frontend): 絵札印刷プレビューが狭い画面で左側フレームアウトする問題を修正する

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -328,6 +328,12 @@ button:active:not(:disabled) {
   height: 297mm;
   background: white;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.2);
+  /* ビューポート幅がA4実寸（210mm）に満たない場合、画面プレビューでは縮小して
+     全体を表示する。zoomは（transformと異なり）子要素のmm単位レイアウトを
+     保ったままレンダリングサイズごと縮小でき、親のflexコンテナも縮小後の
+     サイズを基準にレイアウトし直すため、中央寄せでも左側が画面外へ
+     はみ出さない。印刷時（@media print）はA4実寸に戻す */
+  zoom: min(1, calc(100vw / 210mm));
 }
 
 .efuda-grid {
@@ -437,6 +443,8 @@ button:active:not(:disabled) {
   .efuda-page {
     box-shadow: none;
     page-break-after: always;
+    /* 画面プレビュー用の縮小（zoom）を印刷時は無効化し、A4実寸のまま出力する */
+    zoom: 1;
   }
 
   .efuda-page:last-child {


### PR DESCRIPTION
## 概要

「絵札を印刷する」画面で、画面幅が800px未満（スマホ・タブレット・多くのノートPC）の場合にカード左側が画面外へフレームアウトして表示できない不具合を修正しました。

Closes #387

## 原因

`.efuda-page`が印刷用にA4実寸（`210mm`≒793.7px）の固定幅で作られており、画面プレビュー用のレスポンシブ対応がなかった。親の`.efuda-print-area`は`align-items: center`で中央寄せしているだけなので、ビューポート幅がカード幅未満の場合ははみ出し分が左右均等にオーバーフローするが、ブラウザは通常0未満の位置へスクロールできないため、右側のはみ出しは見えても左側は永久に到達不能になっていた。

## 設計

- `.efuda-page`にCSS `zoom: min(1, calc(100vw / 210mm))`を追加し、ビューポート幅がA4実寸に満たない場合は縮小、それ以上では等倍（拡大しない）とした
- `@media print`側で`zoom: 1`を明示し、印刷・PDF出力はA4実寸のまま変更なし
- `transform: scale()`は要素のレイアウト占有サイズを変えないため別途ラッパー・高さ調整が必要になり複雑になる。`zoom`はレンダリングサイズごと縮小し親のflexレイアウトにも反映されるため、既存の`align-items: center`のまま解決できた

## 影響

- 画面幅800px未満で絵札印刷プレビューを開いた際、縮小表示され全体が見えるようになる
- 800px以上の画面、および印刷・PDFダウンロードの出力サイズには影響なし

## テスト

- Playwrightで実際にビルドしたCSSを読み込み、375/390/430/768px（縮小されフレームアウトしないことを確認）と800/900/1280px（従来通り実寸表示のまま変わらないことを確認）の各ビューポート幅で`.efuda-page`の描画位置・サイズを検証
- `page.emulateMedia({media: "print"})`でも実寸（210mm×297mm相当）のまま変わらないことを確認
- frontend/backendともにlint・test・build（backendはbuild対象外）が0件であることを確認
- jsdom（vitestの既定環境）は実際のCSSレイアウト計算・zoom/calc()を評価しないため、本修正の視覚的効果を検証する自動テストは追加していない（Playwrightによる目視・座標検証で代替）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NYtSzvgvGHgxPT9dnXVPxn)_