### PR TITLE
fix(frontend): 裏面の柄と外枠の間の隙間をなくす

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -405,13 +405,16 @@ button:active:not(:disabled) {
    和柄の背景で装飾している（枠線は.efuda-cardの外枠のみとし、二重にならないようにする）。
    柄そのものは.efuda-pattern-*でカードごとに切り替える */
 .efuda-card-back {
+  /* .efuda-cardのpadding（表面のかな circle/文字を枠から離すためのもの）に食い込んで
+     枠線いっぱいまで柄を敷けるよう、position: absoluteで親のborder-box全体を覆う。
+     角の丸みは親の overflow: hidden によってクリップされる */
+  position: absolute;
+  inset: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 3mm;
-  width: 100%;
-  height: 100%;
   box-sizing: border-box;
   color: #000;
   background-color: #fff;


### PR DESCRIPTION
## 概要

裏面カードの背景（和柄）が`.efuda-card`のpadding分だけ内側に描画され、外枠との間に隙間ができていた不具合を修正した。

## 原因

`.efuda-card`には表面のかな circle・文字を枠から離すための`padding: 4mm`が設定されているが、`.efuda-card-back`もこのpaddingが効いた内側の領域（`width`/`height: 100%`）にしか背景を描画していなかった。

## 対応

`.efuda-card-back`を`position: absolute; inset: 0`にし、親（`.efuda-card`、`position: relative`）のborder-box全体を覆うようにした。角の丸みは親の`overflow: hidden`によって自動的にクリップされる。

## 影響

- 裏面の見た目のみの変更。表面・物理印刷・PDF出力の内容（テキスト）自体には影響しない

## テスト

- Playwrightで実際の`App.css`を読み込んだ静的HTMLを描画し、柄が外枠いっぱいまで広がり隙間がなくなったことを画像で確認
- html2canvasによるキャプチャでも同様に隙間なく描画され、角の丸みも正しくクリップされることを確認
- [x] frontend: `npm run lint` / `npm test`（84件）ともに成功
- [x] backend: `npm run lint` / `npm test`（1289件）ともに成功（本変更の対象外）


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_