### PR TITLE
fix(frontend): 絵札表面の読み札テキストが単語の途中で改行されるのを防ぐ

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -405,7 +405,15 @@ button:active:not(:disabled) {
   font-size: 30.24px; /* 8mm */
   text-align: center;
   line-height: 1.3;
-  word-break: break-word;
+  /* word-break: break-wordは日本語の文字間どこでも改行しうるため、
+     「とけてきた」のような一続きの単語の途中で折り返され読みにくくなっていた。
+     keep-allで単語（スペース区切りの塊）の途中では改行しないようにしつつ、
+     overflow-wrap: anywhereを保険にして、スペースのない1語（英単語等）が
+     枠に収まらない場合のみ強制的に折り返すようにする（overflow-wrap:
+     break-wordはkeep-allと組み合わせると強制折り返しが効かず、枠から
+     はみ出すことを確認したため、より確実なanywhereを使う） */
+  word-break: keep-all;
+  overflow-wrap: anywhere;
   /* カードは常に白背景の紙面を模すため、ダークモードのbody文字色（薄灰色）を継承させず黒固定にする */
   color: #000;
 }


### PR DESCRIPTION
## 概要

絵札表面のテキスト（`.efuda-card-text`）が「とけてきた」のような一続きの単語の途中（「とけてき」/「た」）で改行され読みにくくなっていたため、単語の途中では改行しないようにした。

## 原因

`word-break: break-word`は、日本語（CJK）の文字間であればどこでも改行を許可する仕様になっており、スペースで区切られた「単語」のまとまりを考慮せず改行位置を決めていた。

## 対応

`word-break: keep-all`に変更し、スペース等の区切りがない文字の連なりの途中では改行しないようにした。ただし、スペースを含まない1語（英単語等）が枠に収まらない場合に折り返せなくなるとカード外にはみ出すため、`overflow-wrap: anywhere`を保険として追加した（`overflow-wrap: break-word`は`word-break: keep-all`と組み合わせると強制折り返しが効かないことを確認したため、より確実な`anywhere`を採用した）。

## 影響

- 絵札表面のテキストの改行位置のみの変更。表示内容自体には影響しない

## テスト

- Playwrightで実際の`App.css`を読み込んだ静的HTMLを描画し、
  - 「アイスが とけてきた」等のスペース区切りの日本語フレーズが、単語の途中ではなくスペースの位置で改行されることを確認
  - スペースを含まない長い英単語（`ArrayIndexOutOfBoundsException`等）が、枠からはみ出さず強制的に折り返されることを確認
- [x] frontend: `npm run lint` / `npm test`（84件）ともに成功
- [x] backend: `npm run lint` / `npm test`（1292件）ともに成功（本変更の対象外）


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_