### PR TITLE
feat: 絵札PDF生成をバックエンド（ヘッドレスChromium）に移行する

### DIFF
--- a/backend/efudaPdfHandler.js
+++ b/backend/efudaPdfHandler.js
@@ -1,0 +1,247 @@
+const crypto = require("crypto");
+const { QueryCommand } = require("@aws-sdk/lib-dynamodb");
+const { LambdaClient, InvokeCommand } = require("@aws-sdk/client-lambda");
+const { S3Client, PutObjectCommand, HeadObjectCommand, GetObjectCommand } = require("@aws-sdk/client-s3");
+const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
+const { docClient, resolveAllowedOrigin, streamToBuffer } = require("./handler");
+// @sparticuz/chromium・puppeteer-coreはESM専用パッケージ（"type": "module"）のため、
+// このファイル（CommonJS）からはrequire()できず、使用箇所（renderEfudaPdfWorker内）で
+// 動的import()する
+
+const lambdaClient = new LambdaClient({ region: "ap-northeast-1" });
+const s3Client = new S3Client({ region: "ap-northeast-1" });
+
+// 絵札印刷ページのディープリンク先（?view=print-efuda&category=...&side=...で
+// カテゴリ選択UIを経由せず直接印刷内容を再現できる。frontend/src/App.jsxの
+// view/selectedCategories初期化ロジックを参照）
+const FRONTEND_PRINT_URL = "https://bamiyanapp.github.io/karuta/";
+
+// PDF生成を許可する合計読み札数の上限。renderEfudaPdfWorkerのmemorySize/timeout
+// （serverless.yml）と対応させて設定している。frontend/src/App.jsxの
+// MAX_EFUDA_PRINT_CARDSと同じ値に保つこと（フロントは選択UI自体をブロックする一次防御、
+// こちらはURL直叩き等を弾く二次防御）
+const MAX_EFUDA_PRINT_CARDS_SERVER = 500;
+
+const parseCategoryParam = (value) => (value ? value.split(",").filter(Boolean).map(decodeURIComponent) : []);
+
+const pdfObjectKey = (jobId) => `efuda-pdf/${jobId}.pdf`;
+const errorObjectKey = (jobId) => `efuda-pdf/${jobId}.error.json`;
+
+const isNotFoundError = (error) =>
+  error.name === "NotFound" || error.name === "NoSuchKey" || error.$metadata?.httpStatusCode === 404;
+
+async function countPhrasesInCategory(category) {
+  const result = await docClient.send(new QueryCommand({
+    TableName: process.env.TABLE_NAME,
+    KeyConditionExpression: "category = :cat",
+    ExpressionAttributeValues: { ":cat": category },
+    Select: "COUNT",
+  }));
+  return result.Count || 0;
+}
+
+// PDF生成ジョブを開始する。実際の描画はrenderEfudaPdfWorkerに非同期委譲する
+// （Chromium起動＋大量ページ描画はAPI Gatewayの29秒タイムアウトを超えうるため、
+// startSpeechRecognition/getSpeechRecognitionResultと同じ「開始→ポーリング」構成にしている）
+exports.generateEfudaPdf = async (event) => {
+  const allowedOrigin = resolveAllowedOrigin(event);
+  try {
+    const body = JSON.parse(event.body || "{}");
+    const { categoryParam, side } = body;
+    const categories = parseCategoryParam(categoryParam);
+
+    if (categories.length === 0 || (side !== "front" && side !== "back")) {
+      return {
+        statusCode: 400,
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
+        body: JSON.stringify({ message: "Invalid input" }),
+      };
+    }
+
+    // クライアント側（App.jsxのMAX_EFUDA_PRINT_CARDS）でも上限チェックしているが、
+    // URLを直接叩けばそちらは素通りできてしまう。サーバー側で実際の読み札数を
+    // DynamoDBから数え直し、無制限にヘッドレスChromiumジョブを起動できないようにする
+    const counts = await Promise.all(categories.map(countPhrasesInCategory));
+    const totalCount = counts.reduce((sum, count) => sum + count, 0);
+
+    if (totalCount > MAX_EFUDA_PRINT_CARDS_SERVER) {
+      return {
+        statusCode: 400,
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
+        body: JSON.stringify({
+          message: `選択された読み札数（${totalCount}枚）が上限（${MAX_EFUDA_PRINT_CARDS_SERVER}枚）を超えています`,
+        }),
+      };
+    }
+
+    const jobId = crypto.randomUUID();
+
+    // InvocationType: "Event"は必ずawaitする。awaitしないとこの関数のPromiseが
+    // 解決した直後にLambdaの実行環境が凍結され、送信中のSDK呼び出しが破棄される恐れがある
+    await lambdaClient.send(new InvokeCommand({
+      FunctionName: process.env.RENDER_WORKER_FUNCTION_NAME,
+      InvocationType: "Event",
+      Payload: JSON.stringify({ jobId, categoryParam, side }),
+    }));
+
+    return {
+      statusCode: 200,
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
+      body: JSON.stringify({ jobId }),
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      statusCode: 500,
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
+      body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
+    };
+  }
+};
+
+// API Gateway経由ではなく、generateEfudaPdfからの非同期Invokeでのみ呼ばれる
+// （serverless.ymlでhttpイベントを設定していないため、eventはpayloadそのもの）
+exports.renderEfudaPdfWorker = async (event) => {
+  const { jobId, categoryParam, side } = event;
+  let browser;
+  try {
+    const [{ default: chromium }, { default: puppeteer }] = await Promise.all([
+      import("@sparticuz/chromium"),
+      import("puppeteer-core"),
+    ]);
+
+    const url = new URL(FRONTEND_PRINT_URL);
+    url.searchParams.set("view", "print-efuda");
+    // categoryParamはフロントエンドのserializeCategoriesParam()の出力をそのまま
+    // 受け取ったものなので、ここではエンコード方式を再実装せずそのまま使う
+    url.searchParams.set("category", categoryParam);
+    url.searchParams.set("side", side);
+    // 実物の紙面には印刷しないが、PDFでは種別を確認できるようにする
+    // （既存のhtml2canvas版と同じ挙動。frontend/src/App.cssの.efuda-pdf-export参照）
+    url.searchParams.set("pdfExport", "1");
+
+    browser = await puppeteer.launch({
+      args: await puppeteer.defaultArgs({ args: chromium.args, headless: "shell" }),
+      executablePath: await chromium.executablePath(),
+      headless: "shell",
+    });
+
+    const page = await browser.newPage();
+    await page.goto(url.toString(), { waitUntil: "networkidle0" });
+    // .efuda-print-areaはカテゴリ・読み札の取得が完了して初めて描画される要素のため、
+    // これの出現をもってデータ準備完了とみなす
+    await page.waitForSelector(".efuda-print-area");
+    // コールドスタートしたChromiumはブラウザキャッシュを持たず、Google Fontsの
+    // スワップが完了する前にキャプチャすると文字寸法がずれるおそれがあるため待つ。
+    // このコールバックはNode側ではなくpage.evaluate()経由でブラウザ側で実行される
+    // eslint-disable-next-line no-undef
+    await page.evaluate(() => document.fonts.ready);
+    // page.pdf()は既定で印刷用CSSを適用するが、暗黙の挙動に依存せず明示する
+    await page.emulateMediaType("print");
+
+    const pdfBuffer = await page.pdf({ preferCSSPageSize: true, printBackground: true });
+
+    await s3Client.send(new PutObjectCommand({
+      Bucket: process.env.EFUDA_PDF_BUCKET_NAME,
+      Key: pdfObjectKey(jobId),
+      Body: pdfBuffer,
+      ContentType: "application/pdf",
+    }));
+  } catch (error) {
+    console.error(error);
+    try {
+      await s3Client.send(new PutObjectCommand({
+        Bucket: process.env.EFUDA_PDF_BUCKET_NAME,
+        Key: errorObjectKey(jobId),
+        Body: JSON.stringify({ message: error.message }),
+        ContentType: "application/json",
+      }));
+    } catch (writeError) {
+      console.error("Failed to write error marker", writeError);
+    }
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+  }
+};
+
+// ジョブの状態はDynamoDB等に保存せず、S3上の実際のオブジェクトの有無から都度導出する
+// （getSpeechRecognitionResultと同じ「状態を持たずライブに確認する」方針）
+exports.getEfudaPdfStatus = async (event) => {
+  const allowedOrigin = resolveAllowedOrigin(event);
+  try {
+    const params = event.queryStringParameters || {};
+    const { jobId, categoryLabel, side } = params;
+
+    if (!jobId) {
+      return {
+        statusCode: 400,
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
+        body: JSON.stringify({ message: "Invalid input" }),
+      };
+    }
+
+    try {
+      await s3Client.send(new HeadObjectCommand({
+        Bucket: process.env.EFUDA_PDF_BUCKET_NAME,
+        Key: pdfObjectKey(jobId),
+      }));
+
+      const sideLabel = side === "back" ? "裏面" : "表面";
+      const filename = `${categoryLabel || "karuta"}_絵札_${sideLabel}.pdf`;
+      const url = await getSignedUrl(
+        s3Client,
+        new GetObjectCommand({
+          Bucket: process.env.EFUDA_PDF_BUCKET_NAME,
+          Key: pdfObjectKey(jobId),
+          // カテゴリ名は日本語を含むため、RFC 6266のfilename*形式で指定する
+          ResponseContentDisposition: `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`,
+        }),
+        { expiresIn: 300 }
+      );
+
+      return {
+        statusCode: 200,
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
+        body: JSON.stringify({ status: "DONE", url }),
+      };
+    } catch (headError) {
+      if (!isNotFoundError(headError)) {
+        throw headError;
+      }
+    }
+
+    try {
+      const errorObject = await s3Client.send(new GetObjectCommand({
+        Bucket: process.env.EFUDA_PDF_BUCKET_NAME,
+        Key: errorObjectKey(jobId),
+      }));
+      const errorBuffer = await streamToBuffer(errorObject.Body);
+      const parsedError = JSON.parse(errorBuffer.toString("utf-8"));
+
+      return {
+        statusCode: 200,
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
+        body: JSON.stringify({ status: "FAILED", message: parsedError.message }),
+      };
+    } catch (getError) {
+      if (!isNotFoundError(getError)) {
+        throw getError;
+      }
+    }
+
+    return {
+      statusCode: 200,
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
+      body: JSON.stringify({ status: "IN_PROGRESS" }),
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      statusCode: 500,
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
+      body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
+    };
+  }
+};

