### PR TITLE
chore(release): v1.20.4 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.20.4](https://github.com/bamiyanapp/karuta/compare/v1.20.3...v1.20.4) (2026-07-12)
+
+
+### Bug Fixes
+
+* **frontend:** 絵札印刷画面の画面プレビュー（表面）の文字サイズを抑える ([#414](https://github.com/bamiyanapp/karuta/issues/414)) ([7ff6c1e](https://github.com/bamiyanapp/karuta/commit/7ff6c1e6a3fc8f9f4870be9948b636aa80de95e7))
+
 ## [1.20.3](https://github.com/bamiyanapp/karuta/compare/v1.20.2...v1.20.3) (2026-07-12)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.20.3",
+    "version": "1.20.4",
     "date": "2026/07/12",
+    "body": "### Bug Fixes\n\n* **frontend:** 絵札印刷画面の画面プレビュー（表面）の文字サイズを抑える ([#414](https://github.com/bamiyanapp/karuta/issues/414)) ([7ff6c1e](https://github.com/bamiyanapp/karuta/commit/7ff6c1e6a3fc8f9f4870be9948b636aa80de95e7))"
+  },
+  {
+    "version": "1.20.3",
+    "date": "2026/07/12 23:19",
     "body": "### Bug Fixes\n\n* **backend:** 「モダンソフトウェア開発かるた」を「モダン開発かるた」に短縮する ([#412](https://github.com/bamiyanapp/karuta/issues/412)) ([0c50c30](https://github.com/bamiyanapp/karuta/commit/0c50c30e46a93ccdafdf9f31066a8a1cbda220d6))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.20.3",
+  "version": "1.20.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.20.3",
+      "version": "1.20.4",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.20.3"
+  "version": "1.20.4"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。