### PR TITLE
feat: クイズ大会モード（最小構成）を追加する

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@aws-sdk/client-apigatewaymanagementapi": "^3.958.0",
         "@aws-sdk/client-dynamodb": "^3.958.0",
         "@aws-sdk/client-lambda": "^3.1087.0",
         "@aws-sdk/client-polly": "^3.958.0",
@@ -61,6 +62,25 @@
         "@smithy/fetch-http-handler": "^5.6.4",
         "@smithy/node-http-handler": "^4.9.4",
         "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewaymanagementapi/-/client-apigatewaymanagementapi-3.1088.0.tgz",
+      "integrity": "sha512-pYKWjhCSIHvg05kMl4HxzdBpsxgqnjfHlAIcVndAwjA5YuIo+Os7iruJ1s0+mZGawBxKV2cJ9zuD38gGO7XydA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.69",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "vitest": "^4.0.0"
   },
   "dependencies": {
+    "@aws-sdk/client-apigatewaymanagementapi": "^3.958.0",
     "@aws-sdk/client-dynamodb": "^3.958.0",
     "@aws-sdk/client-lambda": "^3.1087.0",
     "@aws-sdk/client-polly": "^3.958.0",

--- a/backend/quizRoomHandler.js
+++ b/backend/quizRoomHandler.js
@@ -1,0 +1,257 @@
+const crypto = require("crypto");
+const { GetCommand, PutCommand, UpdateCommand, DeleteCommand, QueryCommand } = require("@aws-sdk/lib-dynamodb");
+const { ApiGatewayManagementApiClient, PostToConnectionCommand } = require("@aws-sdk/client-apigatewaymanagementapi");
+const { docClient, resolveAllowedOrigin } = require("./handler");
+
+// issue #470: クイズ大会モード（管理者ルーム開設＋複数端末同期）の最小構成。
+// 音声の同期再生・参加者一覧表示等は初回リリースのスコープ外とし、
+// 「同じ札が見える」ことだけをWebSocket経由でリアルタイムに実現する
+
+const ROOM_TTL_SECONDS = 60 * 60 * 24; // ルームは24時間で自動失効させる（無人ルームの残存を防ぐ）
+const CONNECTION_TTL_SECONDS = 60 * 60 * 24; // $disconnectが確実に呼ばれない異常切断時の保険
+// 誤読・誤入力しやすい0/O・1/I/Lはルームコードから除外する
+const ROOM_CODE_CHARS = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+const ROOM_CODE_LENGTH = 6;
+const MAX_CREATE_ROOM_ATTEMPTS = 5; // ルームコード衝突時の再採番の上限
+const MAX_STATE_JSON_LENGTH = 8000; // 状態データの肥大化・課金濫用を防ぐ上限
+
+function generateRoomCode() {
+  let code = "";
+  for (let i = 0; i < ROOM_CODE_LENGTH; i += 1) {
+    code += ROOM_CODE_CHARS[crypto.randomInt(ROOM_CODE_CHARS.length)];
+  }
+  return code;
+}
+
+// 管理者トークンはDynamoDBにハッシュのみ保存し、平文はレスポンス経由で
+// 管理者の端末にのみ渡す（DB漏洩時にトークンそのものが漏れないようにする）
+function hashToken(token) {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+// POST /quiz-room（REST API）。管理者用のルームを新規作成し、ルームIDと管理者トークンを返す
+exports.createQuizRoom = async (event) => {
+  const allowedOrigin = resolveAllowedOrigin(event);
+  try {
+    let roomId = null;
+    for (let attempt = 0; attempt < MAX_CREATE_ROOM_ATTEMPTS; attempt += 1) {
+      const candidate = generateRoomCode();
+      const existing = await docClient.send(new GetCommand({
+        TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+        Key: { roomId: candidate },
+      }));
+      if (!existing.Item) {
+        roomId = candidate;
+        break;
+      }
+    }
+    if (!roomId) {
+      return {
+        statusCode: 500,
+        headers: { "Access-Control-Allow-Origin": allowedOrigin },
+        body: JSON.stringify({ message: "ルームコードの採番に失敗しました。もう一度お試しください。" }),
+      };
+    }
+
+    const adminToken = crypto.randomUUID();
+    const now = Date.now();
+    await docClient.send(new PutCommand({
+      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+      Item: {
+        roomId,
+        adminTokenHash: hashToken(adminToken),
+        state: {},
+        createdAt: now,
+        ttl: Math.floor(now / 1000) + ROOM_TTL_SECONDS,
+      },
+    }));
+
+    return {
+      statusCode: 200,
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
+      body: JSON.stringify({ roomId, adminToken }),
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      statusCode: 500,
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
+      body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
+    };
+  }
+};
+
+// WebSocket $connect。roomId（必須）はクエリパラメータで受け取り、
+// adminTokenの有無・一致で管理者/参加者の役割を判定する
+exports.connectQuizRoom = async (event) => {
+  try {
+    const params = event.queryStringParameters || {};
+    const { roomId, adminToken } = params;
+    if (!roomId) {
+      return { statusCode: 400, body: "roomId is required" };
+    }
+
+    const room = await docClient.send(new GetCommand({
+      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+      Key: { roomId },
+    }));
+    if (!room.Item) {
+      return { statusCode: 404, body: "Room not found" };
+    }
+
+    let role = "participant";
+    if (adminToken) {
+      if (hashToken(adminToken) !== room.Item.adminTokenHash) {
+        return { statusCode: 403, body: "Invalid admin token" };
+      }
+      role = "admin";
+    }
+
+    const now = Date.now();
+    await docClient.send(new PutCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      Item: {
+        connectionId: event.requestContext.connectionId,
+        roomId,
+        role,
+        connectedAt: now,
+        ttl: Math.floor(now / 1000) + CONNECTION_TTL_SECONDS,
+      },
+    }));
+
+    return { statusCode: 200, body: "Connected" };
+  } catch (error) {
+    console.error(error);
+    return { statusCode: 500, body: "Internal Server Error" };
+  }
+};
+
+// WebSocket $disconnect
+exports.disconnectQuizRoom = async (event) => {
+  try {
+    await docClient.send(new DeleteCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      Key: { connectionId: event.requestContext.connectionId },
+    }));
+    return { statusCode: 200, body: "Disconnected" };
+  } catch (error) {
+    console.error(error);
+    return { statusCode: 500, body: "Internal Server Error" };
+  }
+};
+
+function buildManagementApiClient(event) {
+  const { domainName, stage } = event.requestContext;
+  return new ApiGatewayManagementApiClient({ endpoint: `https://${domainName}/${stage}` });
+}
+
+// 切断済み接続（GoneException/410）への送信は接続レコードを掃除し、他の接続への
+// ブロードキャストは継続できるよう例外を投げずfalseを返す
+async function postToConnection(managementApi, connectionId, payload) {
+  try {
+    await managementApi.send(new PostToConnectionCommand({
+      ConnectionId: connectionId,
+      Data: Buffer.from(JSON.stringify(payload)),
+    }));
+    return true;
+  } catch (error) {
+    if (error.name === "GoneException" || error.$metadata?.httpStatusCode === 410) {
+      await docClient.send(new DeleteCommand({
+        TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+        Key: { connectionId },
+      }));
+      return false;
+    }
+    throw error;
+  }
+}
+
+// WebSocketカスタムルート"sync"（routeSelectionExpression: $request.body.action）。
+// 接続直後にクライアント側から呼ばれ、現在のルーム状態を呼び出し元1件にだけ返す
+exports.syncQuizRoom = async (event) => {
+  try {
+    const connectionId = event.requestContext.connectionId;
+    const connection = await docClient.send(new GetCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      Key: { connectionId },
+    }));
+    if (!connection.Item) {
+      return { statusCode: 200, body: "" };
+    }
+
+    const room = await docClient.send(new GetCommand({
+      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+      Key: { roomId: connection.Item.roomId },
+    }));
+    if (!room.Item) {
+      return { statusCode: 200, body: "" };
+    }
+
+    const managementApi = buildManagementApiClient(event);
+    await postToConnection(managementApi, connectionId, {
+      type: "state",
+      state: room.Item.state || {},
+      role: connection.Item.role,
+    });
+
+    return { statusCode: 200, body: "" };
+  } catch (error) {
+    console.error(error);
+    return { statusCode: 500, body: "Internal Server Error" };
+  }
+};
+
+// WebSocketカスタムルート"updateState"。管理者のみが状態を更新でき、
+// 更新後はルーム内の全接続（管理者自身を含む）へブロードキャストする
+exports.updateQuizRoomState = async (event) => {
+  try {
+    const connectionId = event.requestContext.connectionId;
+    const connection = await docClient.send(new GetCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      Key: { connectionId },
+    }));
+    if (!connection.Item || connection.Item.role !== "admin") {
+      return { statusCode: 403, body: "Forbidden" };
+    }
+
+    const body = JSON.parse(event.body || "{}");
+    const newState = body.state;
+    const stateJson = JSON.stringify(newState ?? null);
+    if (!newState || typeof newState !== "object" || Array.isArray(newState) || stateJson.length > MAX_STATE_JSON_LENGTH) {
+      return { statusCode: 400, body: "Invalid state" };
+    }
+
+    const { roomId } = connection.Item;
+    await docClient.send(new UpdateCommand({
+      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+      Key: { roomId },
+      UpdateExpression: "SET #state = :state, #ttl = :ttl",
+      ExpressionAttributeNames: { "#state": "state", "#ttl": "ttl" },
+      ExpressionAttributeValues: {
+        ":state": newState,
+        ":ttl": Math.floor(Date.now() / 1000) + ROOM_TTL_SECONDS,
+      },
+    }));
+
+    const connections = await docClient.send(new QueryCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      IndexName: "roomId-index",
+      KeyConditionExpression: "roomId = :roomId",
+      ExpressionAttributeValues: { ":roomId": roomId },
+    }));
+
+    const managementApi = buildManagementApiClient(event);
+    await Promise.allSettled(
+      (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
+        type: "state",
+        state: newState,
+        role: conn.role,
+      }))
+    );
+
+    return { statusCode: 200, body: "" };
+  } catch (error) {
+    console.error(error);
+    return { statusCode: 500, body: "Internal Server Error" };
+  }
+};