--- a/backend/efudaPdfHandler.test.js
+++ b/backend/efudaPdfHandler.test.js
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { S3Client, PutObjectCommand, HeadObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
+import { Readable } from 'stream';
+import crypto from 'crypto';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const s3Mock = mockClient(S3Client);
+const lambdaMock = mockClient(LambdaClient);
+
+function readableFromString(text) {
+  const stream = new Readable();
+  stream.push(text);
+  stream.push(null);
+  return stream;
+}
+
+// getSignedUrlはネットワークアクセスせずローカルでSigV4署名を計算するだけなので、
+// モックせず実物を使い、生成されたURLの構造（バケット・キー・ファイル名エンコード等）を検証する
+
+// @sparticuz/chromium・puppeteer-coreはESM専用パッケージのため、
+// efudaPdfHandler.js側では動的import()で読み込んでいる（vi.mockは標準的なESM形状でよい）
+const launchMock = vi.fn();
+vi.mock('puppeteer-core', () => ({
+  default: {
+    launch: (...args) => launchMock(...args),
+    defaultArgs: vi.fn().mockResolvedValue(['--fake-arg']),
+  },
+}));
+vi.mock('@sparticuz/chromium', () => ({
+  default: {
+    args: ['--chromium-arg'],
+    executablePath: vi.fn().mockResolvedValue('/tmp/chromium'),
+  },
+}));
+
+vi.spyOn(crypto, 'randomUUID').mockReturnValue('mock-job-id');
+vi.spyOn(console, 'error').mockImplementation(() => {});
+
+const { generateEfudaPdf, renderEfudaPdfWorker, getEfudaPdfStatus } = await import('./efudaPdfHandler');
+
+process.env.TABLE_NAME = 'TestTable';
+process.env.EFUDA_PDF_BUCKET_NAME = 'test-efuda-pdf-bucket';
+process.env.RENDER_WORKER_FUNCTION_NAME = 'arn:aws:lambda:ap-northeast-1:123456789012:function:renderEfudaPdfWorker';
+
+describe('generateEfudaPdf', () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    lambdaMock.reset();
+  });
+
+  it('rejects invalid input (missing categories or invalid side)', async () => {
+    const response = await generateEfudaPdf({ body: JSON.stringify({ categoryParam: '', side: 'front' }) });
+    expect(response.statusCode).toBe(400);
+
+    const response2 = await generateEfudaPdf({ body: JSON.stringify({ categoryParam: 'Cat1', side: 'sideways' }) });
+    expect(response2.statusCode).toBe(400);
+  });
+
+  it('sums per-category counts from DynamoDB, invokes the worker asynchronously, and returns a jobId', async () => {
+    ddbMock.on(QueryCommand, { ExpressionAttributeValues: { ':cat': 'Cat1' } }).resolves({ Count: 3 });
+    ddbMock.on(QueryCommand, { ExpressionAttributeValues: { ':cat': 'Cat2' } }).resolves({ Count: 5 });
+    lambdaMock.on(InvokeCommand).resolves({ StatusCode: 202 });
+
+    const response = await generateEfudaPdf({ body: JSON.stringify({ categoryParam: 'Cat1,Cat2', side: 'back' }) });
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body).toEqual({ jobId: 'mock-job-id' });
+
+    const invokeCall = lambdaMock.commandCalls(InvokeCommand)[0].args[0].input;
+    expect(invokeCall.InvocationType).toBe('Event');
+    expect(invokeCall.FunctionName).toBe(process.env.RENDER_WORKER_FUNCTION_NAME);
+    expect(JSON.parse(invokeCall.Payload)).toEqual({ jobId: 'mock-job-id', categoryParam: 'Cat1,Cat2', side: 'back' });
+  });
+
+  it('rejects when the total card count exceeds the server-side cap without invoking the worker', async () => {
+    ddbMock.on(QueryCommand, { ExpressionAttributeValues: { ':cat': 'HugeCat' } }).resolves({ Count: 9999 });
+
+    const response = await generateEfudaPdf({ body: JSON.stringify({ categoryParam: 'HugeCat', side: 'front' }) });
+
+    expect(response.statusCode).toBe(400);
+    expect(lambdaMock.commandCalls(InvokeCommand)).toHaveLength(0);
+  });
+
+  it('handles errors', async () => {
+    ddbMock.on(QueryCommand).rejects(new Error('DynamoDB error'));
+    const response = await generateEfudaPdf({ body: JSON.stringify({ categoryParam: 'Cat1', side: 'front' }) });
+    expect(response.statusCode).toBe(500);
+  });
+});
+
+describe('renderEfudaPdfWorker', () => {
+  let pageMock;
+  let browserMock;
+
+  beforeEach(() => {
+    s3Mock.reset();
+    launchMock.mockReset();
+
+    pageMock = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      waitForSelector: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue(undefined),
+      emulateMediaType: vi.fn().mockResolvedValue(undefined),
+      pdf: vi.fn().mockResolvedValue(Buffer.from('%PDF-fake')),
+    };
+    browserMock = {
+      newPage: vi.fn().mockResolvedValue(pageMock),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    launchMock.mockResolvedValue(browserMock);
+  });
+
+  it('navigates to the print view with the expected query params and uploads the resulting PDF to S3', async () => {
+    s3Mock.on(PutObjectCommand).resolves({});
+
+    await renderEfudaPdfWorker({ jobId: 'job-1', categoryParam: 'Cat1,Cat2', side: 'back' });
+
+    const gotoUrl = new URL(pageMock.goto.mock.calls[0][0]);
+    expect(gotoUrl.origin + gotoUrl.pathname).toBe('https://bamiyanapp.github.io/karuta/');
+    expect(gotoUrl.searchParams.get('view')).toBe('print-efuda');
+    expect(gotoUrl.searchParams.get('category')).toBe('Cat1,Cat2');
+    expect(gotoUrl.searchParams.get('side')).toBe('back');
+    expect(gotoUrl.searchParams.get('pdfExport')).toBe('1');
+
+    expect(pageMock.emulateMediaType).toHaveBeenCalledWith('print');
+    expect(pageMock.pdf).toHaveBeenCalledWith({ preferCSSPageSize: true, printBackground: true });
+
+    const putCall = s3Mock.commandCalls(PutObjectCommand)[0].args[0].input;
+    expect(putCall.Bucket).toBe('test-efuda-pdf-bucket');
+    expect(putCall.Key).toBe('efuda-pdf/job-1.pdf');
+    expect(putCall.ContentType).toBe('application/pdf');
+    expect(browserMock.close).toHaveBeenCalled();
+  });
+
+  it('writes an error marker to S3 instead of a PDF when rendering fails, and still closes the browser', async () => {
+    pageMock.pdf.mockRejectedValue(new Error('boom'));
+    s3Mock.on(PutObjectCommand).resolves({});
+
+    await renderEfudaPdfWorker({ jobId: 'job-2', categoryParam: 'Cat1', side: 'front' });
+
+    const putCall = s3Mock.commandCalls(PutObjectCommand)[0].args[0].input;
+    expect(putCall.Key).toBe('efuda-pdf/job-2.error.json');
+    expect(JSON.parse(putCall.Body).message).toBe('boom');
+    expect(browserMock.close).toHaveBeenCalled();
+  });
+});
+
+describe('getEfudaPdfStatus', () => {
+  beforeEach(() => {
+    s3Mock.reset();
+  });
+
+  it('rejects when jobId is missing', async () => {
+    const response = await getEfudaPdfStatus({ queryStringParameters: {} });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('returns a presigned download URL (with a correctly encoded Japanese filename) when the PDF exists', async () => {
+    s3Mock.on(HeadObjectCommand).resolves({});
+
+    const response = await getEfudaPdfStatus({
+      queryStringParameters: { jobId: 'job-1', categoryLabel: 'Cat1', side: 'back' },
+    });
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body.status).toBe('DONE');
+    const url = new URL(body.url);
+    expect(url.hostname).toContain('test-efuda-pdf-bucket');
+    expect(url.pathname).toBe('/efuda-pdf/job-1.pdf');
+    expect(url.searchParams.get('response-content-disposition')).toBe(
+      `attachment; filename*=UTF-8''${encodeURIComponent('Cat1_絵札_裏面.pdf')}`
+    );
+  });
+
+  it('returns FAILED with the stored message when only the error marker exists', async () => {
+    s3Mock.on(HeadObjectCommand).rejects(Object.assign(new Error('not found'), { name: 'NotFound' }));
+    s3Mock.on(GetObjectCommand).resolves({ Body: readableFromString(JSON.stringify({ message: 'render failed' })) });
+
+    const response = await getEfudaPdfStatus({ queryStringParameters: { jobId: 'job-2' } });
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body).toEqual({ status: 'FAILED', message: 'render failed' });
+  });
+
+  it('returns IN_PROGRESS when neither the PDF nor an error marker exist yet', async () => {
+    s3Mock.on(HeadObjectCommand).rejects(Object.assign(new Error('not found'), { name: 'NotFound' }));
+    s3Mock.on(GetObjectCommand).rejects(Object.assign(new Error('not found'), { name: 'NoSuchKey' }));
+
+    const response = await getEfudaPdfStatus({ queryStringParameters: { jobId: 'job-3' } });
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body).toEqual({ status: 'IN_PROGRESS' });
+  });
+
+  it('handles unexpected errors', async () => {
+    s3Mock.on(HeadObjectCommand).rejects(new Error('S3 outage'));
+    const response = await getEfudaPdfStatus({ queryStringParameters: { jobId: 'job-4' } });
+    expect(response.statusCode).toBe(500);
+  });
+});

