### PR TITLE
chore(release): v1.22.3 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.22.3](https://github.com/bamiyanapp/karuta/compare/v1.22.2...v1.22.3) (2026-07-13)
+
+
+### Bug Fixes
+
+* **frontend:** 絵札表面の読み札テキストが単語の途中で改行されるのを防ぐ ([#435](https://github.com/bamiyanapp/karuta/issues/435)) ([59894cd](https://github.com/bamiyanapp/karuta/commit/59894cdd143a0575d6ca94682aa7d1c5ae36bd8d))
+
 ## [1.22.2](https://github.com/bamiyanapp/karuta/compare/v1.22.1...v1.22.2) (2026-07-13)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.22.2",
+    "version": "1.22.3",
     "date": "2026/07/13",
+    "body": "### Bug Fixes\n\n* **frontend:** 絵札表面の読み札テキストが単語の途中で改行されるのを防ぐ ([#435](https://github.com/bamiyanapp/karuta/issues/435)) ([59894cd](https://github.com/bamiyanapp/karuta/commit/59894cdd143a0575d6ca94682aa7d1c5ae36bd8d))"
+  },
+  {
+    "version": "1.22.2",
+    "date": "2026/07/13 12:47",
     "body": "### Bug Fixes\n\n* **frontend:** 絵札裏面のレベル数値をさらに下へ・フォントを大きくする ([#433](https://github.com/bamiyanapp/karuta/issues/433)) ([c3f0764](https://github.com/bamiyanapp/karuta/commit/c3f07646486cd081a6dae2444559c9128075f904))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.22.2",
+      "version": "1.22.3",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.22.2"
+  "version": "1.22.3"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。