### PR TITLE
fix: 両面印刷時に裏面が表面と左右反転した位置になるようにする

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -698,16 +698,52 @@ describe('App', () => {
     // 裏面では表面の内容（読み札・回答）が消え、種別とレベルが中央に表示される
     expect(screen.queryByText('読み札テキスト0')).not.toBeInTheDocument();
     expect(screen.queryByText('回答1')).not.toBeInTheDocument();
+    // 両面印刷（用紙を裏返してセットする運用）に合わせ、裏面は行内で左右が入れ替わって
+    // 描画される（表面で1枚目=左, 2枚目=右 だったものが、裏面では1枚目=右, 2枚目=左になる）
     const backCards = document.querySelectorAll('.efuda-card-back');
     expect(backCards).toHaveLength(2);
     expect(backCards[0].querySelector('.efuda-card-back-category')).toHaveTextContent('Cat1');
-    expect(backCards[0].querySelector('.efuda-card-back-level')).toHaveTextContent('3');
-    // レベル未設定（"-"）のカードには数字を表示しない
-    expect(backCards[1].querySelector('.efuda-card-back-level')).not.toBeInTheDocument();
+    // レベル未設定（"-"）のカードには数字を表示しない（左右入れ替わり、1枚目の位置に2枚目のデータが来る）
+    expect(backCards[0].querySelector('.efuda-card-back-level')).not.toBeInTheDocument();
+    expect(backCards[1].querySelector('.efuda-card-back-level')).toHaveTextContent('3');
 
     fireEvent.click(screen.getByRole('button', { name: '表面' }));
     expect(screen.getByText('読み札テキスト0')).toBeInTheDocument();
     expect(document.querySelector('.efuda-card-back')).not.toBeInTheDocument();
+  });
+
+  it('mirrors each row left-right on the back side so it lines up after flipping the sheet for double-sided printing (両面印刷時の裏面位置ずれ)', async () => {
+    const phrases = Array.from({ length: 10 }, (_, i) => ({
+      id: `p${i}`, category: 'Cat1', kana: 'あ', phrase: `読み札${i}`, answer: '-', level: String(i),
+    }));
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+    await waitFor(() => screen.getByText('絵札を印刷する'));
+    fireEvent.click(screen.getByText('絵札を印刷する'));
+
+    // 表面はグリッドの並び順どおり（2列×5行）: 読み札0, 読み札1, 読み札2, ...
+    await waitFor(() => screen.getByText('読み札0'));
+    const frontTexts = [...document.querySelectorAll('.efuda-card-text')].map((el) => el.textContent);
+    expect(frontTexts).toEqual(['読み札0', '読み札1', '読み札2', '読み札3', '読み札4', '読み札5', '読み札6', '読み札7', '読み札8', '読み札9']);
+
+    fireEvent.click(screen.getByRole('button', { name: '裏面' }));
+
+    // 用紙を裏返してセットする運用に合わせ、裏面は行ごとに左右が入れ替わって描画される。
+    // 表面で1枚目(左)・2枚目(右)だった行は、裏面では2枚目(左)・1枚目(右)になる
+    const backLevels = [...document.querySelectorAll('.efuda-card-back-level-number')].map((el) => el.textContent);
+    expect(backLevels).toEqual(['1', '0', '3', '2', '5', '4', '7', '6', '9', '8']);
   });
 
   it('assigns one of the 5 back-side decorative patterns per category, consistently across cards of the same category and re-renders (裏面の和柄装飾)', async () => {
@@ -781,10 +817,14 @@ describe('App', () => {
     const frontColorClass = colorClassOf(frontCard);
     expect(frontColorClass).toMatch(/^efuda-color-(fundou|shippo|kikkou|seigaiha|tatewaku)$/);
 
-    // 裏面：同じ.efuda-card要素の柄名（efuda-pattern-*）が、表面のefuda-color-*と同じ名前を指す
+    // 裏面：同じ.efuda-card要素の柄名（efuda-pattern-*）が、表面のefuda-color-*と同じ名前を指す。
+    // 裏面は両面印刷の運用（用紙を裏返してセット）に合わせて行内で左右が入れ替わって描画される
+    // ため、1枚しかない場合は表面で1枚目（左）だった内容が裏面では2枚目（右）の位置に来る。
+    // そのため.efuda-card-back（実際に内容が入っている方）から辿って対応する外枠要素を取得する
     fireEvent.click(screen.getByRole('button', { name: '裏面' }));
-    const backCard = document.querySelector('.efuda-card');
-    const patternName = [...backCard.querySelector('.efuda-card-back').classList]
+    const backCardBack = document.querySelector('.efuda-card-back');
+    const backCard = backCardBack.parentElement;
+    const patternName = [...backCardBack.classList]
       .find((c) => c.startsWith('efuda-pattern-'))
       .replace('efuda-pattern-', '');
     expect(colorClassOf(backCard)).toBe(`efuda-color-${patternName}`);

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -39,6 +39,23 @@ const buildBackPatternMap = (categories) => {
 const A4_WIDTH_MM = 210;
 const A4_HEIGHT_MM = 297;
 
+// .efuda-gridの列数（App.cssのgrid-template-columns: 91mm 91mmと一致させる）
+const EFUDA_GRID_COLUMNS = 2;
+
+// 両面印刷は「表面を印刷した用紙をそのまま裏返してセットし、裏面を印刷する」運用
+// （縦の中心線を軸に用紙を裏返す）を想定している。そのため、用紙上の同じ物理的な
+// マス目に表面・裏面が重なるようにするには、裏面では各行内の列の並びを左右反転
+// させる必要がある（表面で左列にあった札は、用紙を裏返すと右列の位置に来るため）。
+// slotIndexは常に「用紙上の物理的なマス目」を表し、printSideが"back"のときだけ、
+// そのマス目に対応する表面側の元のインデックス（=読み札データの取り出し位置）を
+// 行内で左右反転させて求める
+const resolvePhraseIndex = (slotIndex, printSide) => {
+  if (printSide !== "back") return slotIndex;
+  const row = Math.floor(slotIndex / EFUDA_GRID_COLUMNS);
+  const col = slotIndex % EFUDA_GRID_COLUMNS;
+  return row * EFUDA_GRID_COLUMNS + (EFUDA_GRID_COLUMNS - 1 - col);
+};
+
 function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrasesForCategory, efudaPages, efudaPerPage }) {
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
   // 表面（読み札の内容）と裏面（種別・レベル）は用紙を裏返して2回に分けて印刷する運用を想定し、
@@ -169,7 +186,7 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
                 <div className="efuda-page">
                   <div className="efuda-grid">
                     {Array.from({ length: efudaPerPage }).map((_, slotIndex) => {
-                      const p = page.items[slotIndex];
+                      const p = page.items[resolvePhraseIndex(slotIndex, printSide)];
                       const patternName = p && backPatternMap.get(p.category);
                       return (
                         <div className={`efuda-card ${patternName ? `efuda-color-${patternName}` : ""}`} key={slotIndex}>


### PR DESCRIPTION
## Summary
- 両面印刷は「表面を印刷した用紙をそのまま裏返してセットし、裏面を印刷する」運用（縦の中心線を軸に用紙を裏返す）を想定しているが、これまでは裏面も表面と同じ並び順（DOM順）で描画していたため、実際に裏返して印刷すると表面と裏面の内容がずれていた
- 用紙上の同じ物理的なマス目に表面・裏面を重ねるには、裏面では各行内の列の並びを左右反転させる必要がある（表面で左列にあった札は、用紙を裏返すと右列の位置に来るため）
- `printSide`が`"back"`のときだけ、グリッドの各マス目（物理的な位置）に対応する読み札データを行内で左右反転したインデックスから取得する`resolvePhraseIndex()`を追加した

## Test plan
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 全88件成功（表裏で左右反転して対応することを検証する新規テストを含む。既存2件のテストも新しい並び順に合わせて更新）
- [x] `backend`: `npm run lint` エラー0件
- [x] `backend`: `npm test -- --run` 全1292件成功
- [x] Playwright（DOM順のテキスト取得）で、表面の1枚目（左上）の内容が裏面では2枚目の位置（右上）に表示され、用紙を裏返した状態で正しく重なることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_