--- a/backend/efudaPdfHandler.test.js
+++ b/backend/efudaPdfHandler.test.js
@@ -44,6 +44,11 @@ const { generateEfudaPdf, renderEfudaPdfWorker, getEfudaPdfStatus } = await impo
 process.env.TABLE_NAME = 'TestTable';
 process.env.EFUDA_PDF_BUCKET_NAME = 'test-efuda-pdf-bucket';
 process.env.RENDER_WORKER_FUNCTION_NAME = 'arn:aws:lambda:ap-northeast-1:123456789012:function:renderEfudaPdfWorker';
+// getSignedUrlはSigV4署名の計算にAWS認証情報を必要とする（実際に外部へ通信はしない）。
+// CI環境にはAWS認証情報が設定されていないため、ダミーの値を明示的に与えないと
+// 「Could not load credentials」で例外になってしまう
+process.env.AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || 'test-access-key-id';
+process.env.AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY || 'test-secret-access-key';
 
 describe('generateEfudaPdf', () => {
   beforeEach(() => {

--- a/backend/handler.js
+++ b/backend/handler.js
@@ -24,6 +24,10 @@ function resolveAllowedOrigin(event) {
   return ALLOWED_ORIGINS.includes(requestOrigin) ? requestOrigin : ALLOWED_ORIGINS[0];
 }
 
+// efudaPdfHandler.js（絵札PDFのサーバーサイド生成）から再利用するため公開する
+exports.docClient = docClient;
+exports.resolveAllowedOrigin = resolveAllowedOrigin;
+
 function escapeSsml(text) {
   return String(text)
     .replace(/&/g, "&amp;")
@@ -782,3 +786,5 @@ async function streamToBuffer(stream) {
     stream.on("end", () => resolve(Buffer.concat(chunks)));
   });
 }
+
+exports.streamToBuffer = streamToBuffer;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,7 +19,7 @@
         "@aws-sdk/s3-request-presigner": "^3.958.0",
         "@sparticuz/chromium": "^149.0.0",
         "csv-parse": "^7.0.0",
-        "puppeteer-core": "^25.3.0"
+        "puppeteer-core": "^24.43.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -1200,31 +1200,24 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz",
-      "integrity": "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "modern-tar": "^0.7.6",
-        "yargs": "^18.0.0"
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
       },
       "bin": {
-        "browsers": "lib/main-cli.js"
+        "browsers": "lib/cjs/main-cli.js"
       },
       "engines": {
-        "node": ">=22.12.0"
-      },
-      "peerDependencies": {
-        "proxy-agent": ">=8.0.1",
-        "yauzl": "^2.10.0 || ^3.4.0"
-      },
-      "peerDependenciesMeta": {
-        "proxy-agent": {
-          "optional": true
-        },
-        "yauzl": {
-          "optional": true
-        }
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1974,6 +1967,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -2058,7 +2057,7 @@
       "version": "26.1.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -2090,6 +2089,16 @@
       "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.10",
@@ -2360,7 +2369,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2370,7 +2378,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2564,6 +2571,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ast-v8-to-istanbul": {
@@ -2820,6 +2839,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2941,7 +2969,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -3186,16 +3213,13 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-16.0.1.tgz",
-      "integrity": "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",
         "zod": "^3.24.1"
-      },
-      "engines": {
-        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -3329,93 +3353,31 @@
       }
     },
     "node_modules/cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "license": "ISC",
       "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -3448,7 +3410,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3461,7 +3422,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -3628,6 +3588,15 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -3693,7 +3662,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4049,6 +4017,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -4070,9 +4052,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1638949",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1638949.tgz",
-      "integrity": "sha512-mXwg4Fqnv0WR4iuAT/gYUmctNkjILwXFHyZ+m7Ty1dfr0ezZt2U3gnrrJTfRobJTHoXf+IbuFvFITzLrLFjwJA==",
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/dezalgo": {
@@ -4162,7 +4144,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -4432,6 +4413,27 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
     "node_modules/eslint": {
       "version": "9.39.4",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
@@ -4674,7 +4676,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -4724,7 +4725,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -4744,7 +4744,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4835,6 +4834,41 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4929,7 +4963,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -5332,18 +5365,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5425,6 +5446,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/glob": {
@@ -5677,6 +5712,28 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
@@ -5832,6 +5889,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/is-arguments": {
@@ -6045,7 +6111,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7171,6 +7236,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/lru-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
@@ -7427,20 +7501,10 @@
         "obliterator": "^1.6.1"
       }
     },
-    "node_modules/modern-tar": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
-      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -7498,6 +7562,15 @@
         "find-requires": "^1.0.0",
         "fs2": "^0.3.9",
         "type": "^2.7.2"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/next-tick": {
@@ -7882,6 +7955,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -7996,7 +8123,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -8134,6 +8260,15 @@
         "node": ">=10.0"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/promise-queue": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/promise-queue/-/promise-queue-2.2.5.tgz",
@@ -8143,6 +8278,53 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
@@ -8175,20 +8357,21 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.3.0.tgz",
-      "integrity": "sha512-fm+wpUr2oigH1PXZvwgATrM2tYWHMDG8ASzTEe9uukCye4X5Ldx1K5BTHPFKITrIWvQQAQ256d1NpbEveBcKjA==",
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+      "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "3.0.6",
-        "chromium-bidi": "16.0.1",
-        "devtools-protocol": "0.0.1638949",
+        "@puppeteer/browsers": "2.13.2",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1608973",
         "typed-query-selector": "^2.12.2",
-        "webdriver-bidi-protocol": "0.4.2",
-        "ws": "^8.21.0"
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.20.0"
       },
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=18"
       }
     },
     "node_modules/puppeteer-core/node_modules/ws": {
@@ -8467,6 +8650,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -8762,10 +8954,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9082,6 +9273,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -9104,6 +9342,16 @@
       "dependencies": {
         "sort-keys": "^1.0.0"
       },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9223,7 +9471,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -9298,7 +9545,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -9911,7 +10157,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/uni-global": {
@@ -10233,9 +10479,9 @@
       }
     },
     "node_modules/webdriver-bidi-protocol": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
-      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
@@ -10532,86 +10778,36 @@
       }
     },
     "node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "dependencies": {
-        "cliui": "^9.0.1",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^22.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,13 +10,16 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.958.0",
+        "@aws-sdk/client-lambda": "^3.1087.0",
         "@aws-sdk/client-polly": "^3.958.0",
         "@aws-sdk/client-s3": "^3.958.0",
         "@aws-sdk/client-transcribe": "^3.958.0",
         "@aws-sdk/lib-dynamodb": "^3.958.0",
         "@aws-sdk/polly-request-presigner": "^3.958.0",
         "@aws-sdk/s3-request-presigner": "^3.958.0",
-        "csv-parse": "^7.0.0"
+        "@sparticuz/chromium": "^149.0.0",
+        "csv-parse": "^7.0.0",
+        "puppeteer-core": "^25.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -168,19 +171,18 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.1085.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1085.0.tgz",
-      "integrity": "sha512-Ms41fQmgYK/iF89KLoLVxSwPGtCwIYGyH+1Ovm6l7jiubxDmUfzU7keLzZHOymfxfDz5bBcqfwID65fuMKEnYQ==",
-      "dev": true,
+      "version": "3.1087.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1087.0.tgz",
+      "integrity": "sha512-qZVBwoJjdphfnvTpDoeg7vCF16tGmP5B15f7hcGJm7J2mQGRPXA+II16b9jguORgud3y6CHHjsBfcg8o5cHNew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/credential-provider-node": "^3.972.66",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/fetch-http-handler": "^5.6.4",
-        "@smithy/node-http-handler": "^4.9.4",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.2",
+        "@aws-sdk/credential-provider-node": "^3.972.68",
+        "@aws-sdk/types": "^3.974.1",
+        "@smithy/core": "^3.29.3",
+        "@smithy/fetch-http-handler": "^5.6.5",
+        "@smithy/node-http-handler": "^4.9.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -271,17 +273,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.975.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
-      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
+      "version": "3.975.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.2.tgz",
+      "integrity": "sha512-iyeXwziyjJpixq5OmhsIyrSWx8vwcI7gDo4yRUC3EP7NQtOo9iAJiIEc3G+/HkhtNXqOhofiCK7Lc34Sq+fJWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
-        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws-sdk/types": "^3.974.1",
+        "@aws-sdk/xml-builder": "^3.972.35",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.2",
+        "@smithy/core": "^3.29.3",
         "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -290,15 +292,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.57",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
