### PR TITLE
feat(quiz-room): 参加者側でも読み上げ音声を再生できるようにする

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -897,7 +897,9 @@ function App() {
       const p = displayContent.content;
       broadcastQuizRoomState({
         type: "phrase",
-        content: { category: p.category, kana: p.kana, phrase: p.phrase, level: p.level, answer: p.answer },
+        // idを含めるのは、参加者側（issue #490）が自分自身で/get-phraseを呼び直し、
+        // 同じ札の音声を取得・再生できるようにするため
+        content: { id: p.id, category: p.category, kana: p.kana, phrase: p.phrase, level: p.level, answer: p.answer },
       });
     } else if (displayContent.type === "result" && displayContent.content) {
       const r = displayContent.content;

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2395,7 +2395,7 @@ describe('App', () => {
     const payload = JSON.parse(ws.sent.find((msg) => msg.includes('"type":"phrase"')));
     expect(payload).toEqual({
       action: 'updateState',
-      state: { type: 'phrase', content: { category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: undefined } },
+      state: { type: 'phrase', content: { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: undefined } },
     });
   }, 40000);
 

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -1,5 +1,7 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuizRoomSync } from "../hooks/useQuizRoomSync";
+import { useLocalStorageState } from "../hooks/useLocalStorageState";
+import { API_BASE_URL } from "../config";
 
 // クイズ大会モード（issue #470）の参加者用入口（閲覧専用）。
 // ルームコードの直接入力、または招待URL（?roomId=...）からの参加に対応する。
@@ -65,6 +67,77 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     onState: setRoomState,
   });
 
