### PR TITLE
feat(quiz-room): 参加者側の音声を常時オンにし、管理者の読み上げ設定に合わせる

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -897,9 +897,14 @@ function App() {
       const p = displayContent.content;
       broadcastQuizRoomState({
         type: "phrase",
-        // idを含めるのは、参加者側（issue #490）が自分自身で/get-phraseを呼び直し、
-        // 同じ札の音声を取得・再生できるようにするため
-        content: { id: p.id, category: p.category, kana: p.kana, phrase: p.phrase, level: p.level, answer: p.answer },
+        content: {
+          // idを含めるのは、参加者側（issue #490）が自分自身で/get-phraseを呼び直し、
+          // 同じ札の音声を取得・再生できるようにするため
+          id: p.id, category: p.category, kana: p.kana, phrase: p.phrase, level: p.level, answer: p.answer,
+          // 読み上げ設定（issue #498）: 参加者自身のローカル設定ではなく、管理者と
+          // 同じ内容で聞こえるよう、管理者側の設定値をそのまま一緒に配信する
+          repeatCount, speechRate, lang, voiceId, announceCategory: isMultiCategorySelection,
+        },
       });
     } else if (displayContent.type === "result" && displayContent.content) {
       const r = displayContent.content;
@@ -910,7 +915,7 @@ function App() {
     } else {
       broadcastQuizRoomState({ type: "initial" });
     }
-  }, [quizRoom, displayContent, broadcastQuizRoomState]);
+  }, [quizRoom, displayContent, broadcastQuizRoomState, repeatCount, speechRate, lang, voiceId, isMultiCategorySelection]);
 
   useEffect(() => {
     if (view === "comments") {

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2331,6 +2331,13 @@ describe('App', () => {
   }, 40000);
 
   it('lets an admin open a quiz room, keeps them on the normal game screen, shows the room info panel, and broadcasts phrase changes over the WebSocket (issue #470)', async () => {
+    // 読み上げ設定はlocalStorageに永続化されており、他のテストの実行順序に
+    // 左右されないよう、ブロードキャスト内容として期待する値を明示的に固定する
+    localStorage.setItem('repeatCount', '2');
+    localStorage.setItem('speechRate', '80%');
+    localStorage.setItem('lang', 'ja');
+    localStorage.setItem('voiceId', 'Mizuki');
+
     class MockWebSocket {
       constructor(url) {
         this.url = url;
@@ -2395,7 +2402,13 @@ describe('App', () => {
     const payload = JSON.parse(ws.sent.find((msg) => msg.includes('"type":"phrase"')));
     expect(payload).toEqual({
       action: 'updateState',
-      state: { type: 'phrase', content: { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: undefined } },
+      state: {
+        type: 'phrase',
+        content: {
+          id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: undefined,
+          repeatCount: 2, speechRate: '80%', lang: 'ja', voiceId: 'Mizuki', announceCategory: false,
+        },
+      },
     });
   }, 40000);
 

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuizRoomSync } from "../hooks/useQuizRoomSync";
-import { useLocalStorageState } from "../hooks/useLocalStorageState";
 import { API_BASE_URL } from "../config";
 
 // クイズ大会モード（issue #470）の参加者用入口（閲覧専用）。
@@ -70,24 +69,22 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   // issue #490: 音声同期再生は明示的にスコープ外だった（管理者端末でのみ再生）ため、
   // 参加者側は通知（roomState）を受けて自分自身で/get-phraseを呼び直し、取得した
   // 音声を再生する。同じ設定であれば/get-phrase側のPollyキャッシュがヒットするため、
-  // 参加者が増えてもPollyの合成コストは増えない
-  const [audioEnabled, setAudioEnabled] = useLocalStorageState(
-    "quizRoomAudioEnabled", true, (v) => v === "true", (v) => String(v)
-  );
+  // 参加者が増えてもPollyの合成コストは増えない。
+  // issue #497: ミュート操作は設けず常にオンとする（ブラウザの自動再生ポリシーで
+  // 再生自体がブロックされた場合の救済策としてのretryPlaybackのみ用意する）。
+  // issue #498: 再生設定（repeatCount/speechRate/lang/voiceId/announceCategory）は
+  // 参加者自身のlocalStorageではなく、管理者からのブロードキャスト内容（roomState.content）
+  // に含まれる値を使い、全員が管理者と同じ内容で聞こえるようにする
   const [playbackBlocked, setPlaybackBlocked] = useState(false);
-  const [repeatCount] = useLocalStorageState("repeatCount", 2, (v) => parseInt(v, 10));
-  const [speechRate] = useLocalStorageState("speechRate", "80%");
-  const [lang] = useLocalStorageState("lang", "ja");
-  const [voiceId] = useLocalStorageState("voiceId", "Mizuki");
   const lastPlayedKeyRef = useRef(null);
   const lastAudioDataRef = useRef(null);
   const currentAudioRef = useRef(null);
 
   useEffect(() => {
-    if (!audioEnabled || roomState?.type !== "phrase" || !roomState.content?.id) {
+    if (roomState?.type !== "phrase" || !roomState.content?.id) {
       return;
     }
-    const { id, category } = roomState.content;
+    const { id, category, repeatCount, speechRate, lang, voiceId, announceCategory } = roomState.content;
     const key = `${category}:${id}`;
     if (lastPlayedKeyRef.current === key) {
       return;
@@ -97,7 +94,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     let cancelled = false;
     (async () => {
       try {
-        const apiUrl = `${API_BASE_URL}/get-phrase?id=${id}&category=${encodeURIComponent(category)}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}&voiceId=${encodeURIComponent(voiceId)}&announceCategory=false`;
+        const apiUrl = `${API_BASE_URL}/get-phrase?id=${id}&category=${encodeURIComponent(category)}&repeatCount=${repeatCount ?? 2}&speechRate=${encodeURIComponent(speechRate ?? "80%")}&lang=${lang ?? "ja"}&voiceId=${encodeURIComponent(voiceId ?? "Mizuki")}&announceCategory=${!!announceCategory}`;
         const response = await fetch(apiUrl);
         const data = await response.json();
         if (cancelled || !response.ok || !data.audioData) {
@@ -123,7 +120,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     return () => {
       cancelled = true;
     };
-  }, [roomState, audioEnabled, repeatCount, speechRate, lang, voiceId]);
+  }, [roomState]);
 
   // 自動再生がブラウザにブロックされた場合（ユーザー操作を伴わない再生）の救済策。
   // 直近取得済みの音声データをこのクリック操作（ユーザー操作）を起点に再生し直す
@@ -154,16 +151,8 @@ function QuizRoomView({ setView, wsBaseUrl }) {
           <h1 className="h4 fw-bold">クイズ大会モード（参加者）</h1>
           <p className="text-muted small">ルーム: {joinRoomId}</p>
         </header>
-        <p className="text-muted small mb-3">
-          接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}
-          <button
-            onClick={() => setAudioEnabled((v) => !v)}
-            className="btn btn-sm btn-link text-muted text-decoration-none py-0"
-          >
-            {audioEnabled ? "🔊 音声ON" : "🔇 音声OFF"}
-          </button>
-        </p>
-        {playbackBlocked && audioEnabled && (
+        <p className="text-muted small mb-3">接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}</p>
+        {playbackBlocked && (
           <button onClick={retryPlayback} className="btn btn-sm btn-outline-dark rounded-pill mb-3">
             🔊 タップして音声を有効にする
           </button>

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -115,10 +115,12 @@ describe('QuizRoomView', () => {
     expect(setView).toHaveBeenCalledWith('game');
   });
 
-  it('fetches and plays audio for a broadcast phrase using the participant\'s own local playback settings (issue #490)', async () => {
-    localStorage.setItem('repeatCount', '3');
-    localStorage.setItem('speechRate', '70%');
-    localStorage.setItem('voiceId', 'Takumi');
+  it('fetches and plays audio for a broadcast phrase using the settings broadcast by the admin, not the participant\'s own local settings (issue #490, #498)', async () => {
+    // 参加者自身のローカル設定は無視され、管理者からブロードキャストされた設定が使われることを
+    // 確認するため、参加者側のlocalStorageにはあえて異なる値を入れておく
+    localStorage.setItem('repeatCount', '1');
+    localStorage.setItem('speechRate', '100%');
+    localStorage.setItem('voiceId', 'Kazuha');
     fetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }),
@@ -127,7 +129,13 @@ describe('QuizRoomView', () => {
 
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
 
-    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '3' } });
+    emitState({
+      type: 'phrase',
+      content: {
+        id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '3',
+        repeatCount: 3, speechRate: '70%', lang: 'ja', voiceId: 'Takumi', announceCategory: true,
+      },
+    });
 
     await act(async () => {
       await Promise.resolve();
@@ -139,11 +147,33 @@ describe('QuizRoomView', () => {
     expect(requestedUrl).toContain('id=p1');
     expect(requestedUrl).toContain('category=Cat1');
     expect(requestedUrl).toContain('repeatCount=3');
+    expect(requestedUrl).toContain('speechRate=70%25');
     expect(requestedUrl).toContain('voiceId=Takumi');
-    expect(requestedUrl).toContain('announceCategory=false');
+    expect(requestedUrl).toContain('announceCategory=true');
     expect(audioInstances).toHaveLength(1);
     expect(audioInstances[0].src).toBe('data:audio/mp3;base64,DUMMY');
     expect(audioInstances[0].play).toHaveBeenCalled();
+  });
+
+  it('falls back to sensible defaults when the broadcast phrase content has no playback settings', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }) });
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '3' } });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const requestedUrl = fetch.mock.calls[0][0];
+    expect(requestedUrl).toContain('repeatCount=2');
+    expect(requestedUrl).toContain('speechRate=80%25');
+    expect(requestedUrl).toContain('lang=ja');
+    expect(requestedUrl).toContain('voiceId=Mizuki');
+    expect(requestedUrl).toContain('announceCategory=false');
   });
 
   it('stops the still-playing previous phrase audio when the next phrase arrives, to avoid overlapping playback', async () => {
@@ -169,24 +199,13 @@ describe('QuizRoomView', () => {
     expect(audioInstances[0].pause).toHaveBeenCalled();
   });
 
-  it('does not fetch or play audio for a broadcast phrase while muted', async () => {
-    fetch.mockResolvedValueOnce({ ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }) });
+  it('does not show any manual "turn audio on" button, since audio playback is always on by default (issue #497)', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
 
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
 
-    expect(screen.getByText('🔊 音声ON')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('🔊 音声ON'));
-    expect(screen.getByText('🔇 音声OFF')).toBeInTheDocument();
-
-    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
-
-    await act(async () => {
-      await Promise.resolve();
-    });
-
-    expect(fetch).not.toHaveBeenCalled();
-    expect(audioInstances).toHaveLength(0);
+    expect(screen.queryByText('🔊 音声ON')).not.toBeInTheDocument();
+    expect(screen.queryByText('🔇 音声OFF')).not.toBeInTheDocument();
   });
 
   it('shows a retry button when playback is blocked (autoplay policy), and lets the participant retry with a tap', async () => {


### PR DESCRIPTION
## 概要
issue #497・#498対応。

## 対応内容

### issue #497: 音声をボタン操作なしで常にオンにする
- ミュート切り替えボタン「🔊 音声ON / 🔇 音声OFF」を廃止し、音声再生は常にオンにした。
- ブラウザの自動再生ポリシーにより再生が失敗した場合の救済策「🔊 タップして音声を有効にする」リトライボタンは、手動オン/オフとは性質が異なる（再生失敗時のみ表示される復旧導線）ため残した。

### issue #498: 参加者側の読み上げを管理者の設定に合わせる
- 管理者側のWebSocketブロードキャスト内容に`repeatCount`/`speechRate`/`lang`/`voiceId`/`announceCategory`を追加。
- 参加者側は自身のlocalStorage設定ではなく、ブロードキャストされたこれらの値で`/get-phrase`を呼び出すようにした。
- 声の種類（`voiceId`）も一致させることで、「同じ内容で喋らせる」という要望どおり読み上げ音声そのものが管理者と一致するようにした。
- 古い形式（設定値を含まない）の状態を受け取った場合に備え、既存のデフォルト値にフォールバックする。

## Test plan
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 全116件成功（管理者設定の優先利用・デフォルトへのフォールバック・ミュートボタン非表示の3件を追加、issue #470の既存テストを更新）
- [x] `backend`: `npm run lint` エラー0件 / `npm test -- --run` 全1313件成功（変更なし）
- [ ] 実機ブラウザでの自動再生・複数端末間の実際の聞こえ方の目視確認（このセッションからは未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_