-      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.58.tgz",
+      "integrity": "sha512-vyGtvK1rY940eq7JT0yIGKuZ+2kpPSJcHibSvGlit5oiMFDamzC7cxBGLl4FLnd6suihMXDI2FSF2dL6TmBqPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.2",
+        "@aws-sdk/types": "^3.974.1",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -306,17 +308,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
-      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.60.tgz",
+      "integrity": "sha512-g9b9YzDrD5pcKiPBJfCSXRfFMrA39eR0guUhZ5SRm+7vMAVc43+effxbcamxBjSd5bUhrdKo5te/yQuWurLXLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/fetch-http-handler": "^5.6.4",
-        "@smithy/node-http-handler": "^4.9.4",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.2",
+        "@aws-sdk/types": "^3.974.1",
+        "@smithy/core": "^3.29.3",
+        "@smithy/fetch-http-handler": "^5.6.5",
+        "@smithy/node-http-handler": "^4.9.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -324,23 +326,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
-      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
+      "version": "3.973.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.2.tgz",
+      "integrity": "sha512-Yr7yxNyQ8aHt9Ww0RPFUZx+xiem+vl7vuwhP0tniTijoesJNV5jou9HCgVpI0GEPAF+89TkOvilE5uRrZJnjaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/credential-provider-env": "^3.972.57",
-        "@aws-sdk/credential-provider-http": "^3.972.59",
-        "@aws-sdk/credential-provider-login": "^3.972.63",
-        "@aws-sdk/credential-provider-process": "^3.972.57",
-        "@aws-sdk/credential-provider-sso": "^3.973.1",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
+        "@aws-sdk/core": "^3.975.2",
+        "@aws-sdk/credential-provider-env": "^3.972.58",
+        "@aws-sdk/credential-provider-http": "^3.972.60",
+        "@aws-sdk/credential-provider-login": "^3.972.64",
+        "@aws-sdk/credential-provider-process": "^3.972.58",
+        "@aws-sdk/credential-provider-sso": "^3.973.2",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.64",
+        "@aws-sdk/nested-clients": "^3.997.32",
+        "@aws-sdk/types": "^3.974.1",
+        "@smithy/core": "^3.29.3",
         "@smithy/credential-provider-imds": "^4.4.7",
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -348,16 +350,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
-      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
+      "version": "3.972.64",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.64.tgz",
+      "integrity": "sha512-YQoSI4d6kXvoenoG/0Jv/PqaAuukHzGmGXGyHBQYeEUNsYovlNAn/Sw1wp/WQbhcQ3HsEMGgjEahvD3igz6ecQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.2",
+        "@aws-sdk/nested-clients": "^3.997.32",
+        "@aws-sdk/types": "^3.974.1",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -365,21 +367,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.67.tgz",
-      "integrity": "sha512-oYlzWst56rlhhjbYnexwv5hVLYe1cW4liLObhDfxDLI4RAQzleMVHQgQgx7XsC4HKj4e3kjT8v9DId+Pi/dndw==",
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.68.tgz",
+      "integrity": "sha512-4akjzW9CjorByYfqXBXmYUh/h7Io3U4DtVgGGh9TQraZ7ZlyJqNyHwDRGiUFnHD+BTOeTbCesCa4sJaK7BGZ7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.57",
-        "@aws-sdk/credential-provider-http": "^3.972.59",
-        "@aws-sdk/credential-provider-ini": "^3.973.1",
-        "@aws-sdk/credential-provider-process": "^3.972.57",
-        "@aws-sdk/credential-provider-sso": "^3.973.1",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
+        "@aws-sdk/credential-provider-env": "^3.972.58",
+        "@aws-sdk/credential-provider-http": "^3.972.60",
+        "@aws-sdk/credential-provider-ini": "^3.973.2",
+        "@aws-sdk/credential-provider-process": "^3.972.58",
+        "@aws-sdk/credential-provider-sso": "^3.973.2",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.64",
+        "@aws-sdk/types": "^3.974.1",
+        "@smithy/core": "^3.29.3",
         "@smithy/credential-provider-imds": "^4.4.7",
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -387,15 +389,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.57",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
-      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.58.tgz",
+      "integrity": "sha512-1nYitRCaDmXWUrpBJt6WlcGjLx1JVsMY8rlYuHHsTYTSaYikbixYdQSyINN2VYq1F798uTO9qHAzytL25M8g3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.2",
+        "@aws-sdk/types": "^3.974.1",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -403,17 +405,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
-      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
+      "version": "3.973.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.2.tgz",
+      "integrity": "sha512-pjMLaLU/JZi5lVfmR14V1OZqRBTuMHf6AwGNZA0K9hK+JKtO3jcLBarfD8iq5oc8cSowvc/9R32sqMVXZPo6xQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/token-providers": "3.1083.0",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.2",
+        "@aws-sdk/nested-clients": "^3.997.32",
+        "@aws-sdk/token-providers": "3.1087.0",
+        "@aws-sdk/types": "^3.974.1",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -421,16 +423,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
-      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
+      "version": "3.972.64",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.64.tgz",
+      "integrity": "sha512-7Buc7p0OvDHW7iBsu4b+YdS0WnaFBDGKDfbVQqaac9dkWiSiUtIoarBDsA1RmOVXZijaZJDoHJFIQiicQvWRlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.2",
+        "@aws-sdk/nested-clients": "^3.997.32",
+        "@aws-sdk/types": "^3.974.1",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -564,18 +566,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
-      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
+      "version": "3.997.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.32.tgz",
+      "integrity": "sha512-6Yj2fr9XF67cndITea48rchTdVr3VGx6PN47bIKNinJAjLkmaIlz/4EBPCgJ8UmhVopiXmeAuPLI3+DXDDbMhQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/fetch-http-handler": "^5.6.4",
-        "@smithy/node-http-handler": "^4.9.4",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.2",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.40",
+        "@aws-sdk/types": "^3.974.1",
+        "@smithy/core": "^3.29.3",
+        "@smithy/fetch-http-handler": "^5.6.5",
+        "@smithy/node-http-handler": "^4.9.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -618,14 +620,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
-      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+      "version": "3.996.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.40.tgz",
+      "integrity": "sha512-wrGZ/authosokclY1DXsiWT/1WjfCI22FuZGgdcilF+XLTXs5dCjAtiFYSPsEToZkbm3Lj2YP8PoWg0yoMNu0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
+        "@aws-sdk/types": "^3.974.1",
         "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -633,16 +635,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1083.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