--- a/backend/quizRoomHandler.test.js
+++ b/backend/quizRoomHandler.test.js
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, DeleteCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { ApiGatewayManagementApiClient, PostToConnectionCommand } from '@aws-sdk/client-apigatewaymanagementapi';
+import crypto from 'crypto';
+import {
+  createQuizRoom,
+  connectQuizRoom,
+  disconnectQuizRoom,
+  syncQuizRoom,
+  updateQuizRoomState,
+} from './quizRoomHandler';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const managementApiMock = mockClient(ApiGatewayManagementApiClient);
+
+process.env.QUIZ_ROOMS_TABLE_NAME = 'TestQuizRooms';
+process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME = 'TestQuizRoomConnections';
+
+function wsEvent({ connectionId = 'conn-1', domainName = 'abc123.execute-api.ap-northeast-1.amazonaws.com', stage = 'dev', body } = {}) {
+  return {
+    requestContext: { connectionId, domainName, stage },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  };
+}
+
+beforeEach(() => {
+  ddbMock.reset();
+  managementApiMock.reset();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('createQuizRoom', () => {
+  it('creates a room with a unique code and returns roomId/adminToken', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+    ddbMock.on(PutCommand).resolves({});
+
+    const response = await createQuizRoom({ body: '{}' });
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body.roomId).toMatch(/^[A-Z2-9]{6}$/);
+    expect(typeof body.adminToken).toBe('string');
+
+    const putCall = ddbMock.commandCalls(PutCommand)[0].args[0].input;
+    expect(putCall.TableName).toBe('TestQuizRooms');
+    expect(putCall.Item.roomId).toBe(body.roomId);
+    expect(putCall.Item.state).toEqual({});
+    // 平文のadminTokenはDBに保存せず、ハッシュのみ保存する
+    expect(putCall.Item.adminTokenHash).not.toBe(body.adminToken);
+    expect(putCall.Item.adminTokenHash).toBe(
+      crypto.createHash('sha256').update(body.adminToken).digest('hex')
+    );
+  });
+
+  it('retries room code generation on collision and gives up after the attempt limit', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { roomId: 'TAKEN1' } });
+
+    const response = await createQuizRoom({ body: '{}' });
+
+    expect(response.statusCode).toBe(500);
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  it('handles errors', async () => {
+    ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
+    const response = await createQuizRoom({ body: '{}' });
+    expect(response.statusCode).toBe(500);
+  });
+});
+
+describe('connectQuizRoom', () => {
+  it('rejects when roomId is missing', async () => {
+    const response = await connectQuizRoom(wsEvent());
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('rejects when the room does not exist', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+    const response = await connectQuizRoom({
+      ...wsEvent(),
+      queryStringParameters: { roomId: 'NOPE01' },
+    });
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('connects as a participant when no adminToken is given', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { roomId: 'ROOM01', adminTokenHash: 'hash' } });
+    ddbMock.on(PutCommand).resolves({});
+
+    const response = await connectQuizRoom({
+      ...wsEvent({ connectionId: 'conn-participant' }),
+      queryStringParameters: { roomId: 'ROOM01' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const putCall = ddbMock.commandCalls(PutCommand)[0].args[0].input;
+    expect(putCall.Item).toMatchObject({ connectionId: 'conn-participant', roomId: 'ROOM01', role: 'participant' });
+  });
+
+  it('connects as admin when adminToken matches the stored hash', async () => {
+    const adminToken = 'correct-token';
+    const adminTokenHash = crypto.createHash('sha256').update(adminToken).digest('hex');
+    ddbMock.on(GetCommand).resolves({ Item: { roomId: 'ROOM01', adminTokenHash } });
+    ddbMock.on(PutCommand).resolves({});
+
+    const response = await connectQuizRoom({
+      ...wsEvent({ connectionId: 'conn-admin' }),
+      queryStringParameters: { roomId: 'ROOM01', adminToken },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const putCall = ddbMock.commandCalls(PutCommand)[0].args[0].input;
+    expect(putCall.Item.role).toBe('admin');
+  });
+
+  it('rejects when adminToken does not match the stored hash', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { roomId: 'ROOM01', adminTokenHash: 'correct-hash' } });
+
+    const response = await connectQuizRoom({
+      ...wsEvent(),
+      queryStringParameters: { roomId: 'ROOM01', adminToken: 'wrong-token' },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  it('handles errors', async () => {
+    ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
+    const response = await connectQuizRoom({
+      ...wsEvent(),
+      queryStringParameters: { roomId: 'ROOM01' },
+    });
+    expect(response.statusCode).toBe(500);
+  });
+});
+
+describe('disconnectQuizRoom', () => {
+  it('deletes the connection record', async () => {
+    ddbMock.on(DeleteCommand).resolves({});
+    const response = await disconnectQuizRoom(wsEvent({ connectionId: 'conn-1' }));
+    expect(response.statusCode).toBe(200);
+    expect(ddbMock.commandCalls(DeleteCommand)[0].args[0].input.Key).toEqual({ connectionId: 'conn-1' });
+  });
+
+  it('handles errors', async () => {
+    ddbMock.on(DeleteCommand).rejects(new Error('DynamoDB error'));
+    const response = await disconnectQuizRoom(wsEvent());
+    expect(response.statusCode).toBe(500);
+  });
+});
+
+describe('syncQuizRoom', () => {
+  it('does nothing when the connection is unknown (e.g. already disconnected)', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+    const response = await syncQuizRoom(wsEvent());
+    expect(response.statusCode).toBe(200);
+    expect(managementApiMock.commandCalls(PostToConnectionCommand)).toHaveLength(0);
+  });
+
+  it('sends the current room state back to the caller only', async () => {
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
+      Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' },
+    });
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({
+      Item: { roomId: 'ROOM01', state: { type: 'phrase', phrase: { id: 'p1' } } },
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    const response = await syncQuizRoom(wsEvent({ connectionId: 'conn-1' }));
+
+    expect(response.statusCode).toBe(200);
+    const call = managementApiMock.commandCalls(PostToConnectionCommand)[0].args[0].input;
+    expect(call.ConnectionId).toBe('conn-1');
+    const payload = JSON.parse(Buffer.from(call.Data).toString('utf-8'));
+    expect(payload).toEqual({ type: 'state', state: { type: 'phrase', phrase: { id: 'p1' } }, role: 'participant' });
+  });
+
+  it('handles errors', async () => {
+    ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
+    const response = await syncQuizRoom(wsEvent());
+    expect(response.statusCode).toBe(500);
+  });
+});
+
+describe('updateQuizRoomState', () => {
+  it('rejects when the caller is not an admin', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' } });
+    const response = await updateQuizRoomState(wsEvent({ body: { state: { type: 'phrase' } } }));
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('rejects when the connection record is missing', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+    const response = await updateQuizRoomState(wsEvent({ body: { state: { type: 'phrase' } } }));
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('rejects an invalid (non-object) state', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'admin' } });
+    const response = await updateQuizRoomState(wsEvent({ body: { state: 'not-an-object' } }));
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('rejects an oversized state payload', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'admin' } });
+    const response = await updateQuizRoomState(wsEvent({ body: { state: { big: 'x'.repeat(9000) } } }));
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('updates room state and broadcasts it to every connection in the room', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' } });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+        { connectionId: 'conn-participant', roomId: 'ROOM01', role: 'participant' },
+      ],
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    const newState = { type: 'phrase', phrase: { id: 'p1', category: 'Cat1' } };
+    const response = await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
+
+    expect(response.statusCode).toBe(200);
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.Key).toEqual({ roomId: 'ROOM01' });
+    expect(updateCall.ExpressionAttributeValues[':state']).toEqual(newState);
+
+    const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
+    expect(postCalls).toHaveLength(2);
+    const targets = postCalls.map((call) => call.args[0].input.ConnectionId).sort();
+    expect(targets).toEqual(['conn-admin', 'conn-participant']);
+    const payload = JSON.parse(Buffer.from(postCalls[0].args[0].input.Data).toString('utf-8'));
+    expect(payload.state).toEqual(newState);
+  });
+
+  it('removes a stale connection record when broadcasting hits a GoneException, without failing the whole update', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' } });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({
+      Items: [{ connectionId: 'conn-stale', roomId: 'ROOM01', role: 'participant' }],
+    });
+    ddbMock.on(DeleteCommand).resolves({});
+    managementApiMock.on(PostToConnectionCommand).rejects(Object.assign(new Error('Gone'), { name: 'GoneException' }));
+
+    const response = await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: { type: 'phrase' } } }));
+
+    expect(response.statusCode).toBe(200);
+    expect(ddbMock.commandCalls(DeleteCommand)[0].args[0].input.Key).toEqual({ connectionId: 'conn-stale' });
+  });
+
+  it('handles unexpected errors', async () => {
+    ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
+    const response = await updateQuizRoomState(wsEvent({ body: { state: { type: 'phrase' } } }));
+    expect(response.statusCode).toBe(500);
+  });
+});

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -21,6 +21,8 @@ provider:
     COMMENTS_TABLE_NAME: ${self:custom.commentsTableName}
     POLLY_CACHE_TABLE_NAME: ${self:custom.pollyCacheTableName} # 追加
     EFUDA_PDF_BUCKET_NAME: ${self:custom.efudaPdfBucketName}-${aws:accountId} # 追加（絵札PDFのサーバーサイド生成）
