### PR TITLE
docs(frontend): 絵札印刷用紙の案内テキストの冗長な記載を整理する

### DIFF
--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -73,8 +73,8 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
         <>
           <div className="no-print text-center mb-4">
             <p className="text-muted small mb-3">
-              用紙（顔料インク用）: <a href="https://www.a-one.co.jp/product/search/detail.php?id=51677" target="_blank" rel="noopener noreferrer">エーワン マルチカード（マイクロミシン・厚口）A4・10面用</a><br />
-              用紙（インクジェット用）: <a href="https://www.a-one.co.jp/product/search/detail.php?id=51604" target="_blank" rel="noopener noreferrer">エーワン マルチカード（マイクロミシン・厚口）A4・10面用</a><br />
+              用紙（顔料インク用）: <a href="https://www.a-one.co.jp/product/search/detail.php?id=51677" target="_blank" rel="noopener noreferrer">エーワン マルチカード A4・10面用 品番51677</a><br />
+              用紙（インクジェット用）: <a href="https://www.a-one.co.jp/product/search/detail.php?id=51604" target="_blank" rel="noopener noreferrer">エーワン マルチカード A4・10面用 品番51604</a><br />
               印刷ダイアログで「用紙サイズ: A4」「余白: なし」「拡大縮小: 実際のサイズ(100%)」「ヘッダーとフッター: オフ」に設定してください。<br />
               両面印刷する場合は、表面を印刷した用紙をそのまま裏返してセットし、裏面を印刷してください。
             </p>


### PR DESCRIPTION
## 概要

「絵札を印刷する」画面の用紙案内で、顔料インク用・インクジェット用の2つのリンクの表示テキストが完全に同一で区別しづらかった点を修正しました。

## 設計

- 各リンクの表示テキスト末尾に品番（51677／51604、リンク先URLの`id`と一致）を追加し、一目で区別できるようにした
- 両用紙とも同一仕様のため冗長だった「（マイクロミシン・厚口）」の記載を削除した

## 影響

- 表示テキストの変更のみ。リンク先URL・機能面の変更はない

## テスト

- 既存テスト（リンクのhref・target・部分一致テキストで検証）が引き続き通ることを確認
- frontend/backendともにlint・test・build（backendはbuild対象外）が0件であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NYtSzvgvGHgxPT9dnXVPxn)_