### PR TITLE
fix(quiz-room): 管理者の設定変更が読み上げ中の音声配信とズレる競合状態を修正する

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -497,7 +497,7 @@ function App() {
       }
 
       setIsReading(true);
-      const { phraseData, audioData } = audioQueue[0];
+      const { phraseData, audioData, playbackSettings } = audioQueue[0];
 
       if (phraseData) {
         setCurrentPhrase(phraseData);
@@ -539,7 +539,7 @@ function App() {
 
         // 3秒待機してからフェードアニメーションを開始
         flipTimeoutRef.current = setTimeout(() => {
-          nextContentRef.current = { type: "phrase", content: phraseData };
+          nextContentRef.current = { type: "phrase", content: phraseData, playbackSettings };
           setIsFadingOut(true);
         }, 3000); // 待機時間
       }
@@ -772,7 +772,15 @@ function App() {
         }
       }
 
-      setAudioQueue(prev => [...prev, { phraseData: data, audioData: data.audioData }]);
+      // クイズ大会モード（issue #498）: このデータの取得に実際に使った設定を音声と一緒に
+      // 保持しておき、後で参加者へブロードキャストする際もこの値を使う。読み上げ開始まで
+      // 数秒の遅延があり、その間に管理者が設定を変更すると、ブロードキャスト時点の最新設定を
+      // 読むと「管理者が実際に聞いている音声」とズレてしまうため
+      setAudioQueue(prev => [...prev, {
+        phraseData: data,
+        audioData: data.audioData,
+        playbackSettings: { repeatCount, speechRate, lang, voiceId, announceCategory },
+      }]);
 
     } catch (error) {
       console.error("Error fetching phrase:", error);
@@ -895,15 +903,20 @@ function App() {
     }
     if (displayContent.type === "phrase" && displayContent.content) {
       const p = displayContent.content;
+      // 読み上げ設定（issue #498）は、ブロードキャスト時点の最新設定ではなく、この札の
+      // 音声を実際に取得した時点の設定（playbackSettings）を使う。読み上げ開始まで数秒の
+      // 遅延があり、その間に管理者が設定を変更すると、最新設定を読んでしまうと「管理者が
+      // 実際に聞いている音声」とズレるため
+      const settings = displayContent.playbackSettings
+        ?? { repeatCount, speechRate, lang, voiceId, announceCategory: isMultiCategorySelection };
       broadcastQuizRoomState({
         type: "phrase",
         content: {
           // idを含めるのは、参加者側（issue #490）が自分自身で/get-phraseを呼び直し、
           // 同じ札の音声を取得・再生できるようにするため
           id: p.id, category: p.category, kana: p.kana, phrase: p.phrase, level: p.level, answer: p.answer,
-          // 読み上げ設定（issue #498）: 参加者自身のローカル設定ではなく、管理者と
-          // 同じ内容で聞こえるよう、管理者側の設定値をそのまま一緒に配信する
-          repeatCount, speechRate, lang, voiceId, announceCategory: isMultiCategorySelection,
+          repeatCount: settings.repeatCount, speechRate: settings.speechRate, lang: settings.lang,
+          voiceId: settings.voiceId, announceCategory: settings.announceCategory,
         },
       });
     } else if (displayContent.type === "result" && displayContent.content) {

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2412,6 +2412,72 @@ describe('App', () => {
     });
   }, 40000);
 
+  it('broadcasts the settings actually used to fetch the admin\'s own audio, even if the admin changes the voice while that card is still being read out (issue #498)', async () => {
+    localStorage.setItem('repeatCount', '2');
+    localStorage.setItem('speechRate', '80%');
+    localStorage.setItem('lang', 'ja');
+    localStorage.setItem('voiceId', 'Mizuki');
+
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      if (url.includes('/get-phrase?')) {
+        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', audioData: 'dummy' }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    const ws = MockWebSocket.instances[0];
+    act(() => {
+      ws.readyState = MockWebSocket.OPEN;
+      ws.onopen?.();
+    });
+
+    fireEvent.click(screen.getByText('次の札'));
+    // 読み上げが完了しブロードキャストされるまでの数秒の間に、管理者が声の設定を変更する
+    fireEvent.click(screen.getByText('Takumi'));
+
+    await waitFor(() => {
+      const phraseBroadcast = ws.sent.find((msg) => msg.includes('"type":"phrase"'));
+      expect(phraseBroadcast).toBeDefined();
+    }, { timeout: 20000 });
+
+    const payload = JSON.parse(ws.sent.find((msg) => msg.includes('"type":"phrase"')));
+    // 実際に管理者が聞いている音声はvoiceId変更前に取得したものなので、ブロードキャストも
+    // 変更後のTakumiではなく、取得時点のMizukiのままであるべき
+    expect(payload.state.content.voiceId).toBe('Mizuki');
+  }, 40000);
+
   it('shows the list of open quiz rooms on the top page and lets a participant join directly from it (issue #489)', async () => {
     class MockWebSocket {
       constructor(url) {


### PR DESCRIPTION
## 概要
issue #498の追加対応（「声の種類が管理者と参加者で異なる」の報告を受けて）。

## 原因
1枚の札の読み上げには「`/get-phrase`で音声取得 → 約3秒待機 → フェード → ブロードキャスト」という数秒の遅延がある。PR #504時点の実装では、ブロードキャストする読み上げ設定（repeatCount/speechRate/lang/voiceId/announceCategory）を**ブロードキャスト時点の最新state**から読んでいたため、この数秒の間に管理者が声などの設定を変更すると、ブロードキャストだけ新しい設定を反映してしまい、管理者が実際に聞いている音声（変更前の設定で合成済み）と参加者へ配信される設定がズレる競合状態があった。

## 対応内容
- 読み上げ設定を`/get-phrase`取得時点で`playbackSettings`としてaudioQueueの各アイテムに保持し、`nextContentRef`・`displayContent`まで一緒に運ぶようにした。
- ブロードキャスト処理はこの`playbackSettings`（実際に使われた設定）を参照するように変更し、最新stateとのズレを解消した。

## Test plan
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 全117件成功（次の札読み上げ中に声の設定を変更しても、ブロードキャストされる声の種類が取得時点のまま変わらないことを検証するテストを追加）
- [x] `backend`: `npm run lint` エラー0件 / `npm test -- --run` 全1313件成功（変更なし）
- [ ] 実機ブラウザでの目視確認（このセッションからは未実施）

## 補足
このセッションからは実機での再現確認ができないため、上記が「管理者と参加者で声が異なる」の唯一の原因とは限りません（直近デプロイ直後にブラウザタブをリロードしていない場合、古いコードのままブロードキャストされ参加者側は新しいデフォルト値にフォールバックする、といった状況でも同様の症状になり得ます）。マージ後も再現する場合は、両端末で最新版をリロードした状態かどうかを確認いただけると助かります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_