### PR TITLE
chore(release): v1.28.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.28.0](https://github.com/bamiyanapp/karuta/compare/v1.27.1...v1.28.0) (2026-07-16)
+
+
+### Features
+
+* **quiz-room:** トップページに開設中のクイズ大会ルーム一覧を表示する ([#493](https://github.com/bamiyanapp/karuta/issues/493)) ([8e6332b](https://github.com/bamiyanapp/karuta/commit/8e6332b2b7279ff75a7db619f2214781300f8719))
+
 ## [1.27.1](https://github.com/bamiyanapp/karuta/compare/v1.27.0...v1.27.1) (2026-07-16)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
+    "version": "1.28.0",
+    "date": "2026/07/04 07:03",
+    "body": "### Features\n\n* **quiz-room:** トップページに開設中のクイズ大会ルーム一覧を表示する ([#493](https://github.com/bamiyanapp/karuta/issues/493)) ([8e6332b](https://github.com/bamiyanapp/karuta/commit/8e6332b2b7279ff75a7db619f2214781300f8719))"
+  },
+  {
     "version": "1.27.1",
-    "date": "2026/07/16",
+    "date": "2026/07/16 04:07",
     "body": "### Bug Fixes\n\n* **quiz-room:** 参加者モードに「戻る」ボタンを追加する ([#491](https://github.com/bamiyanapp/karuta/issues/491)) ([015e986](https://github.com/bamiyanapp/karuta/commit/015e986bdd8fb8a8ba2729d27283a9c0641a9699))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.27.1",
+      "version": "1.28.0",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.27.1"
+  "version": "1.28.0"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。