### PR TITLE
feat(quiz-room): トップページに開設中のクイズ大会ルーム一覧を表示する

### DIFF
--- a/backend/quizRoomHandler.js
+++ b/backend/quizRoomHandler.js
@@ -1,5 +1,5 @@
 const crypto = require("crypto");
-const { GetCommand, PutCommand, UpdateCommand, DeleteCommand, QueryCommand } = require("@aws-sdk/lib-dynamodb");
+const { GetCommand, PutCommand, UpdateCommand, DeleteCommand, QueryCommand, ScanCommand } = require("@aws-sdk/lib-dynamodb");
 const { ApiGatewayManagementApiClient, PostToConnectionCommand } = require("@aws-sdk/client-apigatewaymanagementapi");
 const { docClient, resolveAllowedOrigin } = require("./handler");
 
@@ -70,6 +70,46 @@ exports.createQuizRoom = async (event) => {
       statusCode: 200,
       headers: { "Access-Control-Allow-Origin": allowedOrigin },
       body: JSON.stringify({ roomId, adminToken }),
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      statusCode: 500,
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
+      body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
+    };
+  }
+};
+
+// GET /quiz-rooms（REST API、issue #489）。開設中（TTLで失効していない）のルームを
+// 一覧で返す。トップページから、参加者がルームコードを知らなくても一覧から直接参加できる
+// ようにするための機能。管理者トークンのハッシュ等、参加者に不要な情報は返さない
+exports.listQuizRooms = async (event) => {
+  const allowedOrigin = resolveAllowedOrigin(event);
+  try {
+    const now = Math.floor(Date.now() / 1000);
+    const result = await docClient.send(new ScanCommand({
+      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+      ProjectionExpression: "roomId, createdAt, #state, #ttl",
+      ExpressionAttributeNames: { "#state": "state", "#ttl": "ttl" },
+      // TTLによる実際の削除には失効後最大48時間程度のラグが生じ得るため、
+      // 削除待ちの失効済みルームを一覧から明示的に除外する
+      FilterExpression: "#ttl > :now",
+      ExpressionAttributeValues: { ":now": now },
+    }));
+
+    const rooms = (result.Items || [])
+      .map((item) => ({
+        roomId: item.roomId,
+        createdAt: item.createdAt,
+        category: item.state?.content?.category || null,
+      }))
+      .sort((a, b) => b.createdAt - a.createdAt);
+
+    return {
+      statusCode: 200,
+      headers: { "Access-Control-Allow-Origin": allowedOrigin },
+      body: JSON.stringify({ rooms }),
     };
   } catch (error) {
     console.error(error);

--- a/backend/quizRoomHandler.test.js
+++ b/backend/quizRoomHandler.test.js
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
-import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, DeleteCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, DeleteCommand, QueryCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
 import { ApiGatewayManagementApiClient, PostToConnectionCommand } from '@aws-sdk/client-apigatewaymanagementapi';
 import crypto from 'crypto';
 import {
   createQuizRoom,
+  listQuizRooms,
   connectQuizRoom,
   disconnectQuizRoom,
   syncQuizRoom,
@@ -65,6 +66,57 @@ describe('createQuizRoom', () => {
   it('handles errors', async () => {
     ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
     const response = await createQuizRoom({ body: '{}' });
+    expect(response.statusCode).toBe(500);
+  });
+});
+
+describe('listQuizRooms', () => {
+  it('returns open rooms sorted by newest first, without leaking adminTokenHash', async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        { roomId: 'ROOM01', createdAt: 1000, state: {}, adminTokenHash: 'secret-hash-1' },
+        { roomId: 'ROOM02', createdAt: 3000, state: { type: 'phrase', content: { category: 'Cat1' } }, adminTokenHash: 'secret-hash-2' },
+        { roomId: 'ROOM03', createdAt: 2000, state: { type: 'initial' }, adminTokenHash: 'secret-hash-3' },
+      ],
+    });
+
+    const response = await listQuizRooms({});
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body.rooms).toEqual([
+      { roomId: 'ROOM02', createdAt: 3000, category: 'Cat1' },
+      { roomId: 'ROOM03', createdAt: 2000, category: null },
+      { roomId: 'ROOM01', createdAt: 1000, category: null },
+    ]);
+    // adminTokenHashが応答に含まれていないことを確認する
+    expect(JSON.stringify(body)).not.toContain('secret-hash');
+  });
+
+  it('excludes rooms whose ttl has already passed via the filter expression', async () => {
+    ddbMock.on(ScanCommand).resolves({ Items: [] });
+
+    const response = await listQuizRooms({});
+
+    expect(response.statusCode).toBe(200);
+    const scanCall = ddbMock.commandCalls(ScanCommand)[0].args[0].input;
+    expect(scanCall.FilterExpression).toBe('#ttl > :now');
+    expect(scanCall.ExpressionAttributeNames).toEqual({ '#state': 'state', '#ttl': 'ttl' });
+  });
+
+  it('returns an empty list when no rooms are open', async () => {
+    ddbMock.on(ScanCommand).resolves({ Items: [] });
+
+    const response = await listQuizRooms({});
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body.rooms).toEqual([]);
+  });
+
+  it('handles errors', async () => {
+    ddbMock.on(ScanCommand).rejects(new Error('DynamoDB error'));
+    const response = await listQuizRooms({});
     expect(response.statusCode).toBe(500);
   });
 });

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -49,11 +49,12 @@ provider:
           Action:
             - s3:GetObject
           Resource: !Sub "${EfudaPdfBucket.Arn}/*"