-      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
+      "version": "3.1087.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1087.0.tgz",
+      "integrity": "sha512-umM+qNq16f2fH+VLM5MqXW4ORNQAjk+TOSto73xbUHcKaU41L48j786r3UWQYlejeJk37NlvRYgxBT+MBkfaYQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.2",
+        "@aws-sdk/nested-clients": "^3.997.32",
+        "@aws-sdk/types": "^3.974.1",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -650,12 +652,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
-      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+      "version": "3.974.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.1.tgz",
+      "integrity": "sha512-W0IQZR0eaBqlBFIIofMapaWkw1W0U+Xi4dvW+BqwmCEMd8Ng2U6IhkxuPSjMVnR8klLjfuS9PeZWUl1N6UaZdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -678,12 +680,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
-      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.35.tgz",
+      "integrity": "sha512-pXzaWe3evZhjxDXAlMnqISe/XefTCGwBJG4nFTXaWSgAnMkqPEhxEPqJNhhpGesEvKFhvNpnozJJ4GTL11bRYw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1195,6 +1197,34 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz",
+      "integrity": "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.7.6",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1825,9 +1855,9 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
-      "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.4.tgz",
+      "integrity": "sha512-G1GRglAabzEhqghJMBAd54FkRS7SAFGHEwbhcI9r+O+LIMuFsLyXkLZkCoFSgAglRu8s/URVXJB0hglq3ZipIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -1838,12 +1868,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
-      "integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.9.tgz",
+      "integrity": "sha512-2nfV4qRKiYeXU4zD2vvSCfg5dfp/BuhrM73vt7q9gzBhxs4rbPxXY21wo+kyI3bRmXcEGRnCLTaW8O437jzHIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.3",
+        "@smithy/core": "^3.29.4",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1903,6 +1933,18 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@sparticuz/chromium": {
+      "version": "149.0.0",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-149.0.0.tgz",
+      "integrity": "sha512-2NECBVKlUA9xIUXb4fT8OoGKdAJs+I2tNYscO8FwcxCKCWA7FmpPI0fdVxGJoIJglrFZYn+4YEJqChq4rdrxQg==",
+      "license": "MIT",
+      "dependencies": {
+        "tar-fs": "^3.1.2"
+      },
+      "engines": {
+        "node": "^22.17.0 || >=24.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -2656,12 +2698,106 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2805,7 +2941,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -3049,6 +3185,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/chromium-bidi": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-16.0.1.tgz",
+      "integrity": "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -3174,6 +3326,99 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clone": {
@@ -3824,6 +4069,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1638949",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1638949.tgz",
+      "integrity": "sha512-mXwg4Fqnv0WR4iuAT/gYUmctNkjILwXFHyZ+m7Ty1dfr0ezZt2U3gnrrJTfRobJTHoXf+IbuFvFITzLrLFjwJA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/dezalgo": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
@@ -3918,7 +4169,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -4161,6 +4411,15 @@
         "es5-ext": "^0.10.46",
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -4522,6 +4781,15 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -4574,6 +4842,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4655,7 +4929,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -5047,6 +5321,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -7104,6 +7399,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -7124,6 +7425,15 @@
       "license": "MIT",
       "dependencies": {
         "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
+      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/ms": {
@@ -7392,7 +7702,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -7687,7 +7996,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -7849,7 +8158,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -7864,6 +8172,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.3.0.tgz",
+      "integrity": "sha512-fm+wpUr2oigH1PXZvwgATrM2tYWHMDG8ASzTEe9uukCye4X5Ldx1K5BTHPFKITrIWvQQAQ256d1NpbEveBcKjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.0.6",
+        "chromium-bidi": "16.0.1",
+        "devtools-protocol": "0.0.1638949",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/qs": {
@@ -8852,6 +9198,17 @@
         "is-stream": "^1.1.0"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -9063,6 +9420,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-fs/node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -9078,6 +9461,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/throat": {
@@ -9421,6 +9822,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "license": "MIT"
     },
     "node_modules/typedarray.prototype.slice": {
       "version": "1.0.5",
@@ -9825,6 +10232,12 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -9998,7 +10411,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -10071,6 +10483,15 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -10110,11 +10531,87 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
@@ -10169,6 +10666,15 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,6 @@
     "@aws-sdk/s3-request-presigner": "^3.958.0",
     "@sparticuz/chromium": "^149.0.0",
     "csv-parse": "^7.0.0",
-    "puppeteer-core": "^25.3.0"
+    "puppeteer-core": "^24.43.1"
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,12 +22,15 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.958.0",
+    "@aws-sdk/client-lambda": "^3.1087.0",
     "@aws-sdk/client-polly": "^3.958.0",
     "@aws-sdk/client-s3": "^3.958.0",
     "@aws-sdk/client-transcribe": "^3.958.0",
     "@aws-sdk/lib-dynamodb": "^3.958.0",
     "@aws-sdk/polly-request-presigner": "^3.958.0",
     "@aws-sdk/s3-request-presigner": "^3.958.0",
-    "csv-parse": "^7.0.0"
+    "@sparticuz/chromium": "^149.0.0",
+    "csv-parse": "^7.0.0",
+    "puppeteer-core": "^25.3.0"
   }
 }

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -1,5 +1,17 @@
 service: karuta-app
 
+# 絵札PDF生成ワーカー（@sparticuz/chromium・puppeteer-core）はrenderEfudaPdfWorker
+# でしか使わない重量級の依存（Chromiumバイナリ圧縮後約50-70MB）のため、全関数で1つの
+# zipを共有するデフォルトのパッケージングのままだと、無関係な関数（getPhrase等）の
+# コールドスタートまで悪化させてしまう。individually: trueで関数ごとに個別zipを作り、
+# 下のpatternsで一旦全関数から重量級依存を除外したうえで、renderEfudaPdfWorker関数側の
+# package.patternsで自分だけ再度含める（後段の定義が優先される.gitignore的な仕組み）
+package:
+  individually: true
+  patterns:
+    - "!node_modules/@sparticuz/**"
+    - "!node_modules/puppeteer-core/**"
+
 provider:
   name: aws
   runtime: nodejs20.x
@@ -9,6 +21,7 @@ provider:
     COMMENTS_TABLE_NAME: ${self:custom.commentsTableName}
     POLLY_CACHE_TABLE_NAME: ${self:custom.pollyCacheTableName} # 追加
     VOICE_AUDIO_BUCKET_NAME: ${self:custom.voiceAudioBucketName}-${aws:accountId} # 追加
+    EFUDA_PDF_BUCKET_NAME: ${self:custom.efudaPdfBucketName}-${aws:accountId} # 追加（絵札PDFのサーバーサイド生成）
   iam:
     role:
       statements:
@@ -37,12 +50,22 @@ provider:
             - transcribe:StartTranscriptionJob
             - transcribe:GetTranscriptionJob
           Resource: "*"
+        - Effect: Allow # 追加（絵札PDFのサーバーサイド生成: generateEfudaPdfからrenderEfudaPdfWorkerを非同期起動する）
+          Action:
+            - lambda:InvokeFunction
+          Resource: !GetAtt RenderEfudaPdfWorkerLambdaFunction.Arn
+        - Effect: Allow # 追加（絵札PDFのサーバーサイド生成: renderEfudaPdfWorkerがPDF/エラーマーカーを書き込み、getEfudaPdfStatusが署名付きURLを発行する）
+          Action:
+            - s3:PutObject
+            - s3:GetObject
+          Resource: !Sub "${EfudaPdfBucket.Arn}/*"
 
 custom:
   tableName: karuta-phrases
   commentsTableName: karuta-comments
   pollyCacheTableName: karuta-polly-cache # 追加
   voiceAudioBucketName: karuta-voice-audio # 追加。バケット名はグローバルに一意である必要があるためアカウントIDを付与する
+  efudaPdfBucketName: karuta-efuda-pdf # 追加（絵札PDFのサーバーサイド生成）。バケット名はグローバルに一意である必要があるためアカウントIDを付与する
   allowedOrigins:
     - https://bamiyanapp.github.io
     - http://localhost:5173 # npm run dev（Vite開発サーバー）
@@ -121,6 +144,36 @@ functions:
           method: get
           cors:
             origins: ${self:custom.allowedOrigins}
+  generateEfudaPdf: # 追加（絵札PDFのサーバーサイド生成）。PDF生成ジョブを開始しjobIdを即返す
+    handler: efudaPdfHandler.generateEfudaPdf
+    environment:
+      RENDER_WORKER_FUNCTION_NAME: !GetAtt RenderEfudaPdfWorkerLambdaFunction.Arn
+    events:
+      - http:
+          path: generate-efuda-pdf
+          method: post
+          cors:
+            origins: ${self:custom.allowedOrigins}
+  renderEfudaPdfWorker: # 追加（絵札PDFのサーバーサイド生成）。generateEfudaPdfからの非同期Invokeでのみ呼ばれ、
+    # API Gatewayには公開しない（httpイベントなし）。Chromium起動＋大量ページ描画は
+    # API Gatewayの29秒タイムアウトを超えうるため、同期のHTTPルートでは完結させない
+    handler: efudaPdfHandler.renderEfudaPdfWorker
+    memorySize: 3008
+    timeout: 300
+    ephemeralStorageSize: 1024 # @sparticuz/chromiumが/tmpに展開する分の余裕を持たせる
+    maximumRetryAttempts: 0 # 失敗時の自動リトライ（既定で最大2回）を無効化。S3のエラーマーカーとの状態不整合を防ぐ
+    package:
+      patterns:
+        - "node_modules/@sparticuz/**"
+        - "node_modules/puppeteer-core/**"
+  getEfudaPdfStatus: # 追加（絵札PDFのサーバーサイド生成）。ジョブの完了をS3上のオブジェクトの有無から都度判定する
+    handler: efudaPdfHandler.getEfudaPdfStatus
+    events:
+      - http:
+          path: generate-efuda-pdf-status
+          method: get
+          cors:
+            origins: ${self:custom.allowedOrigins}
 
 resources:
   Resources:
@@ -182,5 +235,19 @@ resources:
         LifecycleConfiguration: # 録音・認識結果は判定後不要になるため、取り違え時の保持コスト・情報漏洩リスクを抑えるべく短期間で自動削除する
           Rules:
             - Id: ExpireVoiceRecognitionObjects
+              Status: Enabled
+              ExpirationInDays: 1
+    EfudaPdfBucket: # 追加（絵札PDFのサーバーサイド生成）
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: ${self:custom.efudaPdfBucketName}-${aws:accountId}
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: true
+          BlockPublicPolicy: true
+          IgnorePublicAcls: true
+          RestrictPublicBuckets: true
+        LifecycleConfiguration: # 生成済みPDF・エラーマーカーはダウンロード用の一時ファイルのため、短期間で自動削除する
+          Rules:
+            - Id: ExpireEfudaPdfObjects
               Status: Enabled
               ExpirationInDays: 1

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,6 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "html2canvas": "^1.4.1",
-        "jspdf": "^4.2.1",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-markdown": "^10.1.0"
@@ -1594,6 +1592,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3090,19 +3089,6 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
-    "node_modules/@types/pako": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/raf": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
-      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -3133,7 +3119,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -3566,15 +3552,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.11",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
@@ -3728,26 +3705,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/canvg": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
-      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@types/raf": "^3.4.0",
-        "core-js": "^3.8.3",
-        "raf": "^3.4.1",
-        "regenerator-runtime": "^0.13.7",
-        "rgbcolor": "^1.0.1",
-        "stackblur-canvas": "^2.0.0",
-        "svg-pathdata": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -3886,18 +3843,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/core-js": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
-      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
@@ -3935,15 +3880,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -4159,16 +4095,6 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optional": true,
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4705,17 +4631,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-png": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
-      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/pako": "^2.0.3",
-        "iobuffer": "^5.3.2",
-        "pako": "^2.1.0"
-      }
-    },
     "node_modules/fast-uri": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
