### PR TITLE
fix(frontend): クイズ大会モードのWebSocketエンドポイントを設定する

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -2,8 +2,8 @@ export const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ||
   "https://akmnirkx3m.execute-api.ap-northeast-1.amazonaws.com/dev";
 
-// クイズ大会モード（issue #470）のWebSocket API。REST APIと異なりAPI Gateway ID・エンドポイントが
-// 新規に払い出されるため、初回デプロイ完了までは確定した既定値を置けない。デプロイ後、
-// `npx serverless deploy`出力のWebSocket endpointをVITE_WS_BASE_URLとして設定するか、
-// この既定値（null）を実際の"wss://..."エンドポイントに書き換える
-export const WS_BASE_URL = import.meta.env.VITE_WS_BASE_URL || null;
+// クイズ大会モード（issue #470）のWebSocket API。#477マージ後のデプロイで払い出された
+// 実際のエンドポイント（backend/serverless.ymlのwebsocketイベントから自動生成）
+export const WS_BASE_URL =
+  import.meta.env.VITE_WS_BASE_URL ||
+  "wss://k3egkiofa4.execute-api.ap-northeast-1.amazonaws.com/dev";


### PR DESCRIPTION
## 概要
「クイズ大会モードを押すと『準備中』表示のみで何もできない」との報告に対する修正。

## 原因
#477で実装したクイズ大会モードは、WebSocket APIのエンドポイントがデプロイするまで確定しないため、`frontend/src/config.js`の`WS_BASE_URL`を意図的に`null`（未設定時は「準備中です」画面を表示し機能を無効化）としていた（#477本文にも明記済み）。#477マージ後のCD（`deploy-backend`）は正常に完了し、WebSocket APIも実際にデプロイされていたが、`config.js`側の値の書き換えがまだ行われていなかった。

## 対応
GitHub Actionsの`deploy-backend`ジョブログから、実際にデプロイされたWebSocketエンドポイント（`wss://k3egkiofa4.execute-api.ap-northeast-1.amazonaws.com/dev`）を取得し、`WS_BASE_URL`の既定値として設定した。

## Test plan
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 全100件成功
- [x] `backend`: `npm run lint` エラー0件
- [x] `backend`: `npm test -- --run` 全1309件成功
- [ ] マージ・再デプロイ後、実際に管理者・参加者2端末でルーム作成→参加→状態同期が機能することの確認（このセッションからは実機WebSocket通信の確認ができないため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_