### PR TITLE
fix(frontend): 絵札印刷画面の画面プレビュー縮小をzoomからtransform: scale()方式に変更する

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -326,26 +326,28 @@ button:active:not(:disabled) {
   gap: 24px;
 }
 
+/* .efuda-pageは常にA4実寸（210mm×297mm）のまま保ち、画面プレビューでの縮小は
+   .efuda-page-scaler（幅・高さを縮小率ぶん縮めた実要素）× transform: scaleの
+   組み合わせで行う。zoomプロパティは、ボックスのレイアウトサイズは縮小される一方、
+   実機の一部ブラウザ（Mobile Safari等）ではmm/px問わずfont-sizeの描画に縮小が
+   反映されず文字だけ実寸のまま残る不具合を確認したため採用していない。
+   transformは文字を含めた描画全体を確実に縮小できるが、レイアウト上の占有サイズは
+   変えないため、占有サイズの調整は外側の.efuda-page-scalerで行う */
+.efuda-page-scaler {
+  --efuda-scale: min(1, calc(100vw / 210mm), 0.6);
+  width: calc(210mm * var(--efuda-scale));
+  height: calc(297mm * var(--efuda-scale));
+  overflow: hidden;
+}
+
 .efuda-page {
   position: relative;
   width: 210mm;
   height: 297mm;
   background: white;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.2);
