### PR TITLE
chore(release): v1.26.1 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.26.1](https://github.com/bamiyanapp/karuta/compare/v1.26.0...v1.26.1) (2026-07-16)
+
+
+### Bug Fixes
+
+* **quiz-room:** 接続確立前後のbroadcastStateが失われないようにする ([#483](https://github.com/bamiyanapp/karuta/issues/483)) ([b567386](https://github.com/bamiyanapp/karuta/commit/b5673865d519988fa20e621b55cb61b1ff593190))
+
 # [1.26.0](https://github.com/bamiyanapp/karuta/compare/v1.25.1...v1.26.0) (2026-07-16)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
+    "version": "1.26.1",
+    "date": "2026/07/16",
+    "body": "### Bug Fixes\n\n* **quiz-room:** 接続確立前後のbroadcastStateが失われないようにする ([#483](https://github.com/bamiyanapp/karuta/issues/483)) ([b567386](https://github.com/bamiyanapp/karuta/commit/b5673865d519988fa20e621b55cb61b1ff593190))"
+  },
+  {
     "version": "1.26.0",
-    "date": "2026/07/04 06:05",
+    "date": "2026/07/16 02:14",
     "body": "### Features\n\n* **quiz-room:** 通常のゲーム画面を流用し、招待URL・コピー機能を追加する ([#481](https://github.com/bamiyanapp/karuta/issues/481)) ([a174046](https://github.com/bamiyanapp/karuta/commit/a174046ccf4f512f2b508b1234a9fa1e097b8e0c))"
   },
   {
@@ -256,7 +261,7 @@
   },
   {
     "version": "1.26.0",
-    "date": "2026/07/04 06:05",
+    "date": "2026/07/16 02:14",
     "body": "### Features\n\n* **auto-advance:** 自動読み上げモード（ハンズフリー進行）を追加 ([#247](https://github.com/bamiyanapp/karuta/issues/247)) ([a2b0ee5](https://github.com/bamiyanapp/karuta/commit/a2b0ee565f35d40b22ebc72595acbcdc28ecd495))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.26.0",
+      "version": "1.26.1",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.26.0"
+  "version": "1.26.1"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。