### PR TITLE
fix(frontend): ゲーム画面の読み札で、かな丸・レベル表示の文字サイズも画面幅に応じて縮小する

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -104,12 +104,16 @@
   box-shadow: 5px 8px 15px rgba(0,0,0,0.25);
 }
 
+/* かな丸・レベル表示は.yomifuda-phraseに倣いclamp()+vwで指定し、
+   .yomifuda-container（狭い画面では画面幅に応じて縮む）に合わせて
+   文字サイズも一緒に縮小されるようにする（画面幅いっぱいに文字だけ
+   大きいまま残らないようにするため） */
 .yomifuda-kana {
   position: absolute;
   top: 15px;
   left: 15px;
-  width: 60px;
-  height: 60px;
+  width: clamp(40px, 16vw, 60px);
+  height: clamp(40px, 16vw, 60px);
   border: 3px solid #e44d26;
   border-radius: 50%;
   display: flex;
@@ -119,7 +123,7 @@
 }
 
 .yomifuda-kana span {
-  font-size: 32px;
+  font-size: clamp(20px, 8vw, 32px);
   font-weight: bold;
   color: #e44d26;
   line-height: 1;
@@ -136,19 +140,19 @@
 }
 
 .yomifuda-phrase-en {
-  font-size: 1.5em;
+  font-size: clamp(14px, 4.5vw, 24px);
   color: #666;
   margin-top: 0.5rem;
 }
 
 /* こども向けは、より大きな文字でかな（読み仮名）を優先して見せる */
 .yomifuda-kids .yomifuda-kana {
-  width: 84px;
-  height: 84px;
+  width: clamp(56px, 22vw, 84px);
+  height: clamp(56px, 22vw, 84px);
 }
 
 .yomifuda-kids .yomifuda-kana span {
-  font-size: 44px;
+  font-size: clamp(28px, 11vw, 44px);
 }
 
 .yomifuda-kids .yomifuda-phrase {
@@ -159,7 +163,7 @@
   position: absolute;
   bottom: 20px;
   right: 20px;
-  font-size: 1.4rem;
+  font-size: clamp(1rem, 4vw, 1.4rem);
   font-weight: bold;
   color: #e44d26;
 }


### PR DESCRIPTION
## 概要

ゲーム画面（および詳細画面）の読み札表示について、`.yomifuda-phrase`は`clamp()`+vwで画面幅に応じて文字サイズが縮小される一方、かな丸（`.yomifuda-kana`）とレベル表示（`.yomifuda-level`）は固定px/remのままで、`.yomifuda-container`自体が狭い画面で縮んでも文字サイズは変わらず、相対的に大きいまま残っていた。

## 対応

`.yomifuda-kana`（円のサイズ）・`.yomifuda-kana span`（文字サイズ）・`.yomifuda-level`を、`.yomifuda-phrase`と同じ`clamp()`+vwの指定に変更し、画面幅に応じて縮小されるようにした（こども向けの`.yomifuda-kids`のかな丸も同様）。あわせて`.yomifuda-phrase-en`も同じ考え方で`clamp()`に変更した。最大値（clampの上限）は変更前の固定値と揃えており、十分広い画面での見た目は変わらない。

## 影響

- ゲーム画面・詳細画面（`.yomifuda`を使う箇所）の読み札表示のみに関わる変更。絵札印刷画面（`.efuda-*`）には影響しない

## テスト

- Playwrightで実際の`App.css`を読み込んだ静的HTMLを320/375/500px幅で描画し、かな丸・レベル表示の文字サイズが画面幅に応じて縮小されることを画像で確認
- [x] frontend: `npm run lint` / `npm test`（84件）ともに成功
- [x] backend: `npm run lint` / `npm test`（1292件）ともに成功（本変更の対象外）


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_