### PR TITLE
fix(quiz-room): 接続確立前後のbroadcastStateが失われないようにする

### DIFF
--- a/frontend/src/hooks/useQuizRoomSync.js
+++ b/frontend/src/hooks/useQuizRoomSync.js
@@ -14,6 +14,11 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState }) {
   const reconnectAttemptsRef = useRef(0);
   const reconnectTimeoutRef = useRef(null);
   const closedByCleanupRef = useRef(false);
+  // broadcastStateに渡された直近の状態。接続確立前（初回接続のLambdaコールド
+  // スタート・WSハンドシェイク中）やその後の再接続中にbroadcastStateが呼ばれると、
+  // それまではreadyState !== OPENのため送信が黙って失われ、参加者側の画面が
+  // 永久に更新されない不具合があった。openのたびにこの値を送り直すことで解消する
+  const pendingStateRef = useRef(null);
 
   useEffect(() => {
     onStateRef.current = onState;
@@ -25,6 +30,7 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState }) {
     }
     closedByCleanupRef.current = false;
     reconnectAttemptsRef.current = 0;
+    pendingStateRef.current = null;
 
     const connect = () => {
       setInternalStatus("connecting");
@@ -42,6 +48,11 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState }) {
         reconnectAttemptsRef.current = 0;
         setInternalStatus("connected");
         ws.send(JSON.stringify({ action: "sync" }));
+        // 接続確立前にbroadcastStateが呼ばれていた場合（初回接続のタイミング競合・
+        // 再接続時など）に備え、直近の状態を送り直す
+        if (pendingStateRef.current !== null) {
+          ws.send(JSON.stringify({ action: "updateState", state: pendingStateRef.current }));
+        }
       };
 
       ws.onmessage = (event) => {
@@ -85,6 +96,7 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState }) {
   }, [wsBaseUrl, roomId, adminToken]);
 
   const broadcastState = useCallback((state) => {
+    pendingStateRef.current = state;
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       wsRef.current.send(JSON.stringify({ action: "updateState", state }));
     }

--- a/frontend/src/hooks/useQuizRoomSync.test.js
+++ b/frontend/src/hooks/useQuizRoomSync.test.js
@@ -138,6 +138,59 @@ describe('useQuizRoomSync', () => {
     );
   });
 
+  it('resends the last broadcastState call once the socket opens, even if it was attempted before the connection was ready (regression: participant never saw updates because the admin\'s first broadcast raced ahead of the WebSocket handshake)', () => {
+    const { result } = renderHook(() => useQuizRoomSync({
+      wsBaseUrl: 'wss://example.com/dev',
+      roomId: 'ROOM01',
+      adminToken: 'secret-token',
+      onState: vi.fn(),
+    }));
+
+    // 接続がOPENになる前にbroadcastStateが呼ばれる（Lambdaコールドスタート等で
+    // ハンドシェイクに時間がかかる場合に発生する）
+    act(() => {
+      result.current.broadcastState({ type: 'phrase', phrase: { id: 'p1' } });
+    });
+    expect(MockWebSocket.instances[0].sent).toEqual([]);
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+    });
+
+    expect(MockWebSocket.instances[0].sent).toEqual([
+      JSON.stringify({ action: 'sync' }),
+      JSON.stringify({ action: 'updateState', state: { type: 'phrase', phrase: { id: 'p1' } } }),
+    ]);
+  });
+
+  it('resends the last broadcastState call again on reconnect, so participants recover in sync after a dropped connection', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useQuizRoomSync({
+      wsBaseUrl: 'wss://example.com/dev',
+      roomId: 'ROOM01',
+      adminToken: 'secret-token',
+      onState: vi.fn(),
+    }));
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+      result.current.broadcastState({ type: 'phrase', phrase: { id: 'p1' } });
+    });
+
+    act(() => {
+      MockWebSocket.instances[0].triggerClose();
+      vi.advanceTimersByTime(3000);
+    });
+    act(() => {
+      MockWebSocket.instances[1].triggerOpen();
+    });
+
+    expect(MockWebSocket.instances[1].sent).toEqual([
+      JSON.stringify({ action: 'sync' }),
+      JSON.stringify({ action: 'updateState', state: { type: 'phrase', phrase: { id: 'p1' } } }),
+    ]);
+  });
+
   it('reconnects after a close and gives up after the retry limit', async () => {
     vi.useFakeTimers();
     const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));


### PR DESCRIPTION
## 概要
「参加者側は接続済みになっているが、ホスト側でかるたをめくっても『ホストの操作を待っています』のまま進まない」という報告に対する修正。

## 原因調査
このセッションからは実際のAWS環境（CloudWatch Logs等）を確認できないため、コードレビューで原因を特定した。

管理者のWebSocket接続は、ルーム作成直後に`useQuizRoomSync`で確立される。API GatewayのWebSocket `$connect`ルートを処理するLambda（`connectQuizRoom`）は呼び出し頻度が低く、コールドスタートを含めると接続確立（`readyState === WebSocket.OPEN`になるまで）に数百ms〜数秒かかることがある。

一方`frontend/src/hooks/useQuizRoomSync.js`の`broadcastState`は、`readyState !== OPEN`の間は送信を**黙って諦める**実装になっており、リトライの仕組みがなかった。そのため、

- ルーム作成直後、最初の状態変化（カテゴリ選択・最初の「次の札」）のブロードキャストが、WebSocket接続確立より先に発生してしまうと、その更新は失われる
- 一度も成功したブロードキャストが行われないまま以降も同じ状態（`readyState`が開く前に呼ばれる）が続けば、参加者側は永久に初期状態（「ホストの操作を待っています」）のまま

という状態になり得る。同様の理屈で、ネットワーク瞬断やAPI Gatewayのアイドルタイムアウトによる再接続時にも、再接続完了前後のブロードキャストが失われるリスクがあった。

## 対応
`useQuizRoomSync`に、直近の`broadcastState`呼び出し内容を保持する`pendingStateRef`を追加。WebSocketが（初回・再接続を問わず）openするたびに、`sync`要求の直後にこの保持内容を送り直すようにした。これにより、接続確立前後のタイミングでブロードキャストが試みられても、接続が実際に使えるようになった瞬間に必ず反映される。

## Test plan
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 全105件成功（新規回帰テスト2件を含む）
- [x] `backend`: `npm run lint` エラー0件
- [x] `backend`: `npm test -- --run` 全1309件成功（変更なし）
- [ ] マージ・再デプロイ後、実際に管理者・参加者2端末で同期が機能することの確認（このセッションからは実機・実AWS環境の確認ができないため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_