+    QUIZ_ROOMS_TABLE_NAME: ${self:custom.quizRoomsTableName} # 追加（クイズ大会モード）
+    QUIZ_ROOM_CONNECTIONS_TABLE_NAME: ${self:custom.quizRoomConnectionsTableName} # 追加（クイズ大会モード）
   iam:
     role:
       statements:
@@ -47,12 +49,38 @@ provider:
           Action:
             - s3:GetObject
           Resource: !Sub "${EfudaPdfBucket.Arn}/*"
+        - Effect: Allow # 追加（クイズ大会モード: ルーム・接続情報の読み書き）
+          Action:
+            - dynamodb:GetItem
+            - dynamodb:PutItem
+            - dynamodb:UpdateItem
+          Resource:
+            - !GetAtt QuizRoomsTable.Arn
+        - Effect: Allow # 追加（クイズ大会モード: 接続情報の読み書き・ルーム単位の一覧取得）
+          Action:
+            - dynamodb:GetItem
+            - dynamodb:PutItem
+            - dynamodb:DeleteItem
+            - dynamodb:Query
+          Resource:
+            - !GetAtt QuizRoomConnectionsTable.Arn
+            - !Sub "${QuizRoomConnectionsTable.Arn}/index/*"
+        - Effect: Allow # 追加（クイズ大会モード: WebSocket接続への状態ブロードキャスト）
+          # api-id/stageをワイルドカードにしているのはAWS公式ドキュメントで案内されている定型パターン。
+          # Serverless Frameworkが自動生成するWebSocket APIの論理ID（未確定・デプロイ時に決まる）を
+          # !Subで直接参照する方式は、名前を誤ると循環参照等でデプロイ自体が壊れるリスクがあるため
+          # 採用しない（このAWSアカウントは本サービス専用でほかにWebSocket APIを持たない前提）
+          Action:
+            - execute-api:ManageConnections
+          Resource: "arn:aws:execute-api:${aws:region}:${aws:accountId}:*/*/POST/@connections/*"
 
 custom:
   tableName: karuta-phrases
   commentsTableName: karuta-comments
   pollyCacheTableName: karuta-polly-cache # 追加
   efudaPdfBucketName: karuta-efuda-pdf # 追加（絵札PDFのサーバーサイド生成）。バケット名はグローバルに一意である必要があるためアカウントIDを付与する
+  quizRoomsTableName: karuta-quiz-rooms # 追加（クイズ大会モード）
+  quizRoomConnectionsTableName: karuta-quiz-room-connections # 追加（クイズ大会モード）
   allowedOrigins:
     - https://bamiyanapp.github.io
     - http://localhost:5173 # npm run dev（Vite開発サーバー）
@@ -151,6 +179,34 @@ functions:
           method: get
           cors:
             origins: ${self:custom.allowedOrigins}