@@ -4750,12 +4665,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/fflate": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
-      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
-      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -5277,19 +5186,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "license": "MIT",
-      "dependencies": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -5364,12 +5260,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/iobuffer": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
-      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
-      "license": "MIT"
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -6214,23 +6104,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jspdf": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
-      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "fast-png": "^6.2.0",
-        "fflate": "^0.8.1"
-      },
-      "optionalDependencies": {
-        "canvg": "^3.0.11",
-        "core-js": "^3.6.0",
-        "dompurify": "^3.3.1",
-        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/keyv": {
@@ -7202,22 +7075,6 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
-    "node_modules/pako": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
-      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7302,13 +7159,6 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7440,16 +7290,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
@@ -7571,13 +7411,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -7711,16 +7544,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/rgbcolor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
-      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
-      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -8128,16 +7951,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/stackblur-canvas": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
-      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.14"
-      }
-    },
     "node_modules/std-env": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
@@ -8356,16 +8169,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/svg-pathdata": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
-      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -8419,15 +8222,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/tinybench": {
@@ -8877,15 +8671,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vfile": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,8 +13,6 @@
     "deploy": "npx gh-pages -d dist"
   },
   "dependencies": {
-    "html2canvas": "^1.4.1",
-    "jspdf": "^4.2.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-markdown": "^10.1.0"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -610,6 +610,14 @@ button:active:not(:disabled) {
     page-break-after: auto;
   }
 
+  /* サーバーサイドPDF生成（renderEfudaPdfWorkerのpage.pdf()、印刷用CSSがそのまま
+     適用される）時のみ、既存のクライアント生成（html2canvas）版と同じ挙動
+     （実物の紙面には印刷しないが、PDFでは種別を確認できる）を再現するため、
+     .efuda-pdf-export配下でだけno-printを上書きしてefuda-card-categoryを表示する */
+  .efuda-pdf-export .efuda-card-category {
+    display: block !important;
+  }
+
   @page {
     size: A4;
     margin: 0;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import "./App.css";
 import karutaImage from "./assets/karuta_inubou.png";
+import { API_BASE_URL } from "./config";
 import { useLocalStorageState } from "./hooks/useLocalStorageState";
 import { useSessionStorageState } from "./hooks/useSessionStorageState";
 import { useUrlQuerySync, parseCategoriesParam } from "./hooks/useUrlQuerySync";
@@ -12,21 +13,18 @@ import AllPhrasesView from "./views/AllPhrasesView";
 import CommentsView from "./views/CommentsView";
 import ChangelogView from "./views/ChangelogView";
 
-const API_BASE_URL =
-  import.meta.env.VITE_API_BASE_URL ||
-  "https://akmnirkx3m.execute-api.ap-northeast-1.amazonaws.com/dev";
-
 const HISTORY_STORAGE_KEY = "historyByCategory";
 const PLAYERS_STORAGE_KEY = "players";
 const SCORES_STORAGE_KEY = "scoresByCategory";
 const MAX_PLAYERS = 6;
 
-// 絵札印刷時に選択できる合計読み札数の上限。html2canvasでのPDF生成はページ数に
-// 比例して時間・メモリを消費するため、選択中の種別の合計枚数がこれを超える分の
-// 種別選択自体をブロックし、PDF出力の失敗を未然に防ぐ（1ページ10枚 → 最大15ページ）。
-// 従来は300枚を上限としていたが、実際には280枚程度でもPDF出力に失敗する報告が
-// あったため、十分な安全マージンを取って150枚に引き下げた
-const MAX_EFUDA_PRINT_CARDS = 150;
+// 絵札印刷時に選択できる合計読み札数の上限。PDF生成はバックエンド（renderEfudaPdfWorker、
+// ヘッドレスChromiumのpage.pdf()）で行うため、クライアント端末のメモリには依存しなくなった。
+// ただし無制限にすると認証なしのAPIに巨大なジョブを投げ放題になってしまうため、
+// バックエンド側（backend/efudaPdfHandler.jsのMAX_EFUDA_PRINT_CARDS_SERVER）と
+// 同じ値の上限を維持する。こちらは選択UI自体をブロックする一次防御、
+// バックエンド側はURL直叩き等を弾く二次防御
+const MAX_EFUDA_PRINT_CARDS = 500;
 
 // 未読み札から次に読み上げる1件を選ぶ（プリフェッチと実際の選択で同じロジックを使う）
 const pickTargetPhrase = (unreadPhrases, sortOrder) => {

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,25 +1,6 @@
 import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import App from './App';
-import html2canvas from 'html2canvas';
-import jsPDF from 'jspdf';
-
-// PDFダウンロード機能（issue #199）のテスト用。html2canvas/jsPDFはjsdom環境で
-// 実際のcanvas描画・PDFバイナリ生成をサポートしないため、呼び出しの発生と引数のみを検証する
-vi.mock('html2canvas', () => ({
-  default: vi.fn().mockResolvedValue({ toDataURL: () => 'data:image/png;base64,dummy' }),
-}));
-vi.mock('jspdf', () => ({
-  // アプリ側は `new jsPDF(...)` で呼び出すため、vitest v4ではアロー関数を
-  // モック実装に使えない（アロー関数は元々コンストラクタ不可というJS仕様どおりの挙動）
-  default: vi.fn().mockImplementation(function () {
-    return {
-      addPage: vi.fn(),
-      addImage: vi.fn(),
-      save: vi.fn(),
-    };
-  }),
-}));
 
 window.alert = vi.fn();
 
@@ -879,18 +860,24 @@ describe('App', () => {
     expect(new Set(patterns).size).toBe(5);
   });
 
-  it('downloads a PDF of the printed efuda pages, hiding no-print elements in the capture (issue #199)', async () => {
-    const phrases = Array.from({ length: 11 }, (_, i) => ({
-      id: `p${i}`,
-      category: 'Cat1',
-      kana: 'あ',
-      phrase: `読み札テキスト${i}`,
-      answer: `回答${i}`,
-    }));
+  it('starts PDF generation on the backend, polls until done, and navigates to the resulting download URL (バックエンドPDF生成)', async () => {
+    const phrases = [{ id: 'p0', category: 'Cat1', kana: 'あ', phrase: '読み札テキスト0', answer: '-' }];
+    let statusCallCount = 0;
+    let generateRequestBody = null;
 
-    fetch.mockImplementation(async (url) => {
+    fetch.mockImplementation(async (url, options) => {
       if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
       if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases }) };
+      if (url.includes('/generate-efuda-pdf-status')) {
+        statusCallCount += 1;
+        // 1回目はまだ生成中、2回目で完了を返す（ポーリングが継続することを検証する）
+        if (statusCallCount < 2) return { ok: true, json: async () => ({ status: 'IN_PROGRESS' }) };
+        return { ok: true, json: async () => ({ status: 'DONE', url: 'https://example.com/signed-download.pdf' }) };
+      }
+      if (url.includes('/generate-efuda-pdf')) {
+        generateRequestBody = JSON.parse(options.body);
+        return { ok: true, json: async () => ({ jobId: 'job-1' }) };
+      }
       return { ok: false };
     });
 
@@ -904,34 +891,101 @@ describe('App', () => {
     await waitFor(() => screen.getByText('絵札を印刷する'));
     fireEvent.click(screen.getByText('絵札を印刷する'));
 
-    await waitFor(() => {
-      // 11枚 → 10面/ページなので2ページ生成される
-      expect(document.querySelectorAll('.efuda-page').length).toBe(2);
+    await waitFor(() => screen.getByText('読み札テキスト0'));
+
+    // window.location.hrefへの代入はjsdomでは実際のナビゲーションとして
+    // 反映されない（"Not implemented: navigation"となり値が更新されない）ため、
+    // window.locationを一時的に差し替えて代入先を検証する。他のテストに影響が
+    // 残らないよう、必ず元のオブジェクトに戻す
+    const originalLocation = window.location;
+    delete window.location;
+    window.location = { href: originalLocation.href };
+    try {
+      fireEvent.click(screen.getByText('PDFをダウンロード'));
+
+      await waitFor(() => {
+        expect(generateRequestBody).toEqual({ categoryParam: 'Cat1', side: 'front' });
+      });
+      await waitFor(() => {
+        expect(screen.getByText('PDF生成中...')).toBeInTheDocument();
+      });
+
+      // ポーリング間隔(3秒)を挟んで2回目の問い合わせで完了するまで待つ
+      await waitFor(
+        () => {
+          expect(window.location.href).toBe('https://example.com/signed-download.pdf');
+        },
+        { timeout: 10000 }
+      );
+      expect(statusCallCount).toBeGreaterThanOrEqual(2);
+    } finally {
+      delete window.location;
+      window.location = originalLocation;
+    }
+  }, 15000);
+
+  it('shows an alert when the backend PDF generation job fails (バックエンドPDF生成の失敗)', async () => {
+    const phrases = [{ id: 'p0', category: 'Cat1', kana: 'あ', phrase: '読み札テキスト0', answer: '-' }];
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases }) };
+      if (url.includes('/generate-efuda-pdf-status')) {
+        return { ok: true, json: async () => ({ status: 'FAILED', message: '生成に失敗しました' }) };
+      }
+      if (url.includes('/generate-efuda-pdf')) {
+        return { ok: true, json: async () => ({ jobId: 'job-1' }) };
+      }
+      return { ok: false };
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByText('PDFをダウンロード'));
+      render(<App />);
     });
 
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+    await waitFor(() => screen.getByText('絵札を印刷する'));
+    fireEvent.click(screen.getByText('絵札を印刷する'));
+
+    await waitFor(() => screen.getByText('読み札テキスト0'));
+
+    fireEvent.click(screen.getByText('PDFをダウンロード'));
+
+    await waitFor(
+      () => {
+        expect(window.alert).toHaveBeenCalledWith('PDFの生成に失敗しました。');
+      },
+      { timeout: 10000 }
+    );
+  }, 15000);
+
+  it('initializes printSide from the ?side URL query param, for headless server-side rendering (renderEfudaPdfWorkerのディープリンク対応)', async () => {
+    window.history.pushState({}, '', '/?view=print-efuda&category=Cat1&side=back');
+
+    const phrases = [{ id: 'p0', category: 'Cat1', kana: 'あ', phrase: '読み札テキスト0', answer: '-', level: '3' }];
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    // 表面のクリック操作を経由せず、初回描画から裏面（種別・レベル）が表示される
     await waitFor(() => {
-      expect(html2canvas).toHaveBeenCalledTimes(2);
+      expect(document.querySelector('.efuda-card-back')).toBeInTheDocument();
     });
-
-    // no-printの要素（画面上は表示されているカテゴリラベル等）を撮影対象から隠す指定になっている
-    const captureOptions = html2canvas.mock.calls[0][1];
-    expect(typeof captureOptions.onclone).toBe('function');
-
-    const jsPdfInstance = jsPDF.mock.results[0].value;
-    expect(jsPdfInstance.addPage).toHaveBeenCalledTimes(1); // 2ページ目の追加分のみ
-    expect(jsPdfInstance.addImage).toHaveBeenCalledTimes(2);
-    expect(jsPdfInstance.save).toHaveBeenCalledWith('Cat1_絵札_表面.pdf');
+    expect(screen.getByRole('button', { name: '裏面' })).toHaveClass('active');
   });
 
-  it('keeps the front-side category label visible in the PDF capture while still hiding other no-print elements (かるた種別がPDFに表示されない不具合の修正)', async () => {
-    const phrases = [
-      { id: 'p0', category: 'Cat1', kana: 'あ', phrase: '読み札テキスト0', answer: '回答0' },
-    ];
+  it('adds the efuda-pdf-export class when ?pdfExport=1 is present, for server-side PDF capture (efuda-card-categoryをPDFにのみ表示するためのマーカー)', async () => {
+    window.history.pushState({}, '', '/?view=print-efuda&category=Cat1&pdfExport=1');
 
+    const phrases = [{ id: 'p0', category: 'Cat1', kana: 'あ', phrase: '読み札テキスト0', answer: '-' }];
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
       if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases }) };
@@ -942,92 +996,8 @@ describe('App', () => {
       render(<App />);
     });
 
-    fireEvent.click(await screen.findByText('こども向け'));
-    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
-
-    await waitFor(() => screen.getByText('絵札を印刷する'));
-    fireEvent.click(screen.getByText('絵札を印刷する'));
-
-    await waitFor(() => {
-      expect(document.querySelectorAll('.efuda-page').length).toBe(1);
-    });
-
-    let categoryDisplayDuringCapture;
-    let otherNoPrintDisplayDuringCapture;
-    html2canvas.mockImplementationOnce(async (el, options) => {
-      // 実装のoncloneは実際のクローン文書を受け取るが、テストではモックのためdocument自体を渡して検証する
-      options.onclone(document);
-      categoryDisplayDuringCapture = document.querySelector('.efuda-card-category').style.display;
-      otherNoPrintDisplayDuringCapture = document.querySelector('header.no-print').style.display;
-      return { toDataURL: () => 'data:image/png;base64,dummy' };
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('PDFをダウンロード'));
-    });
-
-    await waitFor(() => {
-      expect(html2canvas).toHaveBeenCalledTimes(1);
-    });
-
-    // かるた種別ラベル（efuda-card-category）は隠さず、それ以外のno-print要素は従来どおり隠す
-    expect(categoryDisplayDuringCapture).toBe('');
-    expect(otherNoPrintDisplayDuringCapture).toBe('none');
-  });
-
-  it('disables the transform scale on each .efuda-page while capturing, and restores it afterward (issue #392/#421: PDF text rendering breaks when the on-screen preview is scaled down on narrow viewports)', async () => {
-    const phrases = Array.from({ length: 1 }, (_, i) => ({
-      id: `p${i}`,
-      category: 'Cat1',
-      kana: 'あ',
-      phrase: `読み札テキスト${i}`,
-      answer: `回答${i}`,
-      level: '3',
-      averageTime: 0,
-      averageDifficulty: 0,
-    }));
-
-    fetch.mockImplementation(async (url) => {
-      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
-      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases }) };
-      return { ok: false };
-    });
-
-    await act(async () => {
-      render(<App />);
-    });
-
-    fireEvent.click(await screen.findByText('こども向け'));
-    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
-
-    await waitFor(() => screen.getByText('絵札を印刷する'));
-    fireEvent.click(screen.getByText('絵札を印刷する'));
-
-    await waitFor(() => {
-      expect(document.querySelectorAll('.efuda-page').length).toBe(1);
-    });
-
-    // 画面プレビュー用のtransform: scale()（狭い画面での縮小表示、issue #387/#421）が
-    // 既に適用されている状態を模す
-    const pageEl = document.querySelector('.efuda-page');
-    pageEl.style.transform = 'scale(0.5)';
-
-    let transformDuringCapture;
-    html2canvas.mockImplementationOnce(async (el) => {
-      transformDuringCapture = el.style.transform;
-      return { toDataURL: () => 'data:image/png;base64,dummy' };
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('PDFをダウンロード'));
-    });
-
-    await waitFor(() => {
-      expect(html2canvas).toHaveBeenCalledTimes(1);
-    });
-
-    expect(transformDuringCapture).toBe('none');
-    expect(pageEl.style.transform).toBe('');
+    await waitFor(() => screen.getByText('読み札テキスト0'));
+    expect(document.querySelector('.efuda-print-area')).toHaveClass('efuda-pdf-export');
   });
 
   it('packs printed efuda cards across categories onto the same page without breaking per category', async () => {
@@ -1078,8 +1048,8 @@ describe('App', () => {
           ok: true,
           json: async () => ({
             categories: [
-              { name: 'Cat1', group: 'engineer', count: 75 },
-              { name: 'Cat2', group: 'engineer', count: 75 },
+              { name: 'Cat1', group: 'engineer', count: 250 },
+              { name: 'Cat2', group: 'engineer', count: 250 },
               { name: 'Cat3', group: 'engineer', count: 10 },
             ],
           }),
@@ -1100,14 +1070,14 @@ describe('App', () => {
       expect(screen.getByRole('button', { name: /Cat3/ })).toBeInTheDocument();
     });
 
-    // Cat1(75) + Cat2(75) = 150枚でちょうど上限。選択自体は許可される
+    // Cat1(250) + Cat2(250) = 500枚でちょうど上限。選択自体は許可される
     fireEvent.click(screen.getByRole('button', { name: /Cat1/ }));
     fireEvent.click(screen.getByRole('button', { name: /Cat2/ }));
     expect(screen.getByRole('button', { name: /Cat1/ })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByRole('button', { name: /Cat2/ })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByText(/選択中の合計: 150枚/)).toBeInTheDocument();
+    expect(screen.getByText(/選択中の合計: 500枚/)).toBeInTheDocument();
 
-    // これ以上追加すると上限(150枚)を超えるため、Cat3は選択不可になる
+    // これ以上追加すると上限(500枚)を超えるため、Cat3は選択不可になる
     const cat3Button = screen.getByRole('button', { name: /Cat3/ });
     expect(cat3Button).toBeDisabled();
     fireEvent.click(cat3Button);

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,3 @@
+export const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ||
+  "https://akmnirkx3m.execute-api.ap-northeast-1.amazonaws.com/dev";

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -1,4 +1,6 @@
 import { useMemo, useState } from "react";
+import { API_BASE_URL } from "../config";
+import { serializeCategoriesParam } from "../hooks/useUrlQuerySync";
 
 const getEfudaText = (p) => (p.answer && p.answer !== "-") ? p.answer : p.phrase;
 
@@ -35,9 +37,9 @@ const buildBackPatternMap = (categories) => {
   return map;
 };
 
-// A4サイズ（mm）。efuda-pageのCSS上の実寸と一致させる
-const A4_WIDTH_MM = 210;
-const A4_HEIGHT_MM = 297;
+// PDF生成ジョブのポーリング間隔・最大試行回数（3秒×80回=最大4分でタイムアウトとみなす）
+const PDF_POLL_INTERVAL_MS = 3000;
+const MAX_PDF_POLL_ATTEMPTS = 80;
 
 // .efuda-gridの列数（App.cssのgrid-template-columns: 91mm 91mmと一致させる）
 const EFUDA_GRID_COLUMNS = 2;
@@ -59,8 +61,15 @@ const resolvePhraseIndex = (slotIndex, printSide) => {
 function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrasesForCategory, efudaPages, efudaPerPage }) {
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
   // 表面（読み札の内容）と裏面（種別・レベル）は用紙を裏返して2回に分けて印刷する運用を想定し、
-  // 同じページ構成をどちらの内容で描画するかだけをこのstateで切り替える
-  const [printSide, setPrintSide] = useState("front");
+  // 同じページ構成をどちらの内容で描画するかだけをこのstateで切り替える。
+  // バックエンドのrenderEfudaPdfWorkerがヘッドレスブラウザでこの画面をディープリンク
+  // （?side=back）から直接開けるよう、URLクエリがあればその値を初期値にする
+  const [printSide, setPrintSide] = useState(
+    () => (new URLSearchParams(window.location.search).get("side") === "back" ? "back" : "front")
+  );
+  // サーバーサイドPDF生成（?pdfExport=1、renderEfudaPdfWorkerが付与する）のときだけ、
+  // 印刷用CSSの中でefuda-card-categoryを例外的に表示する（App.cssの.efuda-pdf-export参照）
+  const isPdfExport = new URLSearchParams(window.location.search).get("pdfExport") === "1";
 
   const backPatternMap = useMemo(
     () => buildBackPatternMap(allPhrasesForCategory.map((p) => p.category)),
@@ -70,59 +79,43 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
   const downloadPdf = async () => {
     setIsGeneratingPdf(true);
     try {
-      // ゲーム画面など大多数のユーザーには不要な重量級ライブラリのため、
-      // メインバンドルには含めずダウンロード実行時にのみ読み込む
-      const [{ default: html2canvas }, { default: jsPDF }] = await Promise.all([
-        import("html2canvas"),
-        import("jspdf"),
-      ]);
-
-      const pageElements = document.querySelectorAll(".efuda-print-area .efuda-page");
-      const pdf = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4" });
-
-      // .efuda-pageは狭い画面での画面プレビュー用にtransform: scale()で縮小表示している
-      // （issue #387、#421）ことがある。キャプチャ中だけtransformを無効化し、
-      // 「印刷する」（window.print()、@media printでtransform: none）と同じ実寸で
-      // 撮影されるようにする
-      pageElements.forEach((el) => {
-        el.style.transform = "none";
+      const categoryParam = serializeCategoriesParam(selectedCategories);
+      const startResponse = await fetch(`${API_BASE_URL}/generate-efuda-pdf`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ categoryParam, side: printSide }),
       });
+      if (!startResponse.ok) {
+        const errorBody = await startResponse.json().catch(() => null);
+        throw new Error(errorBody?.message || "PDF生成の開始に失敗しました。");
+      }
+      const { jobId } = await startResponse.json();
 
-      try {
-        for (let i = 0; i < pageElements.length; i++) {
-          // scale: 2で解像度を上げ、印刷用途でも文字が粗くならないようにする。
-          // no-printは@media printでのみ非表示になる（画面上は表示されたまま）ため、
-          // html2canvasが画面表示状態をそのまま撮影しないよう、cloneした文書側で明示的に隠す。
-          // ただしefuda-card-category（表面カードのかるた種別ラベル）は、実物の紙面には印刷しないが
-          // PDFでは種別を確認できるようにしたいという要望のため、隠さず残す
-          const canvas = await html2canvas(pageElements[i], {
-            scale: 2,
-            useCORS: true,
-            onclone: (clonedDoc) => {
-              clonedDoc.querySelectorAll(".no-print:not(.efuda-card-category)").forEach((el) => {
-                el.style.display = "none";
-              });
-            },
-          });
-          const imageData = canvas.toDataURL("image/png");
-          if (i > 0) {
-            pdf.addPage();
-          }
-          pdf.addImage(imageData, "PNG", 0, 0, A4_WIDTH_MM, A4_HEIGHT_MM);
+      let downloadUrl = null;
+      for (let attempt = 0; attempt < MAX_PDF_POLL_ATTEMPTS; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, PDF_POLL_INTERVAL_MS));
 
-          // 大量ページ印刷時（issue #PDF出力エラー）にcanvasの描画バッファが
-          // 累積してメモリを圧迫しないよう、使い終えたcanvasは都度サイズを0にして明示的に解放する
-          canvas.width = 0;
-          canvas.height = 0;
+        const statusResponse = await fetch(
+          `${API_BASE_URL}/generate-efuda-pdf-status?jobId=${encodeURIComponent(jobId)}` +
+          `&categoryLabel=${encodeURIComponent(categoryLabel || "karuta")}&side=${printSide}`
+        );
+        const statusBody = await statusResponse.json();
+
+        if (statusBody.status === "DONE") {
+          downloadUrl = statusBody.url;
+          break;
         }
-      } finally {
-        pageElements.forEach((el) => {
-          el.style.transform = "";
-        });
+        if (statusBody.status === "FAILED") {
+          throw new Error(statusBody.message || "PDFの生成に失敗しました。");
+        }
+        // IN_PROGRESSの場合はポーリングを継続する
       }
 
-      const sideLabel = printSide === "back" ? "裏面" : "表面";
-      pdf.save(`${categoryLabel || "karuta"}_絵札_${sideLabel}.pdf`);
+      if (!downloadUrl) {
+        throw new Error("PDFの生成がタイムアウトしました。時間をおいて再度お試しください。");
+      }
+
+      window.location.href = downloadUrl;
     } catch (error) {
       console.error("Error generating PDF:", error);
       alert("PDFの生成に失敗しました。");
@@ -180,7 +173,7 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
             </div>
           </div>
 
-          <div className="efuda-print-area">
+          <div className={`efuda-print-area ${isPdfExport ? "efuda-pdf-export" : ""}`}>
             {efudaPages.map((page, pageIndex) => (
               <div className="efuda-page-scaler" key={pageIndex}>
                 <div className="efuda-page">


### PR DESCRIPTION
## 背景
これまでPDF生成はブラウザ内でhtml2canvas+jsPDFにより1ページずつ高解像度canvasをラスタライズしていたため、選択枚数が多い（実測280枚程度）と端末メモリを使い果たしエラーになっていた。既に上限を150枚に引き下げる対症療法を行ったが、根本的には端末性能に依存する制約が残っていた。

## 変更内容
- `backend/efudaPdfHandler.js`（新規）: `generateEfudaPdf`（PDF生成ジョブを開始しjobIdを返す）・`renderEfudaPdfWorker`（ヘッドレスChromiumで`?view=print-efuda`のディープリンクへ遷移し`page.pdf()`でPDF化、S3へ保存）・`getEfudaPdfStatus`（S3上のオブジェクトの有無からジョブ状態を都度判定し、完了時は署名付きダウンロードURLを返す）の3関数を追加。Chromium起動・大量ページ描画はAPI Gatewayの29秒タイムアウトを超えうるため、`startSpeechRecognition`/`getSpeechRecognitionResult`と同じ「開始→ポーリング」構成にした
- `?view=print-efuda&category=...`は既存のURL初期化ロジックだけでディープリンクとして機能するため、印刷ビューのHTML/CSSを一切複製せず再利用できる。今回追加したのは`?side=back`対応のみ
- `backend/serverless.yml`: `EfudaPdfBucket`（1日で自動削除）、上記3関数、対応するIAM権限を追加。`@sparticuz/chromium`・`puppeteer-core`は`renderEfudaPdfWorker`でしか使わない重量級の依存のため、`package.individually`+`patterns`で他の関数のzipに巻き込まれないようにした
- `frontend/src/views/PrintEfudaView.jsx`: `downloadPdf()`をhtml2canvas/jsPDFのクライアント処理から、上記バックエンドAPIを呼び出しポーリングする方式に全面的に書き換えた。html2canvas/jsPDFは他に使用箇所がないため`frontend/package.json`からも削除した
- `frontend/src/App.css`: サーバーサイド生成時（`?pdfExport=1`）のみ`efuda-card-category`を印刷用CSSの中で例外的に表示するクラスを追加（実物の紙面には印刷しないがPDFでは種別を確認できる、という既存の挙動を再現するため）
- `frontend/src/App.jsx`: PDF生成が端末メモリに依存しなくなったため、選択可能な合計読み札数の上限を150枚から500枚に引き上げた（backend側でも同じ値をサーバー側の二次防御として検証する）

## 既知のリスク
`@sparticuz/chromium`・`puppeteer-core`の実機起動は、このセッションからは（AWSへのデプロイ権限が無いため）検証できていない。CIはユニットテストのみでネイティブバイナリの起動失敗は検知できないため、**マージ後に実運用環境で一度手動でのPDF生成確認を行うことを推奨する**。

## Test plan
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 全89件成功（バックエンドPDF生成のポーリングフロー、`?side`/`?pdfExport`ディープリンク対応の新規テストを含む）
- [x] `frontend`: `npm run build` 成功
- [x] `backend`: `npm run lint` エラー0件
- [x] `backend`: `npm test -- --run` 全1303件成功（`aws-sdk-client-mock`でS3/Lambda呼び出しをモックし、URL構築・上限検証・3状態のステータス分岐等を検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_