### PR TITLE
chore(release): v1.29.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.29.0](https://github.com/bamiyanapp/karuta/compare/v1.28.0...v1.29.0) (2026-07-16)
+
+
+### Features
+
+* **quiz-room:** 参加者側でも読み上げ音声を再生できるようにする ([#495](https://github.com/bamiyanapp/karuta/issues/495)) ([dcfd304](https://github.com/bamiyanapp/karuta/commit/dcfd304e5dae0aaa5a0f5899cd75e825b539329a))
+
 # [1.28.0](https://github.com/bamiyanapp/karuta/compare/v1.27.1...v1.28.0) (2026-07-16)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
+    "version": "1.29.0",
+    "date": "2026/07/04 07:26",
+    "body": "### Features\n\n* **quiz-room:** 参加者側でも読み上げ音声を再生できるようにする ([#495](https://github.com/bamiyanapp/karuta/issues/495)) ([dcfd304](https://github.com/bamiyanapp/karuta/commit/dcfd304e5dae0aaa5a0f5899cd75e825b539329a))"
+  },
+  {
     "version": "1.28.0",
-    "date": "2026/07/04 07:03",
+    "date": "2026/07/16 05:38",
     "body": "### Features\n\n* **quiz-room:** トップページに開設中のクイズ大会ルーム一覧を表示する ([#493](https://github.com/bamiyanapp/karuta/issues/493)) ([8e6332b](https://github.com/bamiyanapp/karuta/commit/8e6332b2b7279ff75a7db619f2214781300f8719))"
   },
   {
@@ -271,7 +276,7 @@
   },
   {
     "version": "1.28.0",
-    "date": "2026/07/04 07:03",
+    "date": "2026/07/16 05:38",
     "body": "### Features\n\n* **score:** プレイヤー別の取り札スコア記録機能を追加 ([#251](https://github.com/bamiyanapp/karuta/issues/251)) ([627c875](https://github.com/bamiyanapp/karuta/commit/627c875c4f81947375539425cda73478cda58449))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.28.0",
+      "version": "1.29.0",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.28.0"
+  "version": "1.29.0"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。