### PR TITLE
fix(frontend): スマートフォンでの文字自動拡大を無効化する

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -336,6 +336,12 @@ button:active:not(:disabled) {
      広いビューポートでも0.6を上限とする（画面プレビューはA4実寸そのままだと
      文字が大きすぎて見づらいため）。印刷・PDF出力は実寸のまま変わらない */
   zoom: min(1, calc(100vw / 210mm), 0.6);
+  /* スマートフォンのブラウザ（Mobile Safari/Chrome）は、狭い画面で読みやすくする
+     ためzoom等による縮小とは無関係に文字サイズを自動的に拡大する
+     （text size adjust / font boosting）ことがあり、これがzoomによる縮小を
+     打ち消して文字だけ大きいまま残る原因になり得るため、無効化しておく */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 .efuda-grid {


### PR DESCRIPTION
## 概要

絵札印刷画面の`.efuda-page`で、スマートフォンのブラウザが持つ文字サイズの自動拡大（text size adjust / font boosting）により、`zoom`による縮小と文字サイズが噛み合わず、画面自体は縮小されても文字だけ大きいまま残る可能性を防ぐため、`text-size-adjust`を明示的に無効化した。

## 背景

Mobile Safari/Chromeは、狭い画面で読みやすくするためCSSの`zoom`やレイアウト幅とは別に文字サイズを自動的に拡大することがある（text size adjust / font boosting）。`.efuda-page`は狭い画面向けに`zoom`で縮小表示する仕組み（issue #387、#414）になっているが、この自動拡大と干渉すると「画面は縮小されるのに文字サイズだけ変わらない」という見え方になり得る。

## 対応

`.efuda-page`に`-webkit-text-size-adjust: 100%` / `text-size-adjust: 100%`を追加し、ブラウザによる自動拡大を無効化した。印刷時（`@media print`）は実寸表示のため影響はない。

## 影響

- スマートフォンでの画面プレビュー表示のみに関わる変更。印刷・PDF出力の内容・サイズには影響しない

## テスト

- Chromiumのモバイルエミュレーション（iPhone 13）では本対応の前後で見た目上の違いは確認できなかった（Chromium/Playwrightの端末エミュレーションでは実機Safari/Android Chrome相当のfont boostingを再現できないため）。実機での見え方は別途確認をお願いします
- [x] frontend: `npm run lint` / `npm test`（84件）ともに成功
- [x] backend: `npm run lint` / `npm test`（1292件）ともに成功（本変更の対象外）


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_