### PR TITLE
fix(quiz-room): 参加者モードに「戻る」ボタンを追加する

### DIFF
--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -83,6 +83,9 @@ function QuizRoomView({ setView, wsBaseUrl }) {
         </header>
         <p className="text-muted small mb-3">接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}</p>
         {renderParticipantContent(roomState)}
+        <div className="mt-5">
+          <button onClick={() => setView("game")} className="btn btn-link text-muted text-decoration-none">← 戻る</button>
+        </div>
       </div>
     );
   }

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -85,4 +85,14 @@ describe('QuizRoomView', () => {
 
     expect(screen.getByText('接続状態: 接続できませんでした')).toBeInTheDocument();
   });
+
+  it('lets a participant leave the room and go back to the normal game view', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    const setView = vi.fn();
+
+    render(<QuizRoomView setView={setView} wsBaseUrl={WS_BASE_URL} />);
+    fireEvent.click(screen.getByText('← 戻る'));
+
+    expect(setView).toHaveBeenCalledWith('game');
+  });
 });


### PR DESCRIPTION
## 概要
「参加者モードから戻るボタンがない」という報告に対する修正。

## 原因
`QuizRoomView`は3つの分岐（準備中画面／ロビー画面／参加者画面）を持つが、参加者画面（`joinRoomId`が設定されている分岐）だけ「← 戻る」ボタンが存在せず、通常のゲーム画面に戻る手段がなかった。

## 対応
他の2画面と同じ「← 戻る」ボタンを参加者画面にも追加し、`setView("game")`で通常のゲーム画面へ戻れるようにした。

## Test plan
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 全109件成功
- [x] `backend`: `npm run lint` エラー0件 / 全1309件成功（変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_