### PR TITLE
chore(release): v1.30.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.30.0](https://github.com/bamiyanapp/karuta/compare/v1.29.0...v1.30.0) (2026-07-16)
+
+
+### Features
+
+* **quiz-room:** 参加者側の音声を常時オンにし、管理者の読み上げ設定に合わせる ([#504](https://github.com/bamiyanapp/karuta/issues/504)) ([866150e](https://github.com/bamiyanapp/karuta/commit/866150ecdbf067ae33d72071168b4c3aa95fe4ac))
+
 # [1.29.0](https://github.com/bamiyanapp/karuta/compare/v1.28.0...v1.29.0) (2026-07-16)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
+    "version": "1.30.0",
+    "date": "2026/07/04 21:56",
+    "body": "### Features\n\n* **quiz-room:** 参加者側の音声を常時オンにし、管理者の読み上げ設定に合わせる ([#504](https://github.com/bamiyanapp/karuta/issues/504)) ([866150e](https://github.com/bamiyanapp/karuta/commit/866150ecdbf067ae33d72071168b4c3aa95fe4ac))"
+  },
+  {
     "version": "1.29.0",
-    "date": "2026/07/04 07:26",
+    "date": "2026/07/16 05:52",
     "body": "### Features\n\n* **quiz-room:** 参加者側でも読み上げ音声を再生できるようにする ([#495](https://github.com/bamiyanapp/karuta/issues/495)) ([dcfd304](https://github.com/bamiyanapp/karuta/commit/dcfd304e5dae0aaa5a0f5899cd75e825b539329a))"
   },
   {
@@ -271,7 +276,7 @@
   },
   {
     "version": "1.29.0",
-    "date": "2026/07/04 07:26",
+    "date": "2026/07/16 05:52",
     "body": "### Features\n\n* **pwa:** ホーム画面追加導線をSafari/Android向けに追加 ([#253](https://github.com/bamiyanapp/karuta/issues/253)) ([80c78e6](https://github.com/bamiyanapp/karuta/commit/80c78e6c84ca6bf5d20686f98c297e878ba32612))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.29.0"
+  "version": "1.30.0"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。