+  createQuizRoom: # 追加（クイズ大会モード）。管理者用ルームを新規作成し、ルームIDと管理者トークンを返す
+    handler: quizRoomHandler.createQuizRoom
+    events:
+      - http:
+          path: quiz-room
+          method: post
+          cors:
+            origins: ${self:custom.allowedOrigins}
+  connectQuizRoom: # 追加（クイズ大会モード）。WebSocket接続時にroomId/adminTokenから役割を判定する
+    handler: quizRoomHandler.connectQuizRoom
+    events:
+      - websocket:
+          route: $connect
+  disconnectQuizRoom: # 追加（クイズ大会モード）
+    handler: quizRoomHandler.disconnectQuizRoom
+    events:
+      - websocket:
+          route: $disconnect
+  syncQuizRoom: # 追加（クイズ大会モード）。接続直後にクライアントから呼ばれ、現在の状態を1件返す
+    handler: quizRoomHandler.syncQuizRoom
+    events:
+      - websocket:
+          route: sync
+  updateQuizRoomState: # 追加（クイズ大会モード）。管理者のみ状態を更新でき、ルーム内全接続へブロードキャストする
+    handler: quizRoomHandler.updateQuizRoomState
+    events:
+      - websocket:
+          route: updateState
 
 resources:
   Resources:
@@ -214,6 +270,43 @@ resources:
             - Id: ExpireEfudaPdfObjects
               Status: Enabled
               ExpirationInDays: 1
+    QuizRoomsTable: # 追加（クイズ大会モード）。roomId→管理者トークンのハッシュ・現在の状態を保持する
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:custom.quizRoomsTableName}
+        AttributeDefinitions:
+          - AttributeName: roomId
+            AttributeType: S
+        KeySchema:
+          - AttributeName: roomId
+            KeyType: HASH
+        BillingMode: PAY_PER_REQUEST
+        TimeToLiveSpecification: # 無人ルームが際限なく残らないよう、一定期間後に自動削除する
+          AttributeName: ttl
+          Enabled: true
+    QuizRoomConnectionsTable: # 追加（クイズ大会モード）。connectionId→roomId・役割（admin/participant）を保持する
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:custom.quizRoomConnectionsTableName}
+        AttributeDefinitions:
+          - AttributeName: connectionId
+            AttributeType: S
+          - AttributeName: roomId
+            AttributeType: S
+        KeySchema:
+          - AttributeName: connectionId
+            KeyType: HASH
+        GlobalSecondaryIndexes: # 状態更新時、ルーム内の全接続へブロードキャストするために必要
+          - IndexName: roomId-index
+            KeySchema:
+              - AttributeName: roomId
+                KeyType: HASH
+            Projection:
+              ProjectionType: ALL
+        BillingMode: PAY_PER_REQUEST
+        TimeToLiveSpecification: # $disconnectが確実に呼ばれない異常切断時の保険として自動削除する
+          AttributeName: ttl
+          Enabled: true
     RenderEfudaPdfWorkerRole: # 追加（絵札PDFのサーバーサイド生成）。renderEfudaPdfWorker関数専用のロール
       # （provider.iam.roleの共有ロールを使うと、共有ロールのポリシーがこの関数自身のArnを
       # 参照する形になり循環依存でデプロイが失敗するため、専用ロールに分離している）

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "qrcode": "^1.5.4",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-markdown": "^10.1.0"
@@ -3343,7 +3344,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3353,7 +3353,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3684,6 +3683,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001762",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
@@ -3782,11 +3790,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3799,7 +3817,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
@@ -3994,6 +4011,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -4089,6 +4115,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -4133,6 +4165,12 @@
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "8.0.0",
@@ -4878,6 +4916,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5470,6 +5517,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -7068,6 +7124,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -7130,7 +7195,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7178,6 +7242,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -7288,6 +7361,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/react": {
@@ -7504,6 +7594,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -7513,6 +7612,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -7681,6 +7786,12 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -7972,6 +8083,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -8087,6 +8212,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-comments": {
@@ -9028,6 +9165,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.22",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
@@ -9455,6 +9598,20 @@
         "workbox-core": "7.4.1"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -9472,12 +9629,105 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "deploy": "npx gh-pages -d dist"
   },
   "dependencies": {
+    "qrcode": "^1.5.4",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-markdown": "^10.1.0"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import "./App.css";
 import karutaImage from "./assets/karuta_inubou.png";
-import { API_BASE_URL } from "./config";
+import { API_BASE_URL, WS_BASE_URL } from "./config";
 import { useLocalStorageState } from "./hooks/useLocalStorageState";
 import { useSessionStorageState } from "./hooks/useSessionStorageState";
 import { useUrlQuerySync, parseCategoriesParam } from "./hooks/useUrlQuerySync";
@@ -11,6 +11,7 @@ import PrintEfudaView from "./views/PrintEfudaView";
 import AllPhrasesView from "./views/AllPhrasesView";
 import CommentsView from "./views/CommentsView";
 import ChangelogView from "./views/ChangelogView";
+import QuizRoomView from "./views/QuizRoomView";
 
 const HISTORY_STORAGE_KEY = "historyByCategory";
 const PLAYERS_STORAGE_KEY = "players";
@@ -1060,6 +1061,10 @@ function App() {
     return <ChangelogView setView={setView} />;
   }
 
+  if (view === "quiz-room") {
+    return <QuizRoomView setView={setView} apiBaseUrl={API_BASE_URL} wsBaseUrl={WS_BASE_URL} />;
+  }
+
   if (selectedCategories.length === 0 && !division) {
     return (
       <div className="container py-5 mx-auto">
@@ -1095,6 +1100,9 @@ function App() {
           </button>
           <button onClick={() => setView("changelog")} className="btn btn-link text-decoration-none text-muted small">
             更新履歴を見る
+          </button>
+          <button onClick={() => setView("quiz-room")} className="btn btn-link text-decoration-none text-muted small">
+            クイズ大会モード
           </button>
         </div>
       </div>

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,3 +1,9 @@
 export const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ||
   "https://akmnirkx3m.execute-api.ap-northeast-1.amazonaws.com/dev";
+
+// クイズ大会モード（issue #470）のWebSocket API。REST APIと異なりAPI Gateway ID・エンドポイントが
+// 新規に払い出されるため、初回デプロイ完了までは確定した既定値を置けない。デプロイ後、
+// `npx serverless deploy`出力のWebSocket endpointをVITE_WS_BASE_URLとして設定するか、
+// この既定値（null）を実際の"wss://..."エンドポイントに書き換える
+export const WS_BASE_URL = import.meta.env.VITE_WS_BASE_URL || null;

--- a/frontend/src/hooks/useQuizRoomSync.js
+++ b/frontend/src/hooks/useQuizRoomSync.js
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const RECONNECT_DELAY_MS = 3000;
+const MAX_RECONNECT_ATTEMPTS = 5; // 際限ない再接続ループを防ぐための上限
+
+// クイズ大会モード（issue #470）のWebSocket接続を管理する。adminTokenを渡すと管理者として、
+// 渡さなければ参加者（閲覧専用）として接続する。サーバーから状態（{type:"state", state, role}）を
+// 受け取るたびonStateを呼ぶ。管理者はbroadcastStateで新しい状態を送信できる
+export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState }) {
+  const [internalStatus, setInternalStatus] = useState("idle"); // connecting|connected|error（idleはwsBaseUrl/roomId未設定時に導出する）
+  const connectionStatus = (!wsBaseUrl || !roomId) ? "idle" : internalStatus;
+  const wsRef = useRef(null);
+  const onStateRef = useRef(onState);
+  const reconnectAttemptsRef = useRef(0);
+  const reconnectTimeoutRef = useRef(null);
+  const closedByCleanupRef = useRef(false);
+
+  useEffect(() => {
+    onStateRef.current = onState;
+  }, [onState]);
+
+  useEffect(() => {
+    if (!wsBaseUrl || !roomId) {
+      return undefined;
+    }
+    closedByCleanupRef.current = false;
+    reconnectAttemptsRef.current = 0;
+
+    const connect = () => {
+      setInternalStatus("connecting");
+
+      const url = new URL(wsBaseUrl);
+      url.searchParams.set("roomId", roomId);
+      if (adminToken) {
+        url.searchParams.set("adminToken", adminToken);
+      }
+
+      const ws = new WebSocket(url.toString());
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        reconnectAttemptsRef.current = 0;
+        setInternalStatus("connected");
+        ws.send(JSON.stringify({ action: "sync" }));
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data?.type === "state") {
+            onStateRef.current?.(data.state, data.role);
+          }
+        } catch (error) {
+          console.error("Failed to parse quiz room message:", error);
+        }
+      };
+
+      ws.onerror = () => {
+        setInternalStatus("error");
+      };
+
+      ws.onclose = () => {
+        if (closedByCleanupRef.current) {
+          return;
+        }
+        if (reconnectAttemptsRef.current >= MAX_RECONNECT_ATTEMPTS) {
+          setInternalStatus("error");
+          return;
+        }
+        reconnectAttemptsRef.current += 1;
+        setInternalStatus("connecting");
+        reconnectTimeoutRef.current = setTimeout(connect, RECONNECT_DELAY_MS);
+      };
+    };
+
+    connect();
+
+    return () => {
+      closedByCleanupRef.current = true;
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+      }
+      wsRef.current?.close();
+    };
+  }, [wsBaseUrl, roomId, adminToken]);
+
+  const broadcastState = useCallback((state) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ action: "updateState", state }));
+    }
+  }, []);
+
+  return { connectionStatus, broadcastState };
+}

