### PR TITLE
chore(release): v1.18.3 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.18.3](https://github.com/bamiyanapp/karuta/compare/v1.18.2...v1.18.3) (2026-07-12)
+
+
+### Bug Fixes
+
+* **cd:** dev-standards参照をタグ固定([@v1](https://github.com/v1).0.0)に変更する ([#395](https://github.com/bamiyanapp/karuta/issues/395)) ([8053116](https://github.com/bamiyanapp/karuta/commit/805311638ad3d796e9d81dc21d5ccb3907a5e1a5))
+
 ## [1.18.2](https://github.com/bamiyanapp/karuta/compare/v1.18.1...v1.18.2) (2026-07-11)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
+    "version": "1.18.3",
+    "date": "2026/07/12",
+    "body": "### Bug Fixes\n\n* **cd:** dev-standards参照をタグ固定([@v1](https://github.com/v1).0.0)に変更する ([#395](https://github.com/bamiyanapp/karuta/issues/395)) ([8053116](https://github.com/bamiyanapp/karuta/commit/805311638ad3d796e9d81dc21d5ccb3907a5e1a5))"
+  },
+  {
     "version": "1.18.2",
-    "date": "2026/07/11",
+    "date": "2026/07/11 23:40",
     "body": "### Bug Fixes\n\n* **frontend:** PDFダウンロード時に文字サイズが崩れる不具合を修正する ([#393](https://github.com/bamiyanapp/karuta/issues/393)) ([c2bf9ef](https://github.com/bamiyanapp/karuta/commit/c2bf9efc59769a237356c600de12a62a5b650ab5)), closes [#392](https://github.com/bamiyanapp/karuta/issues/392)"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.18.2",
+      "version": "1.18.3",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.18.2"
+  "version": "1.18.3"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。