### PR TITLE
fix(cd): dev-standards参照をタグ固定(@v1.0.0)に変更する

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   release:
-    uses: bamiyanapp/dev-standards/.github/workflows/reusable-cd.yml@main
+    uses: bamiyanapp/dev-standards/.github/workflows/reusable-cd.yml@v1.0.0
     with:
       enable_release: true
       enable_changelog_json: true
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 0
       - name: 🚀 Deploy to GitHub Pages
         id: deploy
-        uses: bamiyanapp/dev-standards/.github/actions/deploy-github-pages@main
+        uses: bamiyanapp/dev-standards/.github/actions/deploy-github-pages@v1.0.0
         with:
           working-directory: frontend
           node-version: 24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   ci:
-    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@main
+    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.0.0
     with:
       frontend_dir: frontend
       backend_dir: backend


### PR DESCRIPTION
## Summary
- `ci.yml`/`cd.yml`が参照する`bamiyanapp/dev-standards`の`reusable-ci.yml`・`reusable-cd.yml`・`deploy-github-pages`を`@main`から`@v1.0.0`に変更した。
- dev-standards側の`docs/cicd-pipeline-specification.md`が定める運用（reusable workflow参照はブランチではなくタグに固定し、Renovateの`github-actions`マネージャーで更新PRを受け取る）に合わせるための変更。
- 前提として、dev-standards側でBOT_TOKEN転送漏れの不具合修正（[PR #49](https://github.com/bamiyanapp/dev-standards/pull/49)・[PR #50](https://github.com/bamiyanapp/dev-standards/pull/50)）を行い、初のリリースタグ`v1.0.0`が発行されたことを確認済み。

## Test plan
- [x] frontend: `npm run lint` / `npm test`（vitest 82件）/ `npm run build` すべて成功
- [x] backend: `npm run lint` / `npm test`（vitest 1289件）すべて成功
- [ ] マージ後、実際のCI/CDで`@v1.0.0`参照が正しく解決されることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FawwgCULfjyqRLyLxXgtx4)_