--- a/frontend/src/hooks/useQuizRoomSync.test.js
+++ b/frontend/src/hooks/useQuizRoomSync.test.js
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useQuizRoomSync } from './useQuizRoomSync';
+
+class MockWebSocket {
+  static OPEN = 1;
+  static instances = [];
+
+  constructor(url) {
+    this.url = url;
+    this.readyState = 0;
+    this.sent = [];
+    this.onopen = null;
+    this.onmessage = null;
+    this.onerror = null;
+    this.onclose = null;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = 3;
+    this.onclose?.();
+  }
+
+  // テスト用ヘルパー（実ブラウザのWebSocketイベントを模擬する）
+  triggerOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  triggerMessage(data) {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+
+  triggerClose() {
+    this.readyState = 3;
+    this.onclose?.();
+  }
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  window.WebSocket = MockWebSocket;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useQuizRoomSync', () => {
+  it('stays idle and opens no connection when wsBaseUrl or roomId is missing', () => {
+    const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: null, roomId: 'ROOM01', onState: vi.fn() }));
+    expect(result.current.connectionStatus).toBe('idle');
+    expect(MockWebSocket.instances).toHaveLength(0);
+  });
+
+  it('connects with roomId in the query string and no adminToken for a participant', () => {
+    renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    const url = new URL(MockWebSocket.instances[0].url);
+    expect(url.searchParams.get('roomId')).toBe('ROOM01');
+    expect(url.searchParams.has('adminToken')).toBe(false);
+  });
+
+  it('includes adminToken in the query string for an admin', () => {
+    renderHook(() => useQuizRoomSync({
+      wsBaseUrl: 'wss://example.com/dev',
+      roomId: 'ROOM01',
+      adminToken: 'secret-token',
+      onState: vi.fn(),
+    }));
+
+    const url = new URL(MockWebSocket.instances[0].url);
+    expect(url.searchParams.get('adminToken')).toBe('secret-token');
+  });
+
+  it('sends a sync request and becomes connected on open', () => {
+    const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+    });
+
+    expect(result.current.connectionStatus).toBe('connected');
+    expect(MockWebSocket.instances[0].sent).toEqual([JSON.stringify({ action: 'sync' })]);
+  });
+
+  it('calls onState with the received state and role', () => {
+    const onState = vi.fn();
+    renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState }));
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+      MockWebSocket.instances[0].triggerMessage({ type: 'state', state: { type: 'phrase', phrase: { id: 'p1' } }, role: 'participant' });
+    });
+
+    expect(onState).toHaveBeenCalledWith({ type: 'phrase', phrase: { id: 'p1' } }, 'participant');
+  });
+
+  it('ignores malformed messages without throwing', () => {
+    const onState = vi.fn();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState }));
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+      MockWebSocket.instances[0].onmessage({ data: 'not-json' });
+    });
+
+    expect(onState).not.toHaveBeenCalled();
+  });
+
+  it('broadcastState sends updateState only while the connection is open', () => {
+    const { result } = renderHook(() => useQuizRoomSync({
+      wsBaseUrl: 'wss://example.com/dev',
+      roomId: 'ROOM01',
+      adminToken: 'secret-token',
+      onState: vi.fn(),
+    }));
+
+    act(() => {
+      result.current.broadcastState({ type: 'phrase' });
+    });
+    expect(MockWebSocket.instances[0].sent).toEqual([]);
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+      result.current.broadcastState({ type: 'phrase', phrase: { id: 'p1' } });
+    });
+
+    expect(MockWebSocket.instances[0].sent).toContain(
+      JSON.stringify({ action: 'updateState', state: { type: 'phrase', phrase: { id: 'p1' } } })
+    );
+  });
+
+  it('reconnects after a close and gives up after the retry limit', async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const instance = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+      act(() => {
+        instance.triggerClose();
+      });
+      expect(result.current.connectionStatus).toBe('connecting');
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+    }
+
+    expect(MockWebSocket.instances).toHaveLength(6); // 初回接続 + 5回の再接続
+    act(() => {
+      MockWebSocket.instances[MockWebSocket.instances.length - 1].triggerClose();
+    });
+    expect(result.current.connectionStatus).toBe('error');
+  });
+
+  it('does not reconnect after the hook unmounts (cleanup closes the connection)', () => {
+    vi.useFakeTimers();
+    const { unmount } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+});

--- a/frontend/src/hooks/useUrlQuerySync.js
+++ b/frontend/src/hooks/useUrlQuerySync.js
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 export const parseCategoriesParam = (value) => (value ? value.split(",").filter(Boolean).map(decodeURIComponent) : []);
 export const serializeCategoriesParam = (categories) => categories.map(encodeURIComponent).join(",");
 