-  /* ビューポート幅がA4実寸（210mm）に満たない場合、画面プレビューでは縮小して
-     全体を表示する。zoomは（transformと異なり）子要素のmm単位レイアウトを
-     保ったままレンダリングサイズごと縮小でき、親のflexコンテナも縮小後の
-     サイズを基準にレイアウトし直すため、中央寄せでも左側が画面外へ
-     はみ出さない。印刷時（@media print）はA4実寸に戻す。
-     広いビューポートでも0.6を上限とする（画面プレビューはA4実寸そのままだと
-     文字が大きすぎて見づらいため）。印刷・PDF出力は実寸のまま変わらない */
-  zoom: min(1, calc(100vw / 210mm), 0.6);
-  /* スマートフォンのブラウザ（Mobile Safari/Chrome）は、狭い画面で読みやすくする
-     ためzoom等による縮小とは無関係に文字サイズを自動的に拡大する
-     （text size adjust / font boosting）ことがあり、これがzoomによる縮小を
-     打ち消して文字だけ大きいまま残る原因になり得るため、無効化しておく */
-  -webkit-text-size-adjust: 100%;
-  text-size-adjust: 100%;
+  transform: scale(var(--efuda-scale));
+  transform-origin: top left;
 }
 
 .efuda-grid {
@@ -556,11 +558,18 @@ button:active:not(:disabled) {
     gap: 0;
   }
 
+  /* 画面プレビュー用の縮小（.efuda-page-scalerのサイズ・.efuda-pageのtransform）を
+     印刷時は無効化し、A4実寸のまま出力する */
+  .efuda-page-scaler {
+    width: 210mm;
+    height: 297mm;
+    overflow: visible;
+  }
+
   .efuda-page {
     box-shadow: none;
     page-break-after: always;
-    /* 画面プレビュー用の縮小（zoom）を印刷時は無効化し、A4実寸のまま出力する */
-    zoom: 1;
+    transform: none;
   }
 
   .efuda-page:last-child {

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -849,7 +849,7 @@ describe('App', () => {
     expect(otherNoPrintDisplayDuringCapture).toBe('none');
   });
 
-  it('forces zoom to 1 on each .efuda-page while capturing, and restores it afterward (issue #392: PDF text rendering breaks when the on-screen preview is zoomed out on narrow viewports)', async () => {
+  it('disables the transform scale on each .efuda-page while capturing, and restores it afterward (issue #392/#421: PDF text rendering breaks when the on-screen preview is scaled down on narrow viewports)', async () => {
     const phrases = Array.from({ length: 1 }, (_, i) => ({
       id: `p${i}`,
       category: 'Cat1',
@@ -881,13 +881,14 @@ describe('App', () => {
       expect(document.querySelectorAll('.efuda-page').length).toBe(1);
     });
 
-    // 画面プレビュー用のzoom（狭い画面での縮小表示、issue #387）が既に適用されている状態を模す
+    // 画面プレビュー用のtransform: scale()（狭い画面での縮小表示、issue #387/#421）が
+    // 既に適用されている状態を模す
     const pageEl = document.querySelector('.efuda-page');
-    pageEl.style.zoom = '0.5';
+    pageEl.style.transform = 'scale(0.5)';
 
-    let zoomDuringCapture;
+    let transformDuringCapture;
     html2canvas.mockImplementationOnce(async (el) => {
-      zoomDuringCapture = el.style.zoom;
+      transformDuringCapture = el.style.transform;
       return { toDataURL: () => 'data:image/png;base64,dummy' };
     });
 
@@ -899,8 +900,8 @@ describe('App', () => {
       expect(html2canvas).toHaveBeenCalledTimes(1);
     });
 
-    expect(zoomDuringCapture).toBe('1');
-    expect(pageEl.style.zoom).toBe('');
+    expect(transformDuringCapture).toBe('none');
+    expect(pageEl.style.transform).toBe('');
   });
 
   it('packs printed efuda cards across categories onto the same page without breaking per category', async () => {

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -40,13 +40,12 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
       const pageElements = document.querySelectorAll(".efuda-print-area .efuda-page");
       const pdf = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4" });
 
-      // .efuda-pageは狭い画面での画面プレビュー用にzoomで縮小表示している（issue #387）ことがある。
-      // html2canvasはzoomによる縮小後の外枠サイズは正しく捉える一方、内部のmm単位のフォントサイズは
-      // 縮小前のまま描画してしまい、文字が枠からはみ出して崩れる。そのためキャプチャ中だけ
-      // zoomを1に固定し、「印刷する」（window.print()、@media printでzoom:1）と同じ実寸で
+      // .efuda-pageは狭い画面での画面プレビュー用にtransform: scale()で縮小表示している
+      // （issue #387、#421）ことがある。キャプチャ中だけtransformを無効化し、
+      // 「印刷する」（window.print()、@media printでtransform: none）と同じ実寸で
       // 撮影されるようにする
       pageElements.forEach((el) => {
-        el.style.zoom = "1";
+        el.style.transform = "none";
       });
 
       try {
@@ -73,7 +72,7 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
         }
       } finally {
         pageElements.forEach((el) => {
-          el.style.zoom = "";
+          el.style.transform = "";
         });
       }
 
@@ -138,27 +137,29 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
 
           <div className="efuda-print-area">
             {efudaPages.map((page, pageIndex) => (
-              <div className="efuda-page" key={pageIndex}>
-                <div className="efuda-grid">
-                  {Array.from({ length: efudaPerPage }).map((_, slotIndex) => {
-                    const p = page.items[slotIndex];
-                    return (
-                      <div className="efuda-card" key={slotIndex}>
-                        {p && (printSide === "back" ? (
-                          <div className={`efuda-card-back ${getBackPatternClass(p)}`}>
-                            <div className="efuda-card-back-category">{p.category}</div>
-                            {p.level !== "-" && <div className="efuda-card-back-level">{p.level}</div>}
-                          </div>
-                        ) : (
-                          <>
-                            <p className="no-print small efuda-card-category">{p.category}</p>
-                            <div className="efuda-card-kana">{p.kana}</div>
-                            <div className="efuda-card-text">{getEfudaText(p)}</div>
-                          </>
-                        ))}
-                      </div>
-                    );
-                  })}
+              <div className="efuda-page-scaler" key={pageIndex}>
+                <div className="efuda-page">
+                  <div className="efuda-grid">
+                    {Array.from({ length: efudaPerPage }).map((_, slotIndex) => {
+                      const p = page.items[slotIndex];
+                      return (
+                        <div className="efuda-card" key={slotIndex}>
+                          {p && (printSide === "back" ? (
+                            <div className={`efuda-card-back ${getBackPatternClass(p)}`}>
+                              <div className="efuda-card-back-category">{p.category}</div>
+                              {p.level !== "-" && <div className="efuda-card-back-level">{p.level}</div>}
+                            </div>
+                          ) : (
+                            <>
+                              <p className="no-print small efuda-card-category">{p.category}</p>
+                              <div className="efuda-card-kana">{p.kana}</div>
+                              <div className="efuda-card-text">{getEfudaText(p)}</div>
+                            </>
+                          ))}
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
               </div>
             ))}


### PR DESCRIPTION
## 概要

実機（Mobile Safari）で確認したところ、絵札印刷画面の画面プレビューは`zoom`によりカード枠は正しく縮小される一方、文字サイズだけ実寸のまま残ってしまい、長い文字列（例: `NullPointerException`）がカード外へはみ出す状態になっていた。`zoom`をやめ、あらゆるブラウザで文字を含めて確実に縮小できる`transform: scale()`方式に変更した。

## 原因

`zoom`はボックスのレイアウトサイズを縮小する一方、mm・px問わず`font-size`の実際の描画への反映は端末・ブラウザ依存であり、一部の実機では文字サイズが縮小されずに残ることを確認した（#414, #416, #421で試みたzoom維持のままの対策では解消しなかった）。

## 対応

- `.efuda-page`は常にA4実寸（210mm×297mm）のまま保持し、`transform: scale()`で見た目だけ縮小する（transformは文字を含めた描画全体を確実に縮小する）
- transformはレイアウト上の占有サイズを変えないため、新設した`.efuda-page-scaler`（幅・高さを縮小率ぶん縮めた実要素）で`.efuda-page`をラップし、親のflexコンテナが正しい縮小後サイズを基準にレイアウトできるようにした
- 縮小率の計算式（画面幅に応じた計算、上限0.6）自体は変更なし
- 印刷時（`@media print`）・PDFダウンロード時（JS）は、`.efuda-page-scaler`を実寸に、`.efuda-page`のtransformを`none`に戻す処理に変更した（従来はzoom:1に戻していた）

## 影響

- 絵札印刷画面の画面プレビューにのみ関わる変更。印刷・PDF出力の見た目には影響しない

## テスト

- Playwrightで実際の`App.css`を読み込んだ静的HTMLを1400px・375px幅で描画し、画面プレビューでの縮小・`@media print`での実寸表示ともに従来と同じ見た目になることを画像で確認
- html2canvasによるキャプチャでも、transformをリセットした状態で実寸どおり描画されることを確認
- 既存テスト（issue #392）をtransformベースの検証に更新
- [x] frontend: `npm run lint` / `npm test`（84件）ともに成功
- [x] backend: `npm run lint` / `npm test`（1292件）ともに成功（本変更の対象外）


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_