### PR TITLE
chore(release): v1.20.8 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.20.8](https://github.com/bamiyanapp/karuta/compare/v1.20.7...v1.20.8) (2026-07-13)
+
+
+### Bug Fixes
+
+* **frontend:** 絵札印刷画面の画面プレビュー縮小をzoomからtransform: scale()方式に変更する ([#423](https://github.com/bamiyanapp/karuta/issues/423)) ([e65a373](https://github.com/bamiyanapp/karuta/commit/e65a37348f9c69bc3ff86e7b3409d837568dc4ec)), closes [#414](https://github.com/bamiyanapp/karuta/issues/414) [#416](https://github.com/bamiyanapp/karuta/issues/416)
+
 ## [1.20.7](https://github.com/bamiyanapp/karuta/compare/v1.20.6...v1.20.7) (2026-07-13)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.20.7",
+    "version": "1.20.8",
     "date": "2026/07/13",
+    "body": "### Bug Fixes\n\n* **frontend:** 絵札印刷画面の画面プレビュー縮小をzoomからtransform: scale()方式に変更する ([#423](https://github.com/bamiyanapp/karuta/issues/423)) ([e65a373](https://github.com/bamiyanapp/karuta/commit/e65a37348f9c69bc3ff86e7b3409d837568dc4ec)), closes [#414](https://github.com/bamiyanapp/karuta/issues/414) [#416](https://github.com/bamiyanapp/karuta/issues/416)"
+  },
+  {
+    "version": "1.20.7",
+    "date": "2026/07/13 10:06",
     "body": "### Bug Fixes\n\n* **frontend:** 絵札印刷画面の文字サイズをpx指定にし、画面プレビューの縮小に確実に追従させる ([#421](https://github.com/bamiyanapp/karuta/issues/421)) ([8ac7b69](https://github.com/bamiyanapp/karuta/commit/8ac7b69619c4f47b1f74fce7ebb0aff84e74e90c))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.20.7",
+  "version": "1.20.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.20.7",
+      "version": "1.20.8",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.20.7"
+  "version": "1.20.8"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。