### PR TITLE
fix(quiz-room): 参加者側の自己修復ポーリングと動線の見直し

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -114,6 +114,8 @@ function App() {
   // 参加者側の状態同期・カテゴリ選択・札めくり自体は通常のゲーム画面をそのまま使い、
   // ここではブロードキャストに必要な最小限の情報（roomId・管理者トークン）のみ保持する
   const [quizRoom, setQuizRoom] = useState(null); // { roomId, adminToken } | null
+  const [creatingQuizRoom, setCreatingQuizRoom] = useState(false);
+  const [quizRoomCreateError, setQuizRoomCreateError] = useState(null);
 
   // コメント投稿用の状態
   const [commentText, setCommentText] = useState("");
@@ -923,6 +925,25 @@ function App() {
     return () => mediaQuery.removeEventListener("change", handleChange);
   }, []);
 
+  // クイズ大会モード（issue #470）: 通常のかるた読み上げ画面のフッターから直接ルームを作成する
+  const createQuizRoom = async () => {
+    setCreatingQuizRoom(true);
+    setQuizRoomCreateError(null);
+    try {
+      const response = await fetch(`${API_BASE_URL}/quiz-room`, { method: "POST" });
+      if (!response.ok) {
+        throw new Error("ルームの作成に失敗しました");
+      }
+      const data = await response.json();
+      setQuizRoom({ roomId: data.roomId, adminToken: data.adminToken });
+    } catch (error) {
+      console.error("Failed to create quiz room:", error);
+      setQuizRoomCreateError("ルームの作成に失敗しました。もう一度お試しください。");
+    } finally {
+      setCreatingQuizRoom(false);
+    }
+  };
+
   const resetGame = () => {
     setSelectedCategories([]);
     setDraftCategories([]);
@@ -1106,14 +1127,7 @@ function App() {
   }
 
   if (view === "quiz-room") {
-    return (
-      <QuizRoomView
-        setView={setView}
-        apiBaseUrl={API_BASE_URL}
-        wsBaseUrl={WS_BASE_URL}
-        onRoomCreated={setQuizRoom}
-      />
-    );
+    return <QuizRoomView setView={setView} wsBaseUrl={WS_BASE_URL} />;
   }
 
   if (selectedCategories.length === 0 && !division) {
@@ -1153,7 +1167,7 @@ function App() {
             更新履歴を見る
           </button>
           <button onClick={() => setView("quiz-room")} className="btn btn-link text-decoration-none text-muted small">
-            クイズ大会モード
+            クイズ大会に参加する
           </button>
         </div>
       </div>
@@ -1565,7 +1579,21 @@ function App() {
         <button onClick={() => setView("print-efuda")} className="btn btn-outline-dark px-4 rounded-pill">絵札を印刷する</button>
         <button onClick={resetGame} className="btn btn-outline-secondary px-4 rounded-pill">かるたの種類を選び直す</button>
       </div>
-      {quizRoom && <QuizRoomInfoPanel roomId={quizRoom.roomId} />}
+      {quizRoom ? (
+        <QuizRoomInfoPanel roomId={quizRoom.roomId} />
+      ) : (
+        <div className="mb-4">
+          <button
+            type="button"
+            onClick={createQuizRoom}
+            disabled={creatingQuizRoom}
+            className="btn btn-link text-decoration-none"
+          >
+            {creatingQuizRoom ? "作成中..." : "クイズ大会のルームを作成する"}
+          </button>
+          {quizRoomCreateError && <p className="text-danger small">{quizRoomCreateError}</p>}
+        </div>
+      )}
     </footer>
     </div>
   );

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2363,13 +2363,14 @@ describe('App', () => {
       render(<App />);
     });
 
-    fireEvent.click(await screen.findByText('クイズ大会モード'));
-    fireEvent.click(await screen.findByText('管理者としてルームを開設する'));
-
-    // ルーム作成後、通常のかるた選択画面に戻ってくる（専用の管理者画面は用意しない）
+    // クイズ大会モードの入口はトップページから削除済み。管理者は通常のかるた
+    // 読み上げ画面まで進み、そのフッターからルームを作成する
     fireEvent.click(await screen.findByText('こども向け'));
     fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
     await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
 
     expect(MockWebSocket.instances).toHaveLength(1);
     const ws = MockWebSocket.instances[0];

--- a/frontend/src/hooks/useQuizRoomSync.js
+++ b/frontend/src/hooks/useQuizRoomSync.js
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 const RECONNECT_DELAY_MS = 3000;
 const MAX_RECONNECT_ATTEMPTS = 5; // 際限ない再接続ループを防ぐための上限
+// プッシュ通知（updateStateのブロードキャスト）が何らかの理由で届かなかった場合に備え、
+// 一定間隔でsyncを再要求し自己修復させる保険（本来はプッシュのみで完結するはずだが、
+// 個別のブロードキャスト送信が届かないケースを完全には排除できないため）
+const SYNC_POLL_INTERVAL_MS = 5000;
 
 // クイズ大会モード（issue #470）のWebSocket接続を管理する。adminTokenを渡すと管理者として、
 // 渡さなければ参加者（閲覧専用）として接続する。サーバーから状態（{type:"state", state, role}）を
@@ -14,6 +18,7 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState }) {
   const reconnectAttemptsRef = useRef(0);
   const reconnectTimeoutRef = useRef(null);
   const closedByCleanupRef = useRef(false);
+  const pollTimerRef = useRef(null);
   // broadcastStateに渡された直近の状態。接続確立前（初回接続のLambdaコールド
   // スタート・WSハンドシェイク中）やその後の再接続中にbroadcastStateが呼ばれると、
   // それまではreadyState !== OPENのため送信が黙って失われ、参加者側の画面が
@@ -53,6 +58,11 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState }) {
         if (pendingStateRef.current !== null) {
           ws.send(JSON.stringify({ action: "updateState", state: pendingStateRef.current }));
         }
+        pollTimerRef.current = setInterval(() => {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ action: "sync" }));
+          }
+        }, SYNC_POLL_INTERVAL_MS);
       };
 
       ws.onmessage = (event) => {
@@ -71,6 +81,10 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState }) {
       };
 
       ws.onclose = () => {
+        if (pollTimerRef.current) {
+          clearInterval(pollTimerRef.current);
+          pollTimerRef.current = null;
+        }
         if (closedByCleanupRef.current) {
           return;
         }
@@ -90,6 +104,9 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState }) {
       closedByCleanupRef.current = true;
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);
+      }
+      if (pollTimerRef.current) {
+        clearInterval(pollTimerRef.current);
       }
       wsRef.current?.close();
     };

