### PR TITLE
fix(frontend): 絵札裏面のレベル数値をさらに下へ・フォントを大きくする

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -507,12 +507,12 @@ button:active:not(:disabled) {
 
 .efuda-card-back-level-number {
   position: absolute;
-  top: 70%;
+  top: 75%;
   left: 50%;
   transform: translate(-50%, -50%);
   font-weight: bold;
   /* font-sizeをpxにする理由は.efuda-card-kanaのコメントを参照 */
-  font-size: 21px;
+  font-size: 23px;
   line-height: 1.1;
   text-align: center;
   color: #fff;


### PR DESCRIPTION
## 概要

🏅絵文字にオーバーラップ表示するレベルの数値・文字列について、もう少し下へ動かし、フォントをさらに大きくした。

## 対応

- `.efuda-card-back-level-number`の`top`を`70%`→`75%`にした
- `font-size`を`21px`→`23px`に拡大した

## 影響

- 絵札裏面のレベル数値表示の位置・サイズのみの変更。他の内容には影響しない

## テスト

- Playwrightで実際の`App.css`を読み込んだ静的HTMLを描画し、数値・文字列レベルいずれも円の中央付近に収まり読みやすいことを画像で確認
- [x] frontend: `npm run lint` / `npm test`（84件）ともに成功
- [x] backend: `npm run lint` / `npm test`（1292件）ともに成功（本変更の対象外）


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_