### PR TITLE
fix(frontend): 絵札PDF表面のかるた種別の文字色を黒にする

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -396,6 +396,8 @@ button:active:not(:disabled) {
   right: 3mm;
   margin: 0;
   font-size: 9px;
+  /* カードは常に白背景の紙面を模すため、text-mutedの薄灰色ではなくPDF出力でも視認できる黒固定にする */
+  color: #000;
 }
 
 /* 裏面（種別・レベル）：表面と同じカード枠内に中央揃えで表示する */

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -136,7 +136,7 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
                           </div>
                         ) : (
                           <>
-                            <p className="no-print text-muted small efuda-card-category">{p.category}</p>
+                            <p className="no-print small efuda-card-category">{p.category}</p>
                             <div className="efuda-card-kana">{p.kana}</div>
                             <div className="efuda-card-text">{getEfudaText(p)}</div>
                           </>


### PR DESCRIPTION
## 概要

絵札PDFダウンロード（表面）に表示されるかるた種別ラベルの文字が、Bootstrapの`text-muted`による薄いグレーで視認しづらかったため黒に変更した。

## 対応

- `efuda-card-category`からBootstrapの`text-muted`クラスを外した
- `App.css`の`.efuda-card-category`に`color: #000`を追加し、他のカード内テキスト（`.efuda-card-text`等）と同様に紙面を模した黒固定にした

## 影響

- PDF出力（表面）のかるた種別ラベルの文字色のみの変更。レイアウト・物理印刷・裏面の出力内容には影響しない

## テスト

- [x] frontend: `npm run lint` / `npm test`（83件）ともに成功
- [x] backend: `npm run lint` / `npm test`（1289件）ともに成功（本変更の対象外）


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_