### PR TITLE
chore(release): v1.22.7 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.22.7](https://github.com/bamiyanapp/karuta/compare/v1.22.6...v1.22.7) (2026-07-13)
+
+
+### Bug Fixes
+
+* **frontend:** スマートフォンでは絵札の印刷ボタンを表示しないようにする ([#449](https://github.com/bamiyanapp/karuta/issues/449)) ([2c3dbc3](https://github.com/bamiyanapp/karuta/commit/2c3dbc36dc1a49a4bed88102afda348dec84b54f))
+
 ## [1.22.6](https://github.com/bamiyanapp/karuta/compare/v1.22.5...v1.22.6) (2026-07-13)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.22.6",
+    "version": "1.22.7",
     "date": "2026/07/13",
+    "body": "### Bug Fixes\n\n* **frontend:** スマートフォンでは絵札の印刷ボタンを表示しないようにする ([#449](https://github.com/bamiyanapp/karuta/issues/449)) ([2c3dbc3](https://github.com/bamiyanapp/karuta/commit/2c3dbc36dc1a49a4bed88102afda348dec84b54f))"
+  },
+  {
+    "version": "1.22.6",
+    "date": "2026/07/13 21:02",
     "body": "### Bug Fixes\n\n* **frontend:** 印刷ボタンで1ページ目しか印刷されない不具合と、PDF出力エラーの再発を修正する ([#447](https://github.com/bamiyanapp/karuta/issues/447)) ([6adc852](https://github.com/bamiyanapp/karuta/commit/6adc852978c7baee3a4c4ec830a1273c0e94820f)), closes [#442](https://github.com/bamiyanapp/karuta/issues/442) [#443](https://github.com/bamiyanapp/karuta/issues/443) [#442](https://github.com/bamiyanapp/karuta/issues/442) [#443](https://github.com/bamiyanapp/karuta/issues/443)"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.22.6",
+  "version": "1.22.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.22.6",
+      "version": "1.22.7",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.22.6"
+  "version": "1.22.7"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。