### PR TITLE
fix(frontend): 絵札裏面のレベル数値をメダルの円中央寄りに大きく表示する

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -507,12 +507,12 @@ button:active:not(:disabled) {
 
 .efuda-card-back-level-number {
   position: absolute;
-  top: 64%;
+  top: 70%;
   left: 50%;
   transform: translate(-50%, -50%);
   font-weight: bold;
   /* font-sizeをpxにする理由は.efuda-card-kanaのコメントを参照 */
-  font-size: 17px;
+  font-size: 21px;
   line-height: 1.1;
   text-align: center;
   color: #fff;


### PR DESCRIPTION
## 概要

🏅絵文字にオーバーラップ表示するレベルの数値・文字列について、位置をメダルの円（星の描かれた面）の中央に合わせて少し下へ動かし、フォントも一回り大きくした。

## 対応

- `.efuda-card-back-level-number`の`top`を`64%`→`70%`にし、絵文字の円部分の中央に来るよう下へ移動した
- `font-size`を`17px`→`21px`に拡大した

## 影響

- 絵札裏面のレベル数値表示の位置・サイズのみの変更。他の内容には影響しない

## テスト

- Playwrightで実際の`App.css`を読み込んだ静的HTMLを描画し、数値・文字列レベルいずれも円の中央に収まり読みやすくなったことを画像で確認
- html2canvasによるキャプチャでも同じ見た目で描画されることを確認
- [x] frontend: `npm run lint` / `npm test`（84件）ともに成功
- [x] backend: `npm run lint` / `npm test`（1292件）ともに成功（本変更の対象外）


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_