### PR TITLE
style(quiz-room): ルーム開設・ルーム情報表示をボタン表現にし、種類選択ボタンの文字色を修正する

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1628,7 +1628,7 @@ function App() {
       <p className="text-muted small mb-4">履歴はこのタブを閉じるまで保持されます（リロードしても消えません）。</p>
       <div className="d-flex flex-wrap gap-2 justify-content-center mb-4">
         <button onClick={() => setView("print-efuda")} className="btn btn-outline-dark px-4 rounded-pill">絵札を印刷する</button>
-        <button onClick={resetGame} className="btn btn-outline-secondary px-4 rounded-pill">かるたの種類を選び直す</button>
+        <button onClick={resetGame} className="btn btn-outline-dark px-4 rounded-pill">かるたの種類を選び直す</button>
       </div>
       {quizRoom ? (
         <QuizRoomInfoPanel roomId={quizRoom.roomId} />
@@ -1638,7 +1638,7 @@ function App() {
             type="button"
             onClick={createQuizRoom}
             disabled={creatingQuizRoom}
-            className="btn btn-link text-decoration-none"
+            className="btn btn-outline-dark px-4 rounded-pill"
           >
             {creatingQuizRoom ? "作成中..." : "クイズ大会のルームを作成する"}
           </button>

--- a/frontend/src/components/QuizRoomInfoPanel.jsx
+++ b/frontend/src/components/QuizRoomInfoPanel.jsx
@@ -37,7 +37,7 @@ function QuizRoomInfoPanel({ roomId }) {
       <button
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
-        className="btn btn-link text-decoration-none"
+        className="btn btn-outline-dark px-4 rounded-pill"
       >
         {expanded ? "ルーム情報を隠す" : "ルーム情報を表示（クイズ大会モード）"}
       </button>


### PR DESCRIPTION
## 概要
読み札画面の「ルーム開設」「ルーム情報表示」をボタン表現にし、あわせて「かるたの種類を選び直す」ボタンの文字を黒字にした。

## 対応内容
- 「クイズ大会のルームを作成する」ボタン（`frontend/src/App.jsx`）: リンク風の`btn btn-link text-decoration-none`から、同じ画面の隣接ボタン「絵札を印刷する」と同じ`btn btn-outline-dark px-4 rounded-pill`へ変更。
- 「ルーム情報を表示（クイズ大会モード）/隠す」ボタン（`frontend/src/components/QuizRoomInfoPanel.jsx`）: 同様にリンク風から`btn btn-outline-dark px-4 rounded-pill`へ変更。
- 「かるたの種類を選び直す」ボタン: `btn-outline-secondary`（グレー系文字色）から`btn-outline-dark`（黒系文字色）へ変更し、隣の「絵札を印刷する」ボタンと統一。

見た目（className）のみの変更で、クリック時の挙動は変更していない。

## Test plan
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 全115件成功（既存テストのみ、className変更のため新規テストは不要と判断）
- [x] `backend`: `npm run lint` エラー0件 / `npm test -- --run` 全1313件成功（変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_