### PR TITLE
chore(release): v1.25.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.25.0](https://github.com/bamiyanapp/karuta/compare/v1.24.0...v1.25.0) (2026-07-16)
+
+
+### Features
+
+* クイズ大会モード（最小構成）を追加する ([#477](https://github.com/bamiyanapp/karuta/issues/477)) ([ed95417](https://github.com/bamiyanapp/karuta/commit/ed9541796ae3058a7eb58763df7ff0a4f2764088))
+
 # [1.24.0](https://github.com/bamiyanapp/karuta/compare/v1.23.2...v1.24.0) (2026-07-16)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
+    "version": "1.25.0",
+    "date": "2026/07/04 03:38",
+    "body": "### Features\n\n* クイズ大会モード（最小構成）を追加する ([#477](https://github.com/bamiyanapp/karuta/issues/477)) ([ed95417](https://github.com/bamiyanapp/karuta/commit/ed9541796ae3058a7eb58763df7ff0a4f2764088))"
+  },
+  {
     "version": "1.24.0",
-    "date": "2026/07/04 03:27",
+    "date": "2026/07/16 00:16",
     "body": "### Features\n\n* **voice:** 試験的な音声認識機能を撤去する ([#475](https://github.com/bamiyanapp/karuta/issues/475)) ([ae5142b](https://github.com/bamiyanapp/karuta/commit/ae5142b1cc6a362ca9f3f81d9b0a59e6d1a456f7))"
   },
   {
@@ -251,7 +256,7 @@
   },
   {
     "version": "1.24.0",
-    "date": "2026/07/04 03:27",
+    "date": "2026/07/16 00:16",
     "body": "### Features\n\n* **reading:** 読み上げ中に停止できる機能を追加 ([#243](https://github.com/bamiyanapp/karuta/issues/243)) ([2159ff0](https://github.com/bamiyanapp/karuta/commit/2159ff0d5a25545bf7caafd5471103c55a48f563))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.24.0"
+  "version": "1.25.0"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。