### PR TITLE
fix: 絵札PDFダウンロードにかるた種別を表示し、Renovate PRのstale化を防ぐ

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -758,6 +758,54 @@ describe('App', () => {
     expect(jsPdfInstance.save).toHaveBeenCalledWith('Cat1_絵札_表面.pdf');
   });
 
+  it('keeps the front-side category label visible in the PDF capture while still hiding other no-print elements (かるた種別がPDFに表示されない不具合の修正)', async () => {
+    const phrases = [
+      { id: 'p0', category: 'Cat1', kana: 'あ', phrase: '読み札テキスト0', answer: '回答0' },
+    ];
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+    await waitFor(() => screen.getByText('絵札を印刷する'));
+    fireEvent.click(screen.getByText('絵札を印刷する'));
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('.efuda-page').length).toBe(1);
+    });
+
+    let categoryDisplayDuringCapture;
+    let otherNoPrintDisplayDuringCapture;
+    html2canvas.mockImplementationOnce(async (el, options) => {
+      // 実装のoncloneは実際のクローン文書を受け取るが、テストではモックのためdocument自体を渡して検証する
+      options.onclone(document);
+      categoryDisplayDuringCapture = document.querySelector('.efuda-card-category').style.display;
+      otherNoPrintDisplayDuringCapture = document.querySelector('header.no-print').style.display;
+      return { toDataURL: () => 'data:image/png;base64,dummy' };
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('PDFをダウンロード'));
+    });
+
+    await waitFor(() => {
+      expect(html2canvas).toHaveBeenCalledTimes(1);
+    });
+
+    // かるた種別ラベル（efuda-card-category）は隠さず、それ以外のno-print要素は従来どおり隠す
+    expect(categoryDisplayDuringCapture).toBe('');
+    expect(otherNoPrintDisplayDuringCapture).toBe('none');
+  });
+
   it('forces zoom to 1 on each .efuda-page while capturing, and restores it afterward (issue #392: PDF text rendering breaks when the on-screen preview is zoomed out on narrow viewports)', async () => {
     const phrases = Array.from({ length: 1 }, (_, i) => ({
       id: `p${i}`,

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -38,12 +38,14 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
         for (let i = 0; i < pageElements.length; i++) {
           // scale: 2で解像度を上げ、印刷用途でも文字が粗くならないようにする。
           // no-printは@media printでのみ非表示になる（画面上は表示されたまま）ため、
-          // html2canvasが画面表示状態をそのまま撮影しないよう、cloneした文書側で明示的に隠す
+          // html2canvasが画面表示状態をそのまま撮影しないよう、cloneした文書側で明示的に隠す。
+          // ただしefuda-card-category（表面カードのかるた種別ラベル）は、実物の紙面には印刷しないが
+          // PDFでは種別を確認できるようにしたいという要望のため、隠さず残す
           const canvas = await html2canvas(pageElements[i], {
             scale: 2,
             useCORS: true,
             onclone: (clonedDoc) => {
-              clonedDoc.querySelectorAll(".no-print").forEach((el) => {
+              clonedDoc.querySelectorAll(".no-print:not(.efuda-card-category)").forEach((el) => {
                 el.style.display = "none";
               });
             },

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "rebaseWhen": "behind-base-branch",
   "git-submodules": {
     "enabled": true
   },


### PR DESCRIPTION
## 概要

- 「絵札を印刷する」画面のPDFダウンロード（表面）でかるた種別が表示されない不具合を修正した
- Renovateの依存関係更新PRがmainから乖離してCIが繰り返し失敗する問題の再発防止策として、`renovate.json`に`rebaseWhen`を設定した

## 設計

### PDFダウンロードでかるた種別が表示されない不具合（fix(frontend)）

- 表面カードのカテゴリラベル（`.efuda-card-category`）は実物の紙面には印刷しない（現物のかるた読み札同様、表面には種別を印刷しない）意図で`no-print`クラスが付与されている
- `downloadPdf()`内のhtml2canvasの`onclone`コールバックは、実際の印刷結果と一致させるため`.no-print`要素を一律で隠していたが、これによりPDF出力でも種別ラベルが消えていた
- `onclone`のセレクタを`.no-print:not(.efuda-card-category)`に変更し、かるた種別ラベルのみPDFキャプチャ時に隠さないようにした
- 物理印刷（`window.print()`、`@media print`）側は従来どおり`.no-print`を隠す挙動のまま変更していないため、紙への印刷結果（種別なし）には影響しない

### RenovateのPRが繰り返し失敗する問題（fix(renovate)）

- 調査の結果、以下2種類の原因でRenovate由来のPR（#300, #303, #313, #318, #319, #322, #345, #349など）のCIが繰り返し失敗していた
  1. mainへのマージ頻度が高いリポジトリ特性に対し、Renovateの既定動作（コンフリクト時、またはPR本文のrebase/retryチェックボックスON時のみリベース）ではPRのCIプレビューがすぐ古い依存関係の組み合わせに固定され、無関係な依存関係差分によるlint/test失敗を繰り返し発生させていた
  2. 一部PR（#303のaws-sdk-js-v3、#349のvite）ではRenovateが生成したlockfileの不整合という別の実バグもあり、こちらは各PRのブランチへ直接`npm install`による修正をpush済み（本PRの対象外）
- 本PRでは(1)の恒久対策として`renovate.json`に`"rebaseWhen": "behind-base-branch"`を追加し、mainが更新されるたびにRenovateがブランチを自動的に作り直すようにした

## 影響

- PDF出力（表面）にかるた種別ラベルが表示されるようになる。物理印刷・裏面の出力内容には影響しない
- Renovate PRが今後mainの更新に自動追従するようになる。既存のpackageRules（vite/eslintのグルーピング、serverlessのバージョン固定）には影響しない

## テスト

- [x] frontend: `npm run lint` / `npm test`（83件、新規テスト1件追加）ともに成功
- [x] backend: `npm run lint` / `npm test`（1289件）ともに成功（本変更の対象外）


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_