-        - Effect: Allow # 追加（クイズ大会モード: ルーム・接続情報の読み書き）
+        - Effect: Allow # 追加（クイズ大会モード: ルーム・接続情報の読み書き、issue #489: トップページの一覧表示用にScanを追加）
           Action:
             - dynamodb:GetItem
             - dynamodb:PutItem
             - dynamodb:UpdateItem
+            - dynamodb:Scan
           Resource:
             - !GetAtt QuizRoomsTable.Arn
         - Effect: Allow # 追加（クイズ大会モード: 接続情報の読み書き・ルーム単位の一覧取得）
@@ -185,6 +186,14 @@ functions:
       - http:
           path: quiz-room
           method: post
+          cors:
+            origins: ${self:custom.allowedOrigins}
+  listQuizRooms: # 追加（クイズ大会モード、issue #489）。開設中のルーム一覧をトップページ表示用に返す
+    handler: quizRoomHandler.listQuizRooms
+    events:
+      - http:
+          path: quiz-rooms
+          method: get
           cors:
             origins: ${self:custom.allowedOrigins}
   connectQuizRoom: # 追加（クイズ大会モード）。WebSocket接続時にroomId/adminTokenから役割を判定する

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -116,6 +116,8 @@ function App() {
   const [quizRoom, setQuizRoom] = useState(null); // { roomId, adminToken } | null
   const [creatingQuizRoom, setCreatingQuizRoom] = useState(false);
   const [quizRoomCreateError, setQuizRoomCreateError] = useState(null);
+  // トップページ下部に表示する、開設中のクイズ大会ルーム一覧（issue #489）
+  const [openQuizRooms, setOpenQuizRooms] = useState([]);
 
   // コメント投稿用の状態
   const [commentText, setCommentText] = useState("");
@@ -334,6 +336,26 @@ function App() {
     }
     };
     fetchCategories();
+  }, []);
+
+  // クイズ大会モード（issue #489）: トップページ下部に開設中のルーム一覧を表示するため、
+  // WebSocket未設定（機能自体が準備中）の場合は取得を試みない
+  useEffect(() => {
+    if (!WS_BASE_URL) {
+      return;
+    }
+    const fetchOpenQuizRooms = async () => {
+      try {
+        const response = await fetch(`${API_BASE_URL}/quiz-rooms`);
+        const data = await response.json();
+        if (response.ok) {
+          setOpenQuizRooms(data.rooms || []);
+        }
+      } catch (error) {
+        console.error("Failed to fetch open quiz rooms:", error);
+      }
+    };
+    fetchOpenQuizRooms();
   }, []);
 
   // カテゴリが選択されたら、選択中の全カテゴリの札IDリストを取得して結合する
@@ -944,6 +966,15 @@ function App() {
     }
   };
 
