### PR TITLE
fix: スマートフォンでは絵札の印刷ボタンを非表示にする

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -326,6 +326,16 @@ button:active:not(:disabled) {
   gap: 24px;
 }
 
+/* スマートフォン（タッチ操作かつ画面幅が狭い端末）はOS標準の印刷ダイアログで
+   余白をなしに設定できないことが多く、A4実寸で作った絵札のレイアウトが崩れる。
+   この端末では「印刷する」ボタン（window.print()）を出さず、余白を持たない
+   PDFファイルとして生成できる「PDFをダウンロード」の利用に誘導する */
+@media (max-width: 600px) and (pointer: coarse) {
+  .efuda-print-button {
+    display: none;
+  }
+}
+
 /* .efuda-pageは常にA4実寸（210mm×297mm）のまま保ち、画面プレビューでの縮小は
    .efuda-page-scaler（幅・高さを縮小率ぶん縮めた実要素）× transform: scaleの
    組み合わせで行う。zoomプロパティは、ボックスのレイアウトサイズは縮小される一方、

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -151,7 +151,7 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
               </button>
             </div>
             <div className="d-flex gap-3 justify-content-center flex-wrap">
-              <button onClick={() => window.print()} className="btn btn-lg px-5 py-2 fw-bold rounded-pill shadow btn-karuta">
+              <button onClick={() => window.print()} className="btn btn-lg px-5 py-2 fw-bold rounded-pill shadow btn-karuta efuda-print-button">
                 印刷する
               </button>
               <button onClick={downloadPdf} disabled={isGeneratingPdf} className="btn btn-lg px-5 py-2 fw-bold rounded-pill shadow btn-outline-dark">


### PR DESCRIPTION
## Summary
- iPhoneでは印刷ダイアログで余白をなしに設定できず、A4実寸で作った絵札レイアウトに余白が入ってしまい、そもそも印刷ボタン（`window.print()`）経由での印刷が実用にならないため、タッチ操作かつ画面幅が狭い端末（`@media (max-width: 600px) and (pointer: coarse)`）でのみ「印刷する」ボタンを非表示にした
- 余白を持たない「PDFをダウンロード」ボタンは引き続き全端末で表示し、そちらの利用に誘導する
- マウス操作の狭いデスクトップウィンドウ（ポインタがcoarseでない環境）では非表示にならないよう`pointer: coarse`条件を併用し、意図せずPC利用者から印刷ボタンを奪わないようにした

## 改ページのずれについて
iPhoneで報告された改ページ位置のずれは、iOS SafariがCSSの`@page { margin: 0 }`を無視して独自の余白を強制するという既知の制限が原因と推測される。PC（Chromiumの`page.pdf()`によるprint-to-PDF）では`@page`の`margin: 0`が正しく適用され、ページ数・内容ともにずれないことをPlaywrightで確認した。CSS側では制御できない端末固有の制限と判断し、印刷ボタン自体を非表示にすることで実質的に解消する方針とした。

## Test plan
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 全86件成功
- [x] `backend`: `npm run lint` エラー0件
- [x] `backend`: `npm test -- --run` 全1292件成功
- [x] Playwright（Desktop 1280px / iPhone 13エミュレーション / マウス操作の狭いデスクトップウィンドウ500pxの3条件）で、iPhoneのみ印刷ボタンが非表示になることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_