### PR TITLE
chore(release): v1.18.5 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.18.5](https://github.com/bamiyanapp/karuta/compare/v1.18.4...v1.18.5) (2026-07-12)
+
+
+### Bug Fixes
+
+* **frontend:** 絵札PDF表面のかるた種別の文字色を黒にする ([#402](https://github.com/bamiyanapp/karuta/issues/402)) ([33243e9](https://github.com/bamiyanapp/karuta/commit/33243e9733f8517a54f796abfef61ee7eed21c65))
+
 ## [1.18.4](https://github.com/bamiyanapp/karuta/compare/v1.18.3...v1.18.4) (2026-07-12)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.18.4",
+    "version": "1.18.5",
     "date": "2026/07/12",
+    "body": "### Bug Fixes\n\n* **frontend:** 絵札PDF表面のかるた種別の文字色を黒にする ([#402](https://github.com/bamiyanapp/karuta/issues/402)) ([33243e9](https://github.com/bamiyanapp/karuta/commit/33243e9733f8517a54f796abfef61ee7eed21c65))"
+  },
+  {
+    "version": "1.18.4",
+    "date": "2026/07/12 09:30",
     "body": "### Bug Fixes\n\n* 絵札PDFダウンロードにかるた種別を表示し、Renovate PRのstale化を防ぐ ([#400](https://github.com/bamiyanapp/karuta/issues/400)) ([663eb24](https://github.com/bamiyanapp/karuta/commit/663eb24edd8c1b96494a5a4027b8667c2d965b84)), closes [#300](https://github.com/bamiyanapp/karuta/issues/300) [#303](https://github.com/bamiyanapp/karuta/issues/303) [#313](https://github.com/bamiyanapp/karuta/issues/313) [#318](https://github.com/bamiyanapp/karuta/issues/318) [#319](https://github.com/bamiyanapp/karuta/issues/319) [#322](https://github.com/bamiyanapp/karuta/issues/322) [#345](https://github.com/bamiyanapp/karuta/issues/345)"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.18.4",
+  "version": "1.18.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.18.4",
+      "version": "1.18.5",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.18.4"
+  "version": "1.18.5"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。