+  // クイズ大会モード（issue #489）: トップページの一覧から直接、参加者としてルームに入る。
+  // QuizRoomViewはマウント時に一度だけURLの?roomId=を読むため、view切り替えの前にURLへ反映する
+  const joinQuizRoom = (roomId) => {
+    const params = new URLSearchParams(window.location.search);
+    params.set("roomId", roomId);
+    window.history.pushState({}, "", `?${params.toString()}`);
+    setView("quiz-room");
+  };
+
   const resetGame = () => {
     setSelectedCategories([]);
     setDraftCategories([]);
@@ -1170,6 +1201,24 @@ function App() {
             クイズ大会に参加する
           </button>
         </div>
+
+        {openQuizRooms.length > 0 && (
+          <div className="mx-auto mt-4" style={{ maxWidth: "400px" }}>
+            <p className="text-muted small text-center mb-2">開設中のクイズ大会ルーム</p>
+            <div className="list-group shadow-sm rounded">
+              {openQuizRooms.map((room) => (
+                <button
+                  key={room.roomId}
+                  onClick={() => joinQuizRoom(room.roomId)}
+                  className="list-group-item list-group-item-action d-flex align-items-center justify-content-between"
+                >
+                  <span className="fw-bold notranslate">{room.roomId}</span>
+                  <span className="text-muted small">{room.category || "開始前"}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     );
   }

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2398,4 +2398,63 @@ describe('App', () => {
       state: { type: 'phrase', content: { category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: undefined } },
     });
   }, 40000);
+
+  it('shows the list of open quiz rooms on the top page and lets a participant join directly from it (issue #489)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+      }
+      send() {}
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('/quiz-rooms')) {
+        return {
+          ok: true,
+          json: async () => ({
+            rooms: [
+              { roomId: 'ABC123', createdAt: 2, category: 'Cat1' },
+              { roomId: 'DEF456', createdAt: 1, category: null },
+            ],
+          }),
+        };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [] }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    expect(await screen.findByText('開設中のクイズ大会ルーム')).toBeInTheDocument();
+    expect(screen.getByText('ABC123')).toBeInTheDocument();
+    expect(screen.getByText('Cat1')).toBeInTheDocument();
+    expect(screen.getByText('DEF456')).toBeInTheDocument();
+    expect(screen.getByText('開始前')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('ABC123'));
+
+    expect(await screen.findByText('クイズ大会モード（参加者）')).toBeInTheDocument();
+    expect(screen.getByText('ルーム: ABC123')).toBeInTheDocument();
+  });
+
+  it('does not show the open-room list section when there are no open quiz rooms', async () => {
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('/quiz-rooms')) return { ok: true, json: async () => ({ rooms: [] }) };
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [] }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    await screen.findByText('かるた読み上げアプリ');
+    expect(screen.queryByText('開設中のクイズ大会ルーム')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
issue #489対応。ルームコードの体系は変更せず、開設中のクイズ大会ルームをトップページ下部に一覧表示し、そこから直接参加できるようにした。

## 対応内容
- `GET /quiz-rooms`（新規）: `QuizRoomsTable`をScanし、TTLで失効していないルームを`{roomId, createdAt, category}`のみに絞って返す。`ProjectionExpression`により管理者トークンのハッシュ等の秘匿情報は取得段階から除外し、応答に一切含まれない。
- トップページ（分類未選択時）マウント時に一覧を一度だけ取得し、開設中のルームがあれば「ルームコード＋カテゴリ（未開始なら「開始前」）」の一覧を表示する。
- 一覧の各ルームをクリックすると、URLの`?roomId=`を設定した上で参加者画面へ直接遷移する（既存の招待URLと同じ仕組みを利用）。

## 設計判断
- ルームコード自体（`ROOM_CODE_CHARS`/`ROOM_CODE_LENGTH`）は変更していない。
- ルーム一覧は認証なしで誰でも閲覧可能になるが、管理者トークンは一覧経由でも一切露出しないため、ルーム操作の安全性には影響しない。

## Test plan
- [x] `backend`: `npm run lint` エラー0件
- [x] `backend`: `npm test -- --run` 全1313件成功（`listQuizRooms`のテスト4件を追加）
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 全111件成功（一覧表示・クリック参加・非表示の3ケースを追加）
- [ ] 実際のAWS環境でのデプロイ確認（このセッションからは未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_