### PR TITLE
fix(frontend): PDFダウンロード時に文字サイズが崩れる不具合を修正する

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -758,6 +758,60 @@ describe('App', () => {
     expect(jsPdfInstance.save).toHaveBeenCalledWith('Cat1_絵札_表面.pdf');
   });
 
+  it('forces zoom to 1 on each .efuda-page while capturing, and restores it afterward (issue #392: PDF text rendering breaks when the on-screen preview is zoomed out on narrow viewports)', async () => {
+    const phrases = Array.from({ length: 1 }, (_, i) => ({
+      id: `p${i}`,
+      category: 'Cat1',
+      kana: 'あ',
+      phrase: `読み札テキスト${i}`,
+      answer: `回答${i}`,
+      level: '3',
+      averageTime: 0,
+      averageDifficulty: 0,
+    }));
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+    await waitFor(() => screen.getByText('絵札を印刷する'));
+    fireEvent.click(screen.getByText('絵札を印刷する'));
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('.efuda-page').length).toBe(1);
+    });
+
+    // 画面プレビュー用のzoom（狭い画面での縮小表示、issue #387）が既に適用されている状態を模す
+    const pageEl = document.querySelector('.efuda-page');
+    pageEl.style.zoom = '0.5';
+
+    let zoomDuringCapture;
+    html2canvas.mockImplementationOnce(async (el) => {
+      zoomDuringCapture = el.style.zoom;
+      return { toDataURL: () => 'data:image/png;base64,dummy' };
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('PDFをダウンロード'));
+    });
+
+    await waitFor(() => {
+      expect(html2canvas).toHaveBeenCalledTimes(1);
+    });
+
+    expect(zoomDuringCapture).toBe('1');
+    expect(pageEl.style.zoom).toBe('');
+  });
+
   it('packs printed efuda cards across categories onto the same page without breaking per category', async () => {
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }, { name: 'Cat2', group: 'engineer' }] }) };

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -25,24 +25,39 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
       const pageElements = document.querySelectorAll(".efuda-print-area .efuda-page");
       const pdf = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4" });
 
-      for (let i = 0; i < pageElements.length; i++) {
-        // scale: 2で解像度を上げ、印刷用途でも文字が粗くならないようにする。
-        // no-printは@media printでのみ非表示になる（画面上は表示されたまま）ため、
-        // html2canvasが画面表示状態をそのまま撮影しないよう、cloneした文書側で明示的に隠す
-        const canvas = await html2canvas(pageElements[i], {
-          scale: 2,
-          useCORS: true,
-          onclone: (clonedDoc) => {
-            clonedDoc.querySelectorAll(".no-print").forEach((el) => {
-              el.style.display = "none";
-            });
-          },
-        });
-        const imageData = canvas.toDataURL("image/png");
-        if (i > 0) {
-          pdf.addPage();
+      // .efuda-pageは狭い画面での画面プレビュー用にzoomで縮小表示している（issue #387）ことがある。
+      // html2canvasはzoomによる縮小後の外枠サイズは正しく捉える一方、内部のmm単位のフォントサイズは
+      // 縮小前のまま描画してしまい、文字が枠からはみ出して崩れる。そのためキャプチャ中だけ
+      // zoomを1に固定し、「印刷する」（window.print()、@media printでzoom:1）と同じ実寸で
+      // 撮影されるようにする
+      pageElements.forEach((el) => {
+        el.style.zoom = "1";
+      });
+
+      try {
+        for (let i = 0; i < pageElements.length; i++) {
+          // scale: 2で解像度を上げ、印刷用途でも文字が粗くならないようにする。
+          // no-printは@media printでのみ非表示になる（画面上は表示されたまま）ため、
+          // html2canvasが画面表示状態をそのまま撮影しないよう、cloneした文書側で明示的に隠す
+          const canvas = await html2canvas(pageElements[i], {
+            scale: 2,
+            useCORS: true,
+            onclone: (clonedDoc) => {
+              clonedDoc.querySelectorAll(".no-print").forEach((el) => {
+                el.style.display = "none";
+              });
+            },
+          });
+          const imageData = canvas.toDataURL("image/png");
+          if (i > 0) {
+            pdf.addPage();
+          }
+          pdf.addImage(imageData, "PNG", 0, 0, A4_WIDTH_MM, A4_HEIGHT_MM);
         }
-        pdf.addImage(imageData, "PNG", 0, 0, A4_WIDTH_MM, A4_HEIGHT_MM);
+      } finally {
+        pageElements.forEach((el) => {
+          el.style.zoom = "";
+        });
       }
 
       const sideLabel = printSide === "back" ? "裏面" : "表面";


### PR DESCRIPTION
## 概要

「絵札を印刷する」画面のPDFダウンロードで文字サイズが異常に大きく崩れる不具合を修正しました。

Closes #392

## 原因

#387で`.efuda-page`に画面プレビュー用の`zoom: min(1, calc(100vw / 210mm))`を追加した結果、画面幅800px未満ではon-screenのzoomが1未満になる。「PDFをダウンロード」機能はこの画面表示状態のDOMをそのままhtml2canvasでキャプチャするが、html2canvasは`zoom`プロパティを完全にはサポートしておらず、要素の外枠は縮小後のサイズで捉える一方、内部のテキストは縮小前のmm単位のフォントサイズのまま描画してしまい、テキストが枠からはみ出して崩れる。

「印刷する」（`window.print()`、`@media print`で`zoom:1`）は影響を受けない。

## 設計

`downloadPdf()`内でhtml2canvasによるキャプチャ直前に各`.efuda-page`へ`el.style.zoom = "1"`を設定し、キャプチャ後（成功・失敗に関わらず）`finally`で元に戻すことで、画面幅に関わらず常に「印刷する」と同じ実寸でキャプチャされるようにした。

## 影響

- 画面幅800px未満でPDFをダウンロードした際、文字崩れが解消され「印刷する」と同じ内容で出力されるようになる
- 800px以上の画面での出力・印刷（`window.print()`）自体への影響はない

## テスト

- Playwrightで実際のhtml2canvasを使い、幅390px（zoom<1適用時）でzoom固定なし・ありを比較キャプチャし、なしでは文字が崩れること、ありでは幅900px（zoom:1）と同じ正しい見た目になることを画像で確認
- `App.test.jsx`に、html2canvasへ渡される要素の`style.zoom`がキャプチャ中は`"1"`、キャプチャ後は元の状態に戻ることを検証する回帰テストを追加
- frontend/backendともにlint・test・build（backendはbuild対象外）が0件であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NYtSzvgvGHgxPT9dnXVPxn)_