### PR TITLE
feat(frontend): 絵札裏面の和柄を5種のランダム柄に差し替え、フォントを一回り小さくする

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -402,7 +402,8 @@ button:active:not(:disabled) {
 
 /* 裏面（種別・レベル）：表面と同じカード枠内に中央揃えで表示する。
    表面はかるた本文で埋まるのに対し裏面は情報量が少なく寂しくなるため、
-   青海波（和柄）の背景と内枠の二重線で装飾している */
+   和柄の背景と内枠の縁取りで装飾している。柄そのものは.efuda-pattern-*で
+   カードごとに切り替える（背景色・共通の枠はここでまとめて指定する） */
 .efuda-card-back {
   display: flex;
   flex-direction: column;
@@ -416,16 +417,11 @@ button:active:not(:disabled) {
   border: 0.6mm solid #e44d26;
   border-radius: 4mm;
   background-color: #fff;
-  background-image:
-    radial-gradient(circle at 50% 100%, transparent 20%, #fbe4da 21%, #fbe4da 27%, transparent 28%, transparent 36%, #fbe4da 37%, #fbe4da 43%, transparent 44%),
-    radial-gradient(circle at 0% 50%, transparent 20%, #fbe4da 21%, #fbe4da 27%, transparent 28%, transparent 36%, #fbe4da 37%, #fbe4da 43%, transparent 44%),
-    radial-gradient(circle at 100% 50%, transparent 20%, #fbe4da 21%, #fbe4da 27%, transparent 28%, transparent 36%, #fbe4da 37%, #fbe4da 43%, transparent 44%);
-  background-size: 12mm 12mm;
 }
 
 .efuda-card-back-category {
   font-weight: bold;
-  font-size: 7mm;
+  font-size: 6mm;
   text-align: center;
   word-break: break-word;
   /* 背景の和柄パターンの上でも文字が読みやすいよう、印章のような白背景の帯を敷く */
@@ -436,22 +432,193 @@ button:active:not(:disabled) {
   max-width: 80mm;
 }
 
+/* 和柄5種（分銅繋ぎ・七宝・亀甲・青海波・立涌）。
+   https://note.com/dakinifox/n/n90d03c62eb25 のCSSレシピを、
+   カード内の文字が読めるようアプリの配色（白地＋薄いオレンジ）に置き換えて採用した。
+   カードごとにgetBackPatternClass()でこの中から1つを決定的に選び適用する */
+:root {
+  --efuda-pattern-base: #fff;
+  --efuda-pattern-accent: #fbe0d2;
+}
+
+.efuda-pattern-fundou {
+  background-image:
+    radial-gradient(100% 100% at 100% 0%, var(--efuda-pattern-base) 50%, transparent 50%),
+    radial-gradient(100% 100% at 0% 100%, var(--efuda-pattern-base) 50%, transparent 50%),
+    radial-gradient(100% 100% at 50% 50%, var(--efuda-pattern-accent) 50%, transparent 50%);
+  background-size: 10mm 10mm;
+}
+
+.efuda-pattern-shippo {
+  background-image:
+    radial-gradient(100% 100% at 50% 50%, transparent 50%, var(--efuda-pattern-base) 50%),
+    radial-gradient(100% 100% at 100% 0%, var(--efuda-pattern-accent) 50%, transparent 50%),
+    radial-gradient(100% 100% at 0% 100%, var(--efuda-pattern-accent) 50%, transparent 50%),
+    radial-gradient(100% 100% at 100% 100%, var(--efuda-pattern-accent) 50%, transparent 50%),
+    radial-gradient(100% 100% at 0% 0%, var(--efuda-pattern-accent) 50%, transparent 50%);
+  background-size: 11mm 11mm;
+}
+
+.efuda-pattern-kikkou {
+  background-image:
+    conic-gradient(from 120deg at 50% calc(100% - 4.5%), var(--efuda-pattern-accent) 0deg 120deg, transparent 120deg 360deg),
+    conic-gradient(from 120deg at 100% calc(100% - 4.5%), var(--efuda-pattern-accent) 0deg 120deg, transparent 120deg 360deg),
+    conic-gradient(from 120deg at 0% calc(100% - 4.5%), var(--efuda-pattern-accent) 0deg 120deg, transparent 120deg 360deg),
+    conic-gradient(from -60deg at 25% calc(16.7% - 5.0%), var(--efuda-pattern-base) 0deg 120deg, transparent 120deg 360deg),
+    conic-gradient(from -60deg at 75% calc(16.7% - 5.0%), var(--efuda-pattern-base) 0deg 120deg, transparent 120deg 360deg),
+    conic-gradient(from -60deg at 25% calc(16.7% + 5.0%), var(--efuda-pattern-accent) 0deg 120deg, transparent 120deg 360deg),
+    conic-gradient(from -60deg at 75% calc(16.7% + 5.0%), var(--efuda-pattern-accent) 0deg 120deg, transparent 120deg 360deg),
+    conic-gradient(from 240deg at calc(25% - 4.5%) calc(50% - 2.0%), var(--efuda-pattern-base) 0deg 120deg, transparent 120deg 360deg),
+    conic-gradient(from 240deg at calc(25% + 4.5%) calc(50% + 2.0%), var(--efuda-pattern-accent) 0deg 120deg, transparent 120deg 360deg),
+    conic-gradient(from 0deg at calc(75% + 4.5%) calc(50% - 2.0%), var(--efuda-pattern-base) 0deg 120deg, transparent 120deg 360deg),
+    conic-gradient(from 0deg at calc(75% - 4.5%) calc(50% + 2.0%), var(--efuda-pattern-accent) 0deg 120deg, transparent 120deg 360deg),
+    conic-gradient(from 240deg at 25% calc(50% - 5.0%), var(--efuda-pattern-base) 0deg 120deg, transparent 120deg 360deg),
+    conic-gradient(from 240deg at 25% calc(50% + 5.0%), var(--efuda-pattern-accent) 0deg 120deg, transparent 120deg 360deg),
+    conic-gradient(from -60deg at 50% calc(66.7% - 5.0%), var(--efuda-pattern-base) 0deg 120deg, transparent 120deg 360deg),
+    conic-gradient(from -60deg at 50% calc(66.7% + 5.0%), var(--efuda-pattern-accent) 0deg 120deg, transparent 120deg 360deg),
+    linear-gradient(
+      90deg,
+      var(--efuda-pattern-accent) calc(0% + 4.5%),
+      transparent calc(0% + 4.5%),
+      transparent calc(50% - 4.5%),
+      var(--efuda-pattern-accent) calc(50% - 4.5%),
+      var(--efuda-pattern-accent) calc(50% + 4.5%),
+      transparent calc(50% + 4.5%),
+      transparent calc(100% - 4.5%),
+      var(--efuda-pattern-accent) calc(100% - 4.5%)
+    );
+  background-size: 16mm 14mm;
+}
+
+.efuda-pattern-seigaiha {
+  background-image:
+    radial-gradient(100% 100% at 100% calc(100% + 25%),
+      var(--efuda-pattern-accent) 0%, var(--efuda-pattern-accent) 5%,
+      var(--efuda-pattern-base) 5%, var(--efuda-pattern-base) 9%,
+      var(--efuda-pattern-accent) 9%, var(--efuda-pattern-accent) 15%,
+      var(--efuda-pattern-base) 15%, var(--efuda-pattern-base) 19%,
+      var(--efuda-pattern-accent) 19%, var(--efuda-pattern-accent) 25%,
+      var(--efuda-pattern-base) 25%, var(--efuda-pattern-base) 29%,
+      var(--efuda-pattern-accent) 29%, var(--efuda-pattern-accent) 35%,
+      var(--efuda-pattern-base) 35%, var(--efuda-pattern-base) 39%,
+      var(--efuda-pattern-accent) 39%, var(--efuda-pattern-accent) 45%,
+      var(--efuda-pattern-base) 45%, var(--efuda-pattern-base) 50%,
+      transparent 50%),
+    radial-gradient(100% 100% at 0% calc(100% + 25%),
+      var(--efuda-pattern-accent) 0%, var(--efuda-pattern-accent) 5%,
+      var(--efuda-pattern-base) 5%, var(--efuda-pattern-base) 9%,
+      var(--efuda-pattern-accent) 9%, var(--efuda-pattern-accent) 15%,
+      var(--efuda-pattern-base) 15%, var(--efuda-pattern-base) 19%,
+      var(--efuda-pattern-accent) 19%, var(--efuda-pattern-accent) 25%,
+      var(--efuda-pattern-base) 25%, var(--efuda-pattern-base) 29%,
+      var(--efuda-pattern-accent) 29%, var(--efuda-pattern-accent) 35%,
+      var(--efuda-pattern-base) 35%, var(--efuda-pattern-base) 39%,
+      var(--efuda-pattern-accent) 39%, var(--efuda-pattern-accent) 45%,
+      var(--efuda-pattern-base) 45%, var(--efuda-pattern-base) 50%,
+      transparent 50%),
+    radial-gradient(100% 100% at 50% 100%,
+      var(--efuda-pattern-accent) 0%, var(--efuda-pattern-accent) 5%,
+      var(--efuda-pattern-base) 5%, var(--efuda-pattern-base) 9%,
+      var(--efuda-pattern-accent) 9%, var(--efuda-pattern-accent) 15%,
+      var(--efuda-pattern-base) 15%, var(--efuda-pattern-base) 19%,
+      var(--efuda-pattern-accent) 19%, var(--efuda-pattern-accent) 25%,
+      var(--efuda-pattern-base) 25%, var(--efuda-pattern-base) 29%,
+      var(--efuda-pattern-accent) 29%, var(--efuda-pattern-accent) 35%,
+      var(--efuda-pattern-base) 35%, var(--efuda-pattern-base) 39%,
+      var(--efuda-pattern-accent) 39%, var(--efuda-pattern-accent) 45%,
+      var(--efuda-pattern-base) 45%, var(--efuda-pattern-base) 50%,
+      transparent 50%),
+    radial-gradient(100% 100% at 0% 75%,
+      var(--efuda-pattern-accent) 0%, var(--efuda-pattern-accent) 5%,
+      var(--efuda-pattern-base) 5%, var(--efuda-pattern-base) 9%,
+      var(--efuda-pattern-accent) 9%, var(--efuda-pattern-accent) 15%,
+      var(--efuda-pattern-base) 15%, var(--efuda-pattern-base) 19%,
+      var(--efuda-pattern-accent) 19%, var(--efuda-pattern-accent) 25%,
+      var(--efuda-pattern-base) 25%, var(--efuda-pattern-base) 29%,
+      var(--efuda-pattern-accent) 29%, var(--efuda-pattern-accent) 35%,
+      var(--efuda-pattern-base) 35%, var(--efuda-pattern-base) 39%,
+      var(--efuda-pattern-accent) 39%, var(--efuda-pattern-accent) 45%,
+      var(--efuda-pattern-base) 45%, var(--efuda-pattern-base) 50%,
+      transparent 50%),
+    radial-gradient(100% 100% at 100% 75%,
+      var(--efuda-pattern-accent) 0%, var(--efuda-pattern-accent) 5%,
+      var(--efuda-pattern-base) 5%, var(--efuda-pattern-base) 9%,
+      var(--efuda-pattern-accent) 9%, var(--efuda-pattern-accent) 15%,
+      var(--efuda-pattern-base) 15%, var(--efuda-pattern-base) 19%,
+      var(--efuda-pattern-accent) 19%, var(--efuda-pattern-accent) 25%,
+      var(--efuda-pattern-base) 25%, var(--efuda-pattern-base) 29%,
+      var(--efuda-pattern-accent) 29%, var(--efuda-pattern-accent) 35%,
+      var(--efuda-pattern-base) 35%, var(--efuda-pattern-base) 39%,
+      var(--efuda-pattern-accent) 39%, var(--efuda-pattern-accent) 45%,
+      var(--efuda-pattern-base) 45%, var(--efuda-pattern-base) 50%,
+      transparent 50%),
+    radial-gradient(100% 100% at 50% 50%,
+      var(--efuda-pattern-accent) 0%, var(--efuda-pattern-accent) 5%,
+      var(--efuda-pattern-base) 5%, var(--efuda-pattern-base) 9%,
+      var(--efuda-pattern-accent) 9%, var(--efuda-pattern-accent) 15%,
+      var(--efuda-pattern-base) 15%, var(--efuda-pattern-base) 19%,
+      var(--efuda-pattern-accent) 19%, var(--efuda-pattern-accent) 25%,
+      var(--efuda-pattern-base) 25%, var(--efuda-pattern-base) 29%,
+      var(--efuda-pattern-accent) 29%, var(--efuda-pattern-accent) 35%,
+      var(--efuda-pattern-base) 35%, var(--efuda-pattern-base) 39%,
+      var(--efuda-pattern-accent) 39%, var(--efuda-pattern-accent) 45%,
+      var(--efuda-pattern-base) 45%, var(--efuda-pattern-base) 50%,
+      transparent 50%),
+    radial-gradient(100% 100% at 100% 25%,
+      var(--efuda-pattern-accent) 0%, var(--efuda-pattern-accent) 5%,
+      var(--efuda-pattern-base) 5%, var(--efuda-pattern-base) 9%,
+      var(--efuda-pattern-accent) 9%, var(--efuda-pattern-accent) 15%,
+      var(--efuda-pattern-base) 15%, var(--efuda-pattern-base) 19%,
+      var(--efuda-pattern-accent) 19%, var(--efuda-pattern-accent) 25%,
+      var(--efuda-pattern-base) 25%, var(--efuda-pattern-base) 29%,
+      var(--efuda-pattern-accent) 29%, var(--efuda-pattern-accent) 35%,
+      var(--efuda-pattern-base) 35%, var(--efuda-pattern-base) 39%,
+      var(--efuda-pattern-accent) 39%, var(--efuda-pattern-accent) 45%,
+      var(--efuda-pattern-base) 45%, var(--efuda-pattern-base) 50%,
+      transparent 50%),
+    radial-gradient(100% 100% at 0% 25%,
+      var(--efuda-pattern-accent) 0%, var(--efuda-pattern-accent) 5%,
+      var(--efuda-pattern-base) 5%, var(--efuda-pattern-base) 9%,
+      var(--efuda-pattern-accent) 9%, var(--efuda-pattern-accent) 15%,
+      var(--efuda-pattern-base) 15%, var(--efuda-pattern-base) 19%,
+      var(--efuda-pattern-accent) 19%, var(--efuda-pattern-accent) 25%,
+      var(--efuda-pattern-base) 25%, var(--efuda-pattern-base) 29%,
+      var(--efuda-pattern-accent) 29%, var(--efuda-pattern-accent) 35%,
+      var(--efuda-pattern-base) 35%, var(--efuda-pattern-base) 39%,
+      var(--efuda-pattern-accent) 39%, var(--efuda-pattern-accent) 45%,
+      var(--efuda-pattern-base) 45%, var(--efuda-pattern-base) 50%,
+      transparent 50%);
+  background-size: 14mm 14mm;
+}
+
+.efuda-pattern-tatewaku {
+  background-image:
+    radial-gradient(100% 100% at 50% 0%, var(--efuda-pattern-base) 35.3%, transparent 35.2%),
+    radial-gradient(100% 100% at 50% 100%, var(--efuda-pattern-base) 35.3%, transparent 35.2%),
+    radial-gradient(100% 100% at 0% 50%, var(--efuda-pattern-accent) 35.3%, transparent 35.2%),
+    radial-gradient(100% 100% at 100% 50%, var(--efuda-pattern-accent) 35.3%, transparent 35.2%),
+    linear-gradient(90deg,
+      var(--efuda-pattern-accent) 25%, var(--efuda-pattern-base) 25%,
+      var(--efuda-pattern-base) 75%, var(--efuda-pattern-accent) 75%);
+  background-size: 8mm 14mm;
+}
+
 /* レベルは1〜100の広い範囲や「上級」「初級」等の文字列も取りうる（星の数では表現できない）ため、
    数値・文字列どちらでもそのまま収まるメダル風の円形バッジで装飾する */
 .efuda-card-back-level {
   position: relative;
-  width: 22mm;
-  height: 22mm;
+  width: 19mm;
+  height: 19mm;
   box-sizing: border-box;
   border-radius: 50%;
-  border: 1.2mm solid #e44d26;
+  border: 1mm solid #e44d26;
   background: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0 1mm;
   font-weight: bold;
-  font-size: 6mm;
+  font-size: 5mm;
   color: #e44d26;
   margin-bottom: 3mm;
 }
@@ -465,7 +632,7 @@ button:active:not(:disabled) {
   width: 0;
   height: 0;
   border-style: solid;
-  border-width: 4mm 2.2mm 0 2.2mm;
+  border-width: 3.5mm 2mm 0 2mm;
 }
 
 .efuda-card-back-level::before {

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -710,6 +710,49 @@ describe('App', () => {
     expect(document.querySelector('.efuda-card-back')).not.toBeInTheDocument();
   });
 
+  it('assigns one of the 5 back-side decorative patterns per card, staying consistent across re-renders (裏面の和柄装飾)', async () => {
+    const phrases = [
+      { id: 'p0', category: 'Cat1', kana: 'あ', phrase: '読み札テキスト0', answer: '-', level: '3' },
+      { id: 'p1', category: 'Cat1', kana: 'い', phrase: '読み札テキスト1', answer: '回答1', level: '-' },
+    ];
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+    await waitFor(() => screen.getByText('絵札を印刷する'));
+    fireEvent.click(screen.getByText('絵札を印刷する'));
+
+    await waitFor(() => screen.getByText('読み札テキスト0'));
+    fireEvent.click(screen.getByRole('button', { name: '裏面' }));
+
+    const patternClassOf = (el) => [...el.classList].find((c) => c.startsWith('efuda-pattern-'));
+    const backCards = document.querySelectorAll('.efuda-card-back');
+    const firstCardPattern = patternClassOf(backCards[0]);
+    const secondCardPattern = patternClassOf(backCards[1]);
+
+    // どちらのカードにも5種類の柄のいずれかが1つ割り当てられている
+    const validPatterns = ['efuda-pattern-fundou', 'efuda-pattern-shippo', 'efuda-pattern-kikkou', 'efuda-pattern-seigaiha', 'efuda-pattern-tatewaku'];
+    expect(validPatterns).toContain(firstCardPattern);
+    expect(validPatterns).toContain(secondCardPattern);
+
+    // 表面⇔裏面の切り替え（再描画）を挟んでも、同じカードには同じ柄が割り当てられ続ける
+    fireEvent.click(screen.getByRole('button', { name: '表面' }));
+    fireEvent.click(screen.getByRole('button', { name: '裏面' }));
+    const backCardsAfterToggle = document.querySelectorAll('.efuda-card-back');
+    expect(patternClassOf(backCardsAfterToggle[0])).toBe(firstCardPattern);
+    expect(patternClassOf(backCardsAfterToggle[1])).toBe(secondCardPattern);
+  });
+
   it('downloads a PDF of the printed efuda pages, hiding no-print elements in the capture (issue #199)', async () => {
     const phrases = Array.from({ length: 11 }, (_, i) => ({
       id: `p${i}`,

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -2,6 +2,21 @@ import { useState } from "react";
 
 const getEfudaText = (p) => (p.answer && p.answer !== "-") ? p.answer : p.phrase;
 
+// 裏面カードに敷く和柄（分銅繋ぎ・七宝・亀甲・青海波・立涌）
+const BACK_PATTERNS = ["fundou", "shippo", "kikkou", "seigaiha", "tatewaku"];
+
+// カードごとにランダムに柄を選ぶが、同一カードを再描画（表面/裏面の切り替え等）しても
+// 柄が変わらないよう、種別+idから決定的に選ぶ
+const getBackPatternClass = (p) => {
+  const key = `${p.category}-${p.id}`;
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = (hash * 31 + key.charCodeAt(i)) | 0;
+  }
+  const index = Math.abs(hash) % BACK_PATTERNS.length;
+  return `efuda-pattern-${BACK_PATTERNS[index]}`;
+};
+
 // A4サイズ（mm）。efuda-pageのCSS上の実寸と一致させる
 const A4_WIDTH_MM = 210;
 const A4_HEIGHT_MM = 297;
@@ -130,7 +145,7 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
                     return (
                       <div className="efuda-card" key={slotIndex}>
                         {p && (printSide === "back" ? (
-                          <div className="efuda-card-back">
+                          <div className={`efuda-card-back ${getBackPatternClass(p)}`}>
                             <div className="efuda-card-back-category">{p.category}</div>
                             {p.level !== "-" && <div className="efuda-card-back-level">{p.level}</div>}
                           </div>


### PR DESCRIPTION
## 概要

裏面の背景装飾（前回追加した青海波の簡易版）が見た目としてイマイチだったため、下記ページで紹介されている伝統的な和柄5種のCSSレシピをアプリの配色に合わせて採用し、カードごとにランダムに割り当てるよう差し替えた。

参考: https://note.com/dakinifox/n/n90d03c62eb25

併せて、和柄を敷いた状態だと文字サイズが大きくバランスが悪かったため、種別ラベルとレベルバッジのフォント・バッジサイズを一回り小さくした。

## 対応

- 分銅繋ぎ・七宝・亀甲・青海波・立涌の5種を`.efuda-pattern-*`として実装（元レシピの配色を、カード内の文字が読めるようアプリの白地＋薄いオレンジに置き換えた）
- `PrintEfudaView.jsx`に`getBackPatternClass()`を追加し、カテゴリ+idから決定的に柄を1つ選んで裏面カードに適用する（同一カードは表面⇔裏面を切り替えても柄が変わらないようにするため、`Math.random()`ではなくハッシュベースで選定）
- `.efuda-card-back-category`のfont-sizeを7mm→6mmに、`.efuda-card-back-level`のバッジ直径を22mm→19mm・フォントを6mm→5mmに縮小した

## 影響

- 裏面の見た目のみの変更。表面・物理印刷・PDF出力の内容（テキスト）自体には影響しない

## テスト

- Playwrightで実際の`App.css`を読み込んだ静的HTMLを描画し、5種の柄すべてと、長いカテゴリ名・3桁の数値・「上級」等の文字列レベルが崩れずに収まることを画像で確認
- 新規テストを追加し、裏面カードに5種のうちいずれかの柄クラスが必ず1つ付与され、表面⇔裏面の切り替えを挟んでも同一カードの柄が変わらないことを確認
- [x] frontend: `npm run lint` / `npm test`（84件、新規テスト1件追加）ともに成功
- [x] backend: `npm run lint` / `npm test`（1289件）ともに成功（本変更の対象外）


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_