+  // issue #490: 音声同期再生は明示的にスコープ外だった（管理者端末でのみ再生）ため、
+  // 参加者側は通知（roomState）を受けて自分自身で/get-phraseを呼び直し、取得した
+  // 音声を再生する。同じ設定であれば/get-phrase側のPollyキャッシュがヒットするため、
+  // 参加者が増えてもPollyの合成コストは増えない
+  const [audioEnabled, setAudioEnabled] = useLocalStorageState(
+    "quizRoomAudioEnabled", true, (v) => v === "true", (v) => String(v)
+  );
+  const [playbackBlocked, setPlaybackBlocked] = useState(false);
+  const [repeatCount] = useLocalStorageState("repeatCount", 2, (v) => parseInt(v, 10));
+  const [speechRate] = useLocalStorageState("speechRate", "80%");
+  const [lang] = useLocalStorageState("lang", "ja");
+  const [voiceId] = useLocalStorageState("voiceId", "Mizuki");
+  const lastPlayedKeyRef = useRef(null);
+  const lastAudioDataRef = useRef(null);
+  const currentAudioRef = useRef(null);
+
+  useEffect(() => {
+    if (!audioEnabled || roomState?.type !== "phrase" || !roomState.content?.id) {
+      return;
+    }
+    const { id, category } = roomState.content;
+    const key = `${category}:${id}`;
+    if (lastPlayedKeyRef.current === key) {
+      return;
+    }
+    lastPlayedKeyRef.current = key;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const apiUrl = `${API_BASE_URL}/get-phrase?id=${id}&category=${encodeURIComponent(category)}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}&voiceId=${encodeURIComponent(voiceId)}&announceCategory=false`;
+        const response = await fetch(apiUrl);
+        const data = await response.json();
+        if (cancelled || !response.ok || !data.audioData) {
+          return;
+        }
+        lastAudioDataRef.current = data.audioData;
+        // 前の札の音声がまだ再生中なら、次の札の音声と重なって再生されないよう止める
+        currentAudioRef.current?.pause();
+        const audio = new Audio(data.audioData);
+        currentAudioRef.current = audio;
+        await audio.play();
+        if (!cancelled) {
+          setPlaybackBlocked(false);
+        }
+      } catch (error) {
+        console.error("Failed to play quiz room audio:", error);
+        if (!cancelled) {
+          setPlaybackBlocked(true);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [roomState, audioEnabled, repeatCount, speechRate, lang, voiceId]);
+
+  // 自動再生がブラウザにブロックされた場合（ユーザー操作を伴わない再生）の救済策。
+  // 直近取得済みの音声データをこのクリック操作（ユーザー操作）を起点に再生し直す
+  const retryPlayback = () => {
+    if (!lastAudioDataRef.current) {
+      return;
+    }
+    const audio = new Audio(lastAudioDataRef.current);
+    currentAudioRef.current = audio;
+    audio.play()
+      .then(() => setPlaybackBlocked(false))
+      .catch(() => setPlaybackBlocked(true));
+  };
+
   if (!wsBaseUrl) {
     return (
       <div className="container py-5 mx-auto text-center">
@@ -81,7 +154,20 @@ function QuizRoomView({ setView, wsBaseUrl }) {
           <h1 className="h4 fw-bold">クイズ大会モード（参加者）</h1>
           <p className="text-muted small">ルーム: {joinRoomId}</p>
         </header>
-        <p className="text-muted small mb-3">接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}</p>
+        <p className="text-muted small mb-3">
+          接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}
+          <button
+            onClick={() => setAudioEnabled((v) => !v)}
+            className="btn btn-sm btn-link text-muted text-decoration-none py-0"
+          >
+            {audioEnabled ? "🔊 音声ON" : "🔇 音声OFF"}
+          </button>
+        </p>
+        {playbackBlocked && audioEnabled && (
+          <button onClick={retryPlayback} className="btn btn-sm btn-outline-dark rounded-pill mb-3">
+            🔊 タップして音声を有効にする
+          </button>
+        )}
         {renderParticipantContent(roomState)}
         <div className="mt-5">
           <button onClick={() => setView("game")} className="btn btn-link text-muted text-decoration-none">← 戻る</button>

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -20,14 +20,33 @@ function emitState(state) {
   });
 }
 
+window.fetch = vi.fn();
+
+const audioInstances = [];
+let audioPlayImpl = () => Promise.resolve();
+
+// App.test.jsxと同様の理由でアロー関数ではなく通常の関数式を使う（newで呼び出すため）
+window.Audio = vi.fn().mockImplementation(function (src) {
+  this.src = src;
+  this.play = vi.fn(() => audioPlayImpl());
+  this.pause = vi.fn();
+  audioInstances.push(this);
+});
+
 beforeEach(() => {
   onStateCallbacks.length = 0;
   mockConnectionStatus = 'connected';
+  fetch.mockReset();
+  audioInstances.length = 0;
+  audioPlayImpl = () => Promise.resolve();
+  localStorage.clear();
 });
 
 afterEach(() => {
   window.history.pushState({}, '', '/');
-  vi.restoreAllMocks();
+  // restoreAllMocksだとwindow.Audio/window.fetchに設定したmockImplementationも
+  // 消えてしまう（モック自体は一度きりの生成のため）ので、呼び出し履歴だけを消すclearを使う
+  vi.clearAllMocks();
 });
 
 describe('QuizRoomView', () => {
@@ -94,5 +113,103 @@ describe('QuizRoomView', () => {
     fireEvent.click(screen.getByText('← 戻る'));
 
     expect(setView).toHaveBeenCalledWith('game');
+  });
+
+  it('fetches and plays audio for a broadcast phrase using the participant\'s own local playback settings (issue #490)', async () => {
+    localStorage.setItem('repeatCount', '3');
+    localStorage.setItem('speechRate', '70%');
+    localStorage.setItem('voiceId', 'Takumi');
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }),
+    });
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '3' } });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const requestedUrl = fetch.mock.calls[0][0];
+    expect(requestedUrl).toContain('id=p1');
+    expect(requestedUrl).toContain('category=Cat1');
+    expect(requestedUrl).toContain('repeatCount=3');
+    expect(requestedUrl).toContain('voiceId=Takumi');
+    expect(requestedUrl).toContain('announceCategory=false');
+    expect(audioInstances).toHaveLength(1);
+    expect(audioInstances[0].src).toBe('data:audio/mp3;base64,DUMMY');
+    expect(audioInstances[0].play).toHaveBeenCalled();
+  });
+
+  it('stops the still-playing previous phrase audio when the next phrase arrives, to avoid overlapping playback', async () => {
+    fetch.mockResolvedValue({ ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }) });
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(audioInstances).toHaveLength(1);
+
+    emitState({ type: 'phrase', content: { id: 'p2', category: 'Cat1', phrase: '読み札2', level: '3' } });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(audioInstances).toHaveLength(2);
+    expect(audioInstances[0].pause).toHaveBeenCalled();
+  });
+
+  it('does not fetch or play audio for a broadcast phrase while muted', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }) });
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+
+    expect(screen.getByText('🔊 音声ON')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('🔊 音声ON'));
+    expect(screen.getByText('🔇 音声OFF')).toBeInTheDocument();
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(audioInstances).toHaveLength(0);
+  });
+
+  it('shows a retry button when playback is blocked (autoplay policy), and lets the participant retry with a tap', async () => {
+    audioPlayImpl = () => Promise.reject(new Error('NotAllowedError'));
+    fetch.mockResolvedValueOnce({ ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }) });
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+
+    const retryButton = await screen.findByText('🔊 タップして音声を有効にする');
+    expect(audioInstances).toHaveLength(1);
+
+    audioPlayImpl = () => Promise.resolve();
+    fireEvent.click(retryButton);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(audioInstances).toHaveLength(2);
+    expect(audioInstances[1].src).toBe('data:audio/mp3;base64,DUMMY');
+    expect(screen.queryByText('🔊 タップして音声を有効にする')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 概要
issue #490対応。クイズ大会モードの参加者側で読み上げ音声が再生されない問題を解消した。

## 対応内容（issue #490の案A採用）
- WebSocketブロードキャストの内容には音声データを含めず、出題札の`id`のみを追加。
- 参加者側クライアントは`id`の変化を検知すると自分自身で`/get-phrase`を呼び直し、取得した音声を再生する。
  - `/get-phrase`はPollyの合成結果をキャッシュしているため、管理者が最初に取得済みの音声（同一設定の場合）はキャッシュヒットし、参加者数が増えてもPollyの合成コストは増えない。
  - 再生設定（repeatCount/speechRate/lang/voiceId）は、通常のかるた読み上げ画面と同じlocalStorageの値をそのまま使う。
- ブラウザの自動再生ブロック対策として、再生に失敗した場合は「🔊 タップして音声を有効にする」ボタンを表示し、タップで再試行できるようにした。
- ミュート切り替え（🔊 音声ON / 🔇 音声OFF）を追加し、オン/オフはlocalStorageに保持する。
- 前の札の音声が再生中のまま次の札の通知が届いた場合は、重複再生を避けるため前の音声を明示的に停止する。

## 既知の制約（issue記載どおり）
- 端末間の再生開始タイミングは完全には一致しない（数百ms〜のずれが生じ得る）。完全な同時再生（案B）は実装コストが大きいため今回は見送り。

## Test plan
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 全115件成功（音声取得・再生／ミュート／再生ブロック時のリトライ／重複再生防止のテスト4件を追加）
- [x] `backend`: `npm run lint` エラー0件 / `npm test -- --run` 全1313件成功（変更なし）
- [ ] 実機ブラウザでの自動再生ブロック挙動の目視確認（このセッションからは未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_