### PR TITLE
fix(frontend): 絵札印刷画面の文字サイズをpx指定にし、画面プレビューの縮小に確実に追従させる

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -387,14 +387,20 @@ button:active:not(:disabled) {
   align-items: center;
   justify-content: center;
   font-weight: bold;
-  font-size: 6mm;
+  /* font-sizeだけはmmではなくpx（mm相当を96dpiで換算した値）で指定する。
+     .efuda-pageのzoomによる画面プレビューの縮小は、mm等の絶対単位で指定した
+     font-sizeには正しく追従しない端末があり、枠は縮小されるのに文字だけ
+     実寸のまま残ってしまう（狭い画面での画面プレビューでのみ発生。
+     印刷・PDF出力はzoom:1の実寸表示のため影響しない） */
+  font-size: 22.68px; /* 6mm */
   color: #e44d26;
   background: white;
 }
 
 .efuda-card-text {
   font-weight: bold;
-  font-size: 8mm;
+  /* font-sizeをpxにする理由は.efuda-card-kanaのコメントを参照 */
+  font-size: 30.24px; /* 8mm */
   text-align: center;
   line-height: 1.3;
   word-break: break-word;
@@ -434,7 +440,8 @@ button:active:not(:disabled) {
 
 .efuda-card-back-category {
   font-weight: bold;
-  font-size: 6mm;
+  /* font-sizeをpxにする理由は.efuda-card-kanaのコメントを参照 */
+  font-size: 22.68px; /* 6mm */
   text-align: center;
   word-break: break-word;
   /* 背景の和柄パターンの上でも文字が読みやすいよう、印章のような白背景の帯を敷く */
@@ -499,7 +506,8 @@ button:active:not(:disabled) {
   justify-content: center;
   padding: 0 1mm;
   font-weight: bold;
-  font-size: 5mm;
+  /* font-sizeをpxにする理由は.efuda-card-kanaのコメントを参照 */
+  font-size: 18.9px; /* 5mm */
   color: #e44d26;
   margin-bottom: 3mm;
 }


### PR DESCRIPTION
## 概要

絵札印刷画面（表面・裏面）について、`.efuda-page`のzoomによる画面プレビューの縮小と、mm単位で指定していた文字サイズ（かなcircle・本文・裏面の種別/レベル）が一部端末で正しく連動せず、枠は縮小されても文字だけ実寸のまま残ってしまう不具合に対応した。

## 原因

`zoom`はCSSピクセルベースの表示を縮小する仕組みだが、mm等の絶対単位で指定した`font-size`については、端末・ブラウザによって`zoom`による縮小が実際のレンダリングに正しく反映されない場合がある（レイアウト上のサイズ・位置は`zoom`に追従する一方、文字の描画だけ実寸のまま残るケースがある）。

## 対応

影響範囲を最小にするため、mm単位のままでも問題ない他のプロパティ（幅・高さ・位置・余白等）はそのままに、`font-size`のみ96dpi換算のpx値に置き換えた。

- `.efuda-card-kana`: `6mm` → `22.68px`
- `.efuda-card-text`: `8mm` → `30.24px`
- `.efuda-card-back-category`: `6mm` → `22.68px`
- `.efuda-card-back-level`: `5mm` → `18.9px`

数値は変更前と完全に同じ実寸になるよう換算しており、印刷・PDF出力（`zoom: 1`）での見た目は変わらない。

## 影響

- 絵札印刷画面（表面・裏面）の画面プレビューにのみ関わる変更。印刷・PDF出力の見た目には影響しない

## テスト

- Playwrightで実際の`App.css`を読み込んだ静的HTMLを1400px・375px幅で描画し、表面・裏面ともに変更前と見た目が変わらないこと（px化による意図しないサイズ変化がないこと）を画像で確認
- [x] frontend: `npm run lint` / `npm test`（84件）ともに成功
- [x] backend: `npm run lint` / `npm test`（1292件）ともに成功（本変更の対象外）


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_