-const URL_SYNCED_VIEWS = ["comments", "changelog", "all-phrases", "print-efuda"];
+const URL_SYNCED_VIEWS = ["comments", "changelog", "all-phrases", "print-efuda", "quiz-room"];
 
 // selectedCategories/division/detailPhraseId/viewをURLクエリパラメータと双方向に同期する。
 // (state→URL、およびブラウザの戻る/進む操作によるURL→stateの両方向)

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -1,0 +1,306 @@
+import { useEffect, useMemo, useState } from "react";
+import QRCode from "qrcode";
+import { useQuizRoomSync } from "../hooks/useQuizRoomSync";
+
+// クイズ大会モード（issue #470）の最小構成:
+// 管理者がルームを開設しQRコード/ルームコードで参加者を招待する。参加者は閲覧専用で、
+// 管理者が「次の札」を進めるたびに全端末へ同じ札が同期表示される。
+// 読み上げ音声の同期再生・参加者一覧表示は初回リリースのスコープ外（issue本文に明記）。
+
+// シャッフルはFisher-Yatesで実施する（Array.prototype.sortのランダム比較関数は
+// 実装依存で偏りが出るため使わない）
+function shuffle(array) {
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+const CONNECTION_STATUS_LABEL = {
+  idle: "未接続",
+  connecting: "接続中...",
+  connected: "接続済み",
+  error: "接続できませんでした",
+};
+
+function QuizRoomView({ setView, apiBaseUrl, wsBaseUrl }) {
+  const urlRoomId = useMemo(() => new URLSearchParams(window.location.search).get("roomId"), []);
+  const [joinRoomId, setJoinRoomId] = useState(urlRoomId);
+  const [manualRoomId, setManualRoomId] = useState("");
+
+  const [room, setRoom] = useState(null); // { roomId, adminToken }（管理者がルーム作成後にのみ設定される）
+  const [creatingRoom, setCreatingRoom] = useState(false);
+  const [createError, setCreateError] = useState(null);
+  const [qrDataUrl, setQrDataUrl] = useState(null);
+
+  const [categories, setCategories] = useState([]);
+  const [selectedCategories, setSelectedCategories] = useState([]);
+  const [queue, setQueue] = useState(null); // カテゴリ選択後にシャッフルされた札の配列
+  const [queueIndex, setQueueIndex] = useState(0);
+  const [loadingPhrase, setLoadingPhrase] = useState(false);
+
+  const [roomState, setRoomState] = useState(null);
+
+  const isAdmin = !joinRoomId;
+  const activeRoomId = joinRoomId || room?.roomId || null;
+
+  const { connectionStatus, broadcastState } = useQuizRoomSync({
+    wsBaseUrl,
+    roomId: activeRoomId,
+    adminToken: room?.adminToken,
+    onState: setRoomState,
+  });
+
+  useEffect(() => {
+    if (isAdmin && categories.length === 0 && wsBaseUrl) {
+      fetch(`${apiBaseUrl}/get-categories`)
+        .then((res) => res.json())
+        .then((data) => setCategories(data.categories || []))
+        .catch((error) => console.error("Failed to fetch categories:", error));
+    }
+  }, [isAdmin, categories.length, apiBaseUrl, wsBaseUrl]);
+
+  useEffect(() => {
+    if (!room?.roomId) {
+      setQrDataUrl(null);
+      return;
+    }
+    const inviteUrl = `${window.location.origin}${window.location.pathname}?view=quiz-room&roomId=${room.roomId}`;
+    QRCode.toDataURL(inviteUrl)
+      .then(setQrDataUrl)
+      .catch((error) => console.error("Failed to generate QR code:", error));
+  }, [room]);
+
+  if (!wsBaseUrl) {
+    return (
+      <div className="container py-5 mx-auto text-center">
+        <p className="text-muted mb-4">クイズ大会モードは現在準備中です。しばらくお待ちください。</p>
+        <button onClick={() => setView("game")} className="btn btn-outline-dark rounded-pill">← 戻る</button>
+      </div>
+    );
+  }
+
+  const createRoom = async () => {
+    setCreatingRoom(true);
+    setCreateError(null);
+    try {
+      const response = await fetch(`${apiBaseUrl}/quiz-room`, { method: "POST" });
+      if (!response.ok) {
+        throw new Error("ルームの作成に失敗しました");
+      }
+      const data = await response.json();
+      setRoom({ roomId: data.roomId, adminToken: data.adminToken });
+    } catch (error) {
+      console.error("Failed to create quiz room:", error);
+      setCreateError("ルームの作成に失敗しました。もう一度お試しください。");
+    } finally {
+      setCreatingRoom(false);
+    }
+  };
+
+  const toggleCategory = (name) => {
+    setSelectedCategories((prev) => (
+      prev.includes(name) ? prev.filter((c) => c !== name) : [...prev, name]
+    ));
+  };
+
+  const startQuiz = async () => {
+    try {
+      const results = await Promise.all(
+        selectedCategories.map(async (category) => {
+          const response = await fetch(`${apiBaseUrl}/get-phrases-list?category=${encodeURIComponent(category)}`);
+          const data = await response.json();
+          return (data.phrases || []).map((p) => ({ id: p.id, category }));
+        })
+      );
+      const shuffled = shuffle(results.flat());
+      setQueue(shuffled);
+      setQueueIndex(0);
+      broadcastState({ type: "waiting", categoryLabel: selectedCategories.join("・") });
+    } catch (error) {
+      console.error("Failed to start quiz:", error);
+      alert("読み札の取得に失敗しました。もう一度お試しください。");
+    }
+  };
+
+  const advanceToNextPhrase = async () => {
+    if (!queue || queueIndex >= queue.length) {
+      return;
+    }
+    setLoadingPhrase(true);
+    try {
+      const target = queue[queueIndex];
+      const response = await fetch(
+        `${apiBaseUrl}/get-phrase?id=${encodeURIComponent(target.id)}&category=${encodeURIComponent(target.category)}` +
+        `&repeatCount=2&speechRate=90%25&lang=ja&voiceId=Mizuki&announceCategory=${selectedCategories.length > 1}`
+      );
+      const phrase = await response.json();
+      if (response.ok) {
+        if (phrase.audioData) {
+          new Audio(phrase.audioData).play().catch((error) => console.error("Audio playback failed:", error));
+        }
+        broadcastState({
+          type: "phrase",
+          phrase: {
+            id: phrase.id,
+            category: phrase.category,
+            kana: phrase.kana,
+            phrase: phrase.phrase,
+            level: phrase.level,
+            answer: phrase.answer,
+          },
+        });
+      }
+      const nextIndex = queueIndex + 1;
+      setQueueIndex(nextIndex);
+      if (nextIndex >= queue.length) {
+        broadcastState({ type: "finished" });
+      }
+    } catch (error) {
+      console.error("Failed to advance to the next phrase:", error);
+      alert("札の取得に失敗しました。もう一度お試しください。");
+    } finally {
+      setLoadingPhrase(false);
+    }
+  };
+
+  const renderConnectionStatus = () => (
+    <p className="text-muted small mb-3">
+      接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}
+    </p>
+  );
+
+  // 参加者（閲覧専用）
+  if (!isAdmin) {
+    return (
+      <div className="container py-5 mx-auto text-center">
+        <header className="mb-4">
+          <h1 className="h4 fw-bold">クイズ大会モード（参加者）</h1>
+          <p className="text-muted small">ルーム: {joinRoomId}</p>
+        </header>
+        {renderConnectionStatus()}
+        {(!roomState || Object.keys(roomState).length === 0) && (
+          <p className="text-muted py-5">ホストの操作を待っています...</p>
+        )}
+        {roomState?.type === "waiting" && (
+          <p className="text-muted py-5">まもなく開始します（{roomState.categoryLabel}）...</p>
+        )}
+        {roomState?.type === "phrase" && (
+          <div className="yomifuda-container mx-auto">
+            <div className="yomifuda">
+              <div className="yomifuda-kana"><span>{roomState.phrase.kana || roomState.phrase.phrase?.[0]}</span></div>
+              <div className="yomifuda-phrase">{roomState.phrase.phrase}</div>
+              {roomState.phrase.level !== "-" && <div className="yomifuda-level fw-bold">レベル: {roomState.phrase.level}</div>}
+            </div>
+          </div>
+        )}
+        {roomState?.type === "finished" && (
+          <p className="text-muted py-5">すべての読み札が終わりました。お疲れ様でした！</p>
+        )}
+      </div>
+    );
+  }
+
+  // 管理者: ルーム未作成（ロビー画面。ルームコードを直接入力しての参加も許可する）
+  if (!room) {
+    return (
+      <div className="container py-5 mx-auto">
+        <header className="text-center mb-4">
+          <h1 className="h4 fw-bold">クイズ大会モード</h1>
+        </header>
+        <main className="mx-auto" style={{ maxWidth: "480px" }}>
+          <div className="text-center mb-5">
+            <button onClick={createRoom} disabled={creatingRoom} className="btn btn-lg btn-karuta rounded-pill px-4 py-3 fw-bold shadow-sm">
+              {creatingRoom ? "作成中..." : "管理者としてルームを開設する"}
+            </button>
+            {createError && <p className="text-danger small mt-2">{createError}</p>}
+          </div>
+          <div className="text-center">
+            <p className="text-muted small mb-2">ルームコードを知っている場合はこちら</p>
+            <div className="d-flex gap-2 justify-content-center">
+              <input
+                type="text"
+                value={manualRoomId}
+                onChange={(e) => setManualRoomId(e.target.value.toUpperCase())}
+                placeholder="ルームコード"
+                className="form-control"
+                style={{ maxWidth: "160px" }}
+              />
+              <button
+                onClick={() => setJoinRoomId(manualRoomId)}
+                disabled={!manualRoomId}
+                className="btn btn-outline-dark rounded-pill"
+              >
+                参加する
+              </button>
+            </div>
+          </div>
+          <div className="text-center mt-5">
+            <button onClick={() => setView("game")} className="btn btn-link text-muted text-decoration-none">← 戻る</button>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  // 管理者: ルーム作成済み
+  return (
+    <div className="container py-5 mx-auto">
+      <header className="text-center mb-4">
+        <h1 className="h4 fw-bold">クイズ大会モード（管理者）</h1>
+        <p className="h2 fw-bold notranslate">{room.roomId}</p>
+        {qrDataUrl && <img src={qrDataUrl} alt="参加用QRコード" style={{ width: "200px", height: "200px" }} />}
+        {renderConnectionStatus()}
+      </header>
+
+      <main className="mx-auto" style={{ maxWidth: "600px" }}>
+        {!queue && (
+          <>
+            <h2 className="h5 text-center mb-3">出題するかるたの種類を選択してください</h2>
+            <div className="d-flex flex-wrap gap-2 justify-content-center mb-4">
+              {categories.map((c) => (
+                <button
+                  key={c.name}
+                  onClick={() => toggleCategory(c.name)}
+                  className={`btn btn-sm ${selectedCategories.includes(c.name) ? 'btn-dark' : 'btn-outline-dark'}`}
+                >
+                  {c.name}
+                </button>
+              ))}
+            </div>
+            <div className="text-center">
+              <button
+                onClick={startQuiz}
+                disabled={selectedCategories.length === 0 || connectionStatus !== "connected"}
+                className="btn btn-lg btn-karuta rounded-pill px-4 py-3 fw-bold shadow-sm"
+              >
+                開始する
+              </button>
+            </div>
+          </>
+        )}
+
+        {queue && (
+          <div className="text-center">
+            <p className="text-muted mb-3">{queueIndex} / {queue.length} 枚</p>
+            <button
+              onClick={advanceToNextPhrase}
+              disabled={loadingPhrase || queueIndex >= queue.length || connectionStatus !== "connected"}
+              className="btn btn-lg btn-karuta rounded-pill px-5 py-3 fw-bold shadow-sm"
+            >
+              {queueIndex >= queue.length ? "終了しました" : (loadingPhrase ? "読み込み中..." : "次の札")}
+            </button>
+          </div>
+        )}
+      </main>
+
+      <div className="text-center mt-5">
+        <button onClick={() => setView("game")} className="btn btn-link text-muted text-decoration-none">← 戻る</button>
+      </div>
+    </div>
+  );
+}
+
+export default QuizRoomView;

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import QuizRoomView from './QuizRoomView';
+
+const onStateCallbacks = [];
+const broadcastState = vi.fn();
+let mockConnectionStatus = 'connected';
+
+vi.mock('../hooks/useQuizRoomSync', () => ({
+  useQuizRoomSync: ({ onState }) => {
+    onStateCallbacks.push(onState);
+    return { connectionStatus: mockConnectionStatus, broadcastState };
+  },
+}));
+
+vi.mock('qrcode', () => ({
+  default: { toDataURL: vi.fn().mockResolvedValue('data:image/png;base64,fake') },
+}));
+
+const API_BASE_URL = 'https://api.example.com';
+const WS_BASE_URL = 'wss://ws.example.com';
+
+function emitState(state, role = 'participant') {
+  act(() => {
+    onStateCallbacks[onStateCallbacks.length - 1]?.(state, role);
+  });
+}
+
+beforeEach(() => {
+  onStateCallbacks.length = 0;
+  broadcastState.mockClear();
+  mockConnectionStatus = 'connected';
+  // 管理者ロビー画面はマウント時に/get-categoriesを取得するため、個別に上書きしないテストでも
+  // fetchが未定義呼び出しで例外にならないよう既定のレスポンスを用意する
+  window.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ categories: [] }) });
+  // Audioはnew Audio(...)で呼ばれるため、newできないアロー関数実装は使えない
+  window.Audio = vi.fn().mockImplementation(function MockAudio() {
+    return { play: vi.fn().mockResolvedValue(undefined) };
+  });
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(window, 'alert').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  window.history.pushState({}, '', '/');
+  vi.restoreAllMocks();
+});
+
+describe('QuizRoomView', () => {
+  it('shows a preparing message and no room UI when wsBaseUrl is not configured', () => {
+    render(<QuizRoomView setView={vi.fn()} apiBaseUrl={API_BASE_URL} wsBaseUrl={null} />);
+    expect(screen.getByText('クイズ大会モードは現在準備中です。しばらくお待ちください。')).toBeInTheDocument();
+  });
+
+  it('lets the admin create a room, fetch categories, and shows the room code with a QR code', async () => {
+    window.fetch.mockImplementation((url) => {
+      if (url.includes('/quiz-room')) {
+        return Promise.resolve({ ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) });
+      }
+      if (url.includes('/get-categories')) {
+        return Promise.resolve({ ok: true, json: async () => ({ categories: [{ name: 'Cat1' }, { name: 'Cat2' }] }) });
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`));
+    });
+
+    render(<QuizRoomView setView={vi.fn()} apiBaseUrl={API_BASE_URL} wsBaseUrl={WS_BASE_URL} />);
+
+    fireEvent.click(screen.getByText('管理者としてルームを開設する'));
+
+    expect(await screen.findByText('ABC123')).toBeInTheDocument();
+    expect(await screen.findByText('Cat1')).toBeInTheDocument();
+    expect(await screen.findByAltText('参加用QRコード')).toBeInTheDocument();
+  });
+
+  it('disables 開始する while the WebSocket connection is not yet established, to avoid silently dropping the broadcast', async () => {
+    mockConnectionStatus = 'connecting';
+    window.fetch.mockImplementation((url) => {
+      if (url.includes('/quiz-room')) {
+        return Promise.resolve({ ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) });
+      }
+      if (url.includes('/get-categories')) {
+        return Promise.resolve({ ok: true, json: async () => ({ categories: [{ name: 'Cat1' }] }) });
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`));
+    });
+
+    render(<QuizRoomView setView={vi.fn()} apiBaseUrl={API_BASE_URL} wsBaseUrl={WS_BASE_URL} />);
+    fireEvent.click(screen.getByText('管理者としてルームを開設する'));
+    fireEvent.click(await screen.findByText('Cat1'));
+
+    expect(screen.getByText('開始する')).toBeDisabled();
+  });
+
+  it('shows a create-room error and allows retry when room creation fails', async () => {
+    window.fetch.mockResolvedValue({ ok: false });
+
+    render(<QuizRoomView setView={vi.fn()} apiBaseUrl={API_BASE_URL} wsBaseUrl={WS_BASE_URL} />);
+    fireEvent.click(screen.getByText('管理者としてルームを開設する'));
+
+    expect(await screen.findByText('ルームの作成に失敗しました。もう一度お試しください。')).toBeInTheDocument();
+  });
+
+  it('runs the full admin flow: select a category, start, and advance to the next phrase', async () => {
+    window.fetch.mockImplementation((url) => {
+      if (url.includes('/quiz-room')) {
+        return Promise.resolve({ ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) });
+      }
+      if (url.includes('/get-categories')) {
+        return Promise.resolve({ ok: true, json: async () => ({ categories: [{ name: 'Cat1' }] }) });
+      }
+      if (url.includes('/get-phrases-list')) {
+        return Promise.resolve({ ok: true, json: async () => ({ phrases: [{ id: 'p1' }] }) });
+      }
+      if (url.includes('/get-phrase')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', audioData: 'data:audio/mp3;base64,fake' }),
+        });
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`));
+    });
+
+    render(<QuizRoomView setView={vi.fn()} apiBaseUrl={API_BASE_URL} wsBaseUrl={WS_BASE_URL} />);
+
+    fireEvent.click(screen.getByText('管理者としてルームを開設する'));
+    fireEvent.click(await screen.findByText('Cat1'));
+    fireEvent.click(screen.getByText('開始する'));
+
+    expect(await screen.findByText('0 / 1 枚')).toBeInTheDocument();
+    expect(broadcastState).toHaveBeenCalledWith({ type: 'waiting', categoryLabel: 'Cat1' });
+
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(broadcastState).toHaveBeenCalledWith({
+        type: 'phrase',
+        phrase: { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: undefined },
+      });
+    });
+    // 最後の1枚を出したのでfinishedも合わせて配信される
+    expect(broadcastState).toHaveBeenCalledWith({ type: 'finished' });
+    expect(await screen.findByText('終了しました')).toBeInTheDocument();
+    expect(screen.getByText('1 / 1 枚')).toBeInTheDocument();
+  });
+
+  it('lets a participant join via a manually entered room code', () => {
+    render(<QuizRoomView setView={vi.fn()} apiBaseUrl={API_BASE_URL} wsBaseUrl={WS_BASE_URL} />);
+
+    fireEvent.change(screen.getByPlaceholderText('ルームコード'), { target: { value: 'xyz789' } });
+    fireEvent.click(screen.getByText('参加する'));
+
+    expect(screen.getByText('クイズ大会モード（参加者）')).toBeInTheDocument();
+    expect(screen.getByText('ルーム: XYZ789')).toBeInTheDocument();
+  });
+
+  it('renders the participant view from a ?roomId= deep link and updates as state is broadcast', () => {
+    window.history.pushState({}, '', '?view=quiz-room&roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} apiBaseUrl={API_BASE_URL} wsBaseUrl={WS_BASE_URL} />);
+
+    expect(screen.getByText('クイズ大会モード（参加者）')).toBeInTheDocument();
+    expect(screen.getByText('ホストの操作を待っています...')).toBeInTheDocument();
+
+    emitState({ type: 'waiting', categoryLabel: 'Cat1' });
+    expect(screen.getByText('まもなく開始します（Cat1）...')).toBeInTheDocument();
+
+    emitState({ type: 'phrase', phrase: { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '3' } });
+    expect(screen.getByText('読み札1')).toBeInTheDocument();
+    expect(screen.getByText('レベル: 3')).toBeInTheDocument();
+
+    emitState({ type: 'finished' });
+    expect(screen.getByText('すべての読み札が終わりました。お疲れ様でした！')).toBeInTheDocument();
+  });
+
+  it('shows the connection status label to the participant', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    mockConnectionStatus = 'error';
+
+    render(<QuizRoomView setView={vi.fn()} apiBaseUrl={API_BASE_URL} wsBaseUrl={WS_BASE_URL} />);
+
+    expect(screen.getByText('接続状態: 接続できませんでした')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
issue #470「クイズ大会モードを追加する」の最小構成（MVP）を実装する。管理者がルームを開設し、参加者はQRコード（またはルームコード直接入力）で招待され、同じルームに接続した全端末に現在の札がリアルタイムに同期表示される。管理者のみが札をめくる・カテゴリを選ぶ等の操作を行える。

## 実装前に確認した設計判断
着手前に以下3点をユーザーに確認し、決定した内容に基づいて実装した。

1. **複数端末間の同期方式**: WebSocket API Gateway（新規インフラだが真のリアルタイム同期が可能）
2. **初回リリースのスコープ**: 最小限（ルーム作成・参加者接続・現在の札の表示同期・管理者限定操作のみ。QRコードは招待URLのエンコードのみ、読み上げ音声の同期再生は次段階に見送り）
3. **管理者・参加者の権限分離**: ルーム発行トークン方式（アカウント登録は導入せず、ルーム作成時にのみ管理者用の秘密トークンを発行）

## バックエンド（新規: `backend/quizRoomHandler.js`）
- `POST /quiz-room`（REST）: ルームを新規作成し、ルームコード（6文字、誤読しやすい文字は除外）と管理者トークンを発行する。トークンはDB上ハッシュ（SHA-256）のみ保存
- WebSocket `$connect`: `roomId`（必須）・`adminToken`（任意）をクエリパラメータで受け取り、トークンの有無・一致から`admin`/`participant`の役割を判定
- WebSocket `$disconnect`: 接続レコードを削除
- WebSocketカスタムルート`sync`: 接続直後にクライアントから呼ばれ、現在のルーム状態を呼び出し元1件にだけ返す
- WebSocketカスタムルート`updateState`: 管理者のみ状態を更新でき、更新後はルーム内の全接続へブロードキャストする（切断済み接続はGoneException検知で自動的にレコード削除）
- DynamoDBに`QuizRoomsTable`・`QuizRoomConnectionsTable`（ともにTTLで自動失効、無人ルームの残存を防止）を新設

## フロントエンド（新規: `frontend/src/views/QuizRoomView.jsx`, `frontend/src/hooks/useQuizRoomSync.js`）
- 初期画面に「クイズ大会モード」導線を追加（`?view=quiz-room&roomId=...`のディープリンクで参加者として直接開ける）
- 管理者: ルーム作成→カテゴリ選択→「次の札」で1枚ずつ出題（音声は管理者の端末でのみ再生、状態をWebSocketでブロードキャスト）。ルームコード・QRコード（`qrcode`パッケージ）を表示
- 参加者: 閲覧専用。ホストの状態（待機中/出題中/終了）をリアルタイム表示
- WebSocket未接続時に「開始する」「次の札」を無効化し、ブロードキャストが静かに失われるのを防止

## 既知の制約（今回のスコープ外）
- 読み上げ音声の同期再生（管理者の端末でのみ再生される）
- 参加者一覧・人数表示
- ルームの手動終了（TTLによる自動失効のみ）

## デプロイに関する注意
WebSocket APIのエンドポイントはデプロイ後に確定するため、`frontend/src/config.js`の`WS_BASE_URL`は初回デプロイまで`null`（未設定時は「準備中」画面を表示）としている。**マージ後、実際にデプロイして得られたWebSocketエンドポイントを`VITE_WS_BASE_URL`として設定するか`config.js`を直接更新する必要がある**。また、実際に2台の端末（またはブラウザタブ）でルーム作成→参加→状態同期が機能することの手動確認を推奨する（このセッションからは実デプロイ・実機WebSocket通信の確認ができないため）。

## Test plan
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 全100件成功
- [x] `backend`: `npm run lint` エラー0件
- [x] `backend`: `npm test -- --run` 全1309件成功
- [x] `npx serverless print`でYAML構文の正当性を確認済み（`${aws:accountId}`の実解決には本番AWS認証情報が必要なため、この環境ではそこで止まるが従来から同様）
- [ ] マージ後、実際のデプロイとWebSocket通信の動作確認（管理者・参加者2端末での同期）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_