--- a/frontend/src/hooks/useQuizRoomSync.test.js
+++ b/frontend/src/hooks/useQuizRoomSync.test.js
@@ -191,6 +191,46 @@ describe('useQuizRoomSync', () => {
     ]);
   });
 
+  it('periodically re-requests sync while connected, as a fallback in case a broadcast is missed', () => {
+    vi.useFakeTimers();
+    renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+    });
+    expect(MockWebSocket.instances[0].sent).toEqual([JSON.stringify({ action: 'sync' })]);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(MockWebSocket.instances[0].sent).toEqual([
+      JSON.stringify({ action: 'sync' }),
+      JSON.stringify({ action: 'sync' }),
+    ]);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(MockWebSocket.instances[0].sent).toHaveLength(3);
+  });
+
+  it('stops polling once the connection closes', () => {
+    vi.useFakeTimers();
+    renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+      MockWebSocket.instances[0].triggerClose();
+    });
+    const sentAtClose = MockWebSocket.instances[0].sent.length;
+
+    act(() => {
+      vi.advanceTimersByTime(20000);
+    });
+    // 再接続タイマー（3秒後）は動くが、閉じた古い接続へのポーリング送信は増えない
+    expect(MockWebSocket.instances[0].sent).toHaveLength(sentAtClose);
+  });
+
   it('reconnects after a close and gives up after the retry limit', async () => {
     vi.useFakeTimers();
     const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -1,12 +1,10 @@
 import { useMemo, useState } from "react";
 import { useQuizRoomSync } from "../hooks/useQuizRoomSync";
 
-// クイズ大会モード（issue #470）の入口。
-// - 管理者: ルームを作成したら、通常のかるたプレー画面（App.jsxのview="game"）へ遷移する。
-//   カテゴリ選択・札めくり・読み上げは既存のゲーム画面をそのまま踏襲し、状態のブロードキャストは
-//   App.jsx側（displayContentの変化を監視）で行う。招待用のルームコード・URL・QRコードは
-//   ゲーム画面側のQuizRoomInfoPanelから確認する
-// - 参加者: 閲覧専用。管理者の状態（初期/出題中/結果）をリアルタイム表示する
+// クイズ大会モード（issue #470）の参加者用入口（閲覧専用）。
+// ルームコードの直接入力、または招待URL（?roomId=...）からの参加に対応する。
+// ルーム作成（管理者側の導線）はここではなく、通常のかるた読み上げ画面の
+// フッターにあるQuizRoomInfoPanel経由で行う（App.jsx参照）
 
 const CONNECTION_STATUS_LABEL = {
   idle: "未接続",
@@ -16,7 +14,10 @@ const CONNECTION_STATUS_LABEL = {
 };
 
 function renderParticipantContent(roomState) {
-  if (!roomState || roomState.type === "initial") {
+  // ルーム作成直後（まだ一度もupdateStateが呼ばれていない）は、サーバー側の状態が
+  // 空オブジェクト{}のままsyncで返ってくる。typeを持たない・未知のtypeの場合は
+  // すべて「待機中」として扱い、空白画面にならないようにする
+  if (!roomState || !["phrase", "result"].includes(roomState.type)) {
     return <p className="text-muted py-5">ホストの操作を待っています...</p>;
   }
   if (roomState.type === "phrase" && roomState.content) {
@@ -51,13 +52,10 @@ function renderParticipantContent(roomState) {
   return null;
 }
 
-function QuizRoomView({ setView, apiBaseUrl, wsBaseUrl, onRoomCreated }) {
+function QuizRoomView({ setView, wsBaseUrl }) {
   const urlRoomId = useMemo(() => new URLSearchParams(window.location.search).get("roomId"), []);
   const [joinRoomId, setJoinRoomId] = useState(urlRoomId);
   const [manualRoomId, setManualRoomId] = useState("");
-
-  const [creatingRoom, setCreatingRoom] = useState(false);
-  const [createError, setCreateError] = useState(null);
 
   const [roomState, setRoomState] = useState(null);
 
@@ -76,26 +74,6 @@ function QuizRoomView({ setView, apiBaseUrl, wsBaseUrl, onRoomCreated }) {
     );
   }
 
-  const createRoom = async () => {
-    setCreatingRoom(true);
-    setCreateError(null);
-    try {
-      const response = await fetch(`${apiBaseUrl}/quiz-room`, { method: "POST" });
-      if (!response.ok) {
-        throw new Error("ルームの作成に失敗しました");
-      }
-      const data = await response.json();
-      onRoomCreated({ roomId: data.roomId, adminToken: data.adminToken });
-      setView("game");
-    } catch (error) {
-      console.error("Failed to create quiz room:", error);
-      setCreateError("ルームの作成に失敗しました。もう一度お試しください。");
-    } finally {
-      setCreatingRoom(false);
-    }
-  };
-
-  // 参加者（閲覧専用）
   if (joinRoomId) {
     return (
       <div className="container py-5 mx-auto text-center">
@@ -109,38 +87,29 @@ function QuizRoomView({ setView, apiBaseUrl, wsBaseUrl, onRoomCreated }) {
     );
   }
 
-  // ロビー: 管理者としてルームを開設する、またはルームコードを直接入力して参加する
   return (
     <div className="container py-5 mx-auto">
       <header className="text-center mb-4">
-        <h1 className="h4 fw-bold">クイズ大会モード</h1>
+        <h1 className="h4 fw-bold">クイズ大会に参加する</h1>
       </header>
-      <main className="mx-auto" style={{ maxWidth: "480px" }}>
-        <div className="text-center mb-5">
-          <button onClick={createRoom} disabled={creatingRoom} className="btn btn-lg btn-karuta rounded-pill px-4 py-3 fw-bold shadow-sm">
-            {creatingRoom ? "作成中..." : "管理者としてルームを開設する"}
+      <main className="mx-auto text-center" style={{ maxWidth: "480px" }}>
+        <p className="text-muted small mb-2">ホストから伝えられたルームコードを入力してください</p>
+        <div className="d-flex gap-2 justify-content-center">
+          <input
+            type="text"
+            value={manualRoomId}
+            onChange={(e) => setManualRoomId(e.target.value.toUpperCase())}
+            placeholder="ルームコード"
+            className="form-control"
+            style={{ maxWidth: "160px" }}
+          />
+          <button
+            onClick={() => setJoinRoomId(manualRoomId)}
+            disabled={!manualRoomId}
+            className="btn btn-outline-dark rounded-pill"
+          >
+            参加する
           </button>
-          {createError && <p className="text-danger small mt-2">{createError}</p>}
-        </div>
-        <div className="text-center">
-          <p className="text-muted small mb-2">ルームコードを知っている場合はこちら</p>
-          <div className="d-flex gap-2 justify-content-center">
-            <input
-              type="text"
-              value={manualRoomId}
-              onChange={(e) => setManualRoomId(e.target.value.toUpperCase())}
-              placeholder="ルームコード"
-              className="form-control"
-              style={{ maxWidth: "160px" }}
-            />
-            <button
-              onClick={() => setJoinRoomId(manualRoomId)}
-              disabled={!manualRoomId}
-              className="btn btn-outline-dark rounded-pill"
-            >
-              参加する
-            </button>
-          </div>
         </div>
         <div className="text-center mt-5">
           <button onClick={() => setView("game")} className="btn btn-link text-muted text-decoration-none">← 戻る</button>

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -12,7 +12,6 @@ vi.mock('../hooks/useQuizRoomSync', () => ({
   },
 }));
 
-const API_BASE_URL = 'https://api.example.com';
 const WS_BASE_URL = 'wss://ws.example.com';
 
 function emitState(state) {
@@ -24,8 +23,6 @@ function emitState(state) {
 beforeEach(() => {
   onStateCallbacks.length = 0;
   mockConnectionStatus = 'connected';
-  window.fetch = vi.fn();
-  vi.spyOn(console, 'error').mockImplementation(() => {});
 });
 
 afterEach(() => {
@@ -35,38 +32,14 @@ afterEach(() => {
 
 describe('QuizRoomView', () => {
   it('shows a preparing message and no room UI when wsBaseUrl is not configured', () => {
-    render(<QuizRoomView setView={vi.fn()} apiBaseUrl={API_BASE_URL} wsBaseUrl={null} onRoomCreated={vi.fn()} />);
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={null} />);
     expect(screen.getByText('クイズ大会モードは現在準備中です。しばらくお待ちください。')).toBeInTheDocument();
   });
 
-  it('creates a room, hands roomId/adminToken up to the parent, and switches to the normal game view', async () => {
-    window.fetch.mockResolvedValue({ ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) });
-    const onRoomCreated = vi.fn();
-    const setView = vi.fn();
-
-    render(<QuizRoomView setView={setView} apiBaseUrl={API_BASE_URL} wsBaseUrl={WS_BASE_URL} onRoomCreated={onRoomCreated} />);
-    fireEvent.click(screen.getByText('管理者としてルームを開設する'));
-
-    await vi.waitFor(() => expect(onRoomCreated).toHaveBeenCalledWith({ roomId: 'ABC123', adminToken: 'token-1' }));
-    expect(setView).toHaveBeenCalledWith('game');
-  });
-
-  it('shows a create-room error and does not transition when creation fails', async () => {
-    window.fetch.mockResolvedValue({ ok: false });
-    const onRoomCreated = vi.fn();
-    const setView = vi.fn();
-
-    render(<QuizRoomView setView={setView} apiBaseUrl={API_BASE_URL} wsBaseUrl={WS_BASE_URL} onRoomCreated={onRoomCreated} />);
-    fireEvent.click(screen.getByText('管理者としてルームを開設する'));
-
-    expect(await screen.findByText('ルームの作成に失敗しました。もう一度お試しください。')).toBeInTheDocument();
-    expect(onRoomCreated).not.toHaveBeenCalled();
-    expect(setView).not.toHaveBeenCalled();
-  });
-
   it('lets a participant join via a manually entered room code', () => {
-    render(<QuizRoomView setView={vi.fn()} apiBaseUrl={API_BASE_URL} wsBaseUrl={WS_BASE_URL} onRoomCreated={vi.fn()} />);
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
 
+    expect(screen.getByText('クイズ大会に参加する')).toBeInTheDocument();
     fireEvent.change(screen.getByPlaceholderText('ルームコード'), { target: { value: 'xyz789' } });
     fireEvent.click(screen.getByText('参加する'));
 
@@ -77,7 +50,7 @@ describe('QuizRoomView', () => {
   it('renders the participant view from a ?roomId= deep link and updates as state is broadcast', () => {
     window.history.pushState({}, '', '?view=quiz-room&roomId=ABC123');
 
-    render(<QuizRoomView setView={vi.fn()} apiBaseUrl={API_BASE_URL} wsBaseUrl={WS_BASE_URL} onRoomCreated={vi.fn()} />);
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
 
     expect(screen.getByText('クイズ大会モード（参加者）')).toBeInTheDocument();
     expect(screen.getByText('ホストの操作を待っています...')).toBeInTheDocument();
@@ -94,11 +67,21 @@ describe('QuizRoomView', () => {
     expect(screen.getByText('答え1')).toBeInTheDocument();
   });
 
+  it('treats an unrecognized or empty room state (e.g. right after room creation, before any card is shown) as "waiting" rather than a blank screen', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+
+    emitState({});
+
+    expect(screen.getByText('ホストの操作を待っています...')).toBeInTheDocument();
+  });
+
   it('shows the connection status label to the participant', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
     mockConnectionStatus = 'error';
 
-    render(<QuizRoomView setView={vi.fn()} apiBaseUrl={API_BASE_URL} wsBaseUrl={WS_BASE_URL} onRoomCreated={vi.fn()} />);
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
 
     expect(screen.getByText('接続状態: 接続できませんでした')).toBeInTheDocument();
   });


### PR DESCRIPTION
## 概要
以下2点に対応する。

1. 参加者側で依然かるた表示が更新されない
2. 動線の見直し（参加者は既存通り、ホストのルーム開設導線をかるた読み上げ画面下部に移動）

## 1. 表示が更新されない件について

このセッションからは実際のAWS環境（CloudWatch Logs等）を確認できないため、#483の修正が実際に症状を解消したかは確証が持てない。今回、コードレビューで独立した2つの対策を行った。

### a. 参加者側の描画バグ（新規発見）
`QuizRoomView`の`renderParticipantContent`は、`roomState.type`が`"initial"`または未設定（`!roomState`）の場合だけ「待機中」を表示し、それ以外は`phrase`/`result`分岐に進んでいた。ところが、ルーム作成直後はサーバー側の状態が空オブジェクト`{}`のままsyncで返ってくるため、`roomState = {}`は`!roomState`にもtype判定にも一致せず、**どの分岐にも一致せず画面が空白（null）になる**バグがあった。既知のtype（`phrase`/`result`）以外はすべて「待機中」を表示するよう修正した。

### b. 自己修復ポーリング（保険的対策）
`useQuizRoomSync`に、接続中5秒ごとに`sync`を再要求する仕組みを追加した。#483で対応したのは「接続確立前後にブロードキャストが失われる」ケースだったが、根本原因が別にある可能性（個別のPostToConnection失敗等、このセッションからは検証できないAWS側の要因）も考え、プッシュ通知が届かなくても定期的に現在の状態を取り直すことで自己修復できるようにした。

## 2. 動線の見直し
- トップページの「クイズ大会モード」ボタンを「クイズ大会に参加する」に改称し、参加者向け（ルームコード入力・URL参加）専用にした。管理者としてのルーム開設導線はここから削除
- かるた読み上げ画面のフッターに「クイズ大会のルームを作成する」リンクを新設。ここから直接ルームを作成でき、作成後はルーム情報パネル（コード・URL・QR）に置き換わる

## Test plan
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 全106件成功
- [x] `backend`: `npm run lint` エラー0件
- [x] `backend`: `npm test -- --run` 全1309件成功（変更なし）
- [ ] マージ・再デプロイ後、参加者側の表示が正しく更新されるかの実機確認（このセッションからは実施できないため）

## 補足
「読み上げ（音声）」の同期再生は、issue #470着手時にユーザー自身が選定した「最小限スコープ」で明示的に対象外としており、今回も対応していません（管理者の端末でのみ音声が再生される設計のままです）。別途必要であれば、改めて設計してPR化します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_