### PR TITLE
chore(release): v1.25.1 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.25.1](https://github.com/bamiyanapp/karuta/compare/v1.25.0...v1.25.1) (2026-07-16)
+
+
+### Bug Fixes
+
+* **frontend:** クイズ大会モードのWebSocketエンドポイントを設定する ([#479](https://github.com/bamiyanapp/karuta/issues/479)) ([d4295bc](https://github.com/bamiyanapp/karuta/commit/d4295bc318c1a3efee5b66f7e283b45d214031f7))
+
 # [1.25.0](https://github.com/bamiyanapp/karuta/compare/v1.24.0...v1.25.0) (2026-07-16)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
+    "version": "1.25.1",
+    "date": "2026/07/16",
+    "body": "### Bug Fixes\n\n* **frontend:** クイズ大会モードのWebSocketエンドポイントを設定する ([#479](https://github.com/bamiyanapp/karuta/issues/479)) ([d4295bc](https://github.com/bamiyanapp/karuta/commit/d4295bc318c1a3efee5b66f7e283b45d214031f7))"
+  },
+  {
     "version": "1.25.0",
-    "date": "2026/07/04 03:38",
+    "date": "2026/07/16 01:31",
     "body": "### Features\n\n* クイズ大会モード（最小構成）を追加する ([#477](https://github.com/bamiyanapp/karuta/issues/477)) ([ed95417](https://github.com/bamiyanapp/karuta/commit/ed9541796ae3058a7eb58763df7ff0a4f2764088))"
   },
   {
@@ -251,7 +256,7 @@
   },
   {
     "version": "1.25.0",
-    "date": "2026/07/04 03:38",
+    "date": "2026/07/16 01:31",
     "body": "### Features\n\n* **reading:** 次の札の音声をプリフェッチして待ち時間を削減 ([#245](https://github.com/bamiyanapp/karuta/issues/245)) ([f80c86d](https://github.com/bamiyanapp/karuta/commit/f80c86d726b846cf83b48666fa7c4a095b306d50))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.25.0"
+  "version": "1.25.1"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。