### PR TITLE
fix(quiz-room): 参加者側の「音声を有効にする」ボタンを廃止し、自動再生の解錠で対応する

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import AllPhrasesView from "./views/AllPhrasesView";
 import CommentsView from "./views/CommentsView";
 import ChangelogView from "./views/ChangelogView";
 import QuizRoomView from "./views/QuizRoomView";
+import { unlockAudioPlayback } from "./utils/audioUnlock";
 import QuizRoomInfoPanel from "./components/QuizRoomInfoPanel";
 
 const HISTORY_STORAGE_KEY = "historyByCategory";
@@ -989,6 +990,9 @@ function App() {
   // クイズ大会モード（issue #489）: トップページの一覧から直接、参加者としてルームに入る。
   // QuizRoomViewはマウント時に一度だけURLの?roomId=を読むため、view切り替えの前にURLへ反映する
   const joinQuizRoom = (roomId) => {
+    // ブラウザの自動再生ポリシー対策（issue #497）: この参加操作（クリック）に
+    // 便乗して無音再生しておき、参加後の自動再生が通りやすくする
+    unlockAudioPlayback();
     const params = new URLSearchParams(window.location.search);
     params.set("roomId", roomId);
     window.history.pushState({}, "", `?${params.toString()}`);

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2520,6 +2520,13 @@ describe('App', () => {
 
     expect(await screen.findByText('クイズ大会モード（参加者）')).toBeInTheDocument();
     expect(screen.getByText('ルーム: ABC123')).toBeInTheDocument();
+
+    // ブラウザの自動再生ポリシー対策（issue #497）: 一覧からの参加クリックに便乗して
+    // 無音再生による解錠を行っていることを確認する
+    const silentAudioCall = window.Audio.mock.calls.find(
+      ([src]) => typeof src === 'string' && src.startsWith('data:audio/wav')
+    );
+    expect(silentAudioCall).toBeDefined();
   });
 
   it('does not show the open-room list section when there are no open quiz rooms', async () => {

--- a/frontend/src/utils/audioUnlock.js
+++ b/frontend/src/utils/audioUnlock.js
@@ -1,0 +1,13 @@
+// ブラウザの自動再生ポリシー対策（issue #497）: ユーザー操作（クリック/タップ）を
+// 伴わないaudio.play()は多くのブラウザでブロックされる。無音の音声をユーザー操作の
+// 延長として一度再生しておくと、以降のWebSocket通知に応じた自動再生（ユーザー操作を
+// 伴わない再生）が許可されやすくなるため、ボタンを出す代わりにこれで解決を図る
+const SILENT_AUDIO_DATA_URI = "data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=";
+
+export function unlockAudioPlayback() {
+  try {
+    new Audio(SILENT_AUDIO_DATA_URI).play().catch(() => {});
+  } catch {
+    // 対応していないブラウザでは何もしない
+  }
+}

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuizRoomSync } from "../hooks/useQuizRoomSync";
 import { API_BASE_URL } from "../config";
+import { unlockAudioPlayback } from "../utils/audioUnlock";
 
 // クイズ大会モード（issue #470）の参加者用入口（閲覧専用）。
 // ルームコードの直接入力、または招待URL（?roomId=...）からの参加に対応する。
@@ -70,15 +71,31 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   // 参加者側は通知（roomState）を受けて自分自身で/get-phraseを呼び直し、取得した
   // 音声を再生する。同じ設定であれば/get-phrase側のPollyキャッシュがヒットするため、
   // 参加者が増えてもPollyの合成コストは増えない。
-  // issue #497: ミュート操作は設けず常にオンとする（ブラウザの自動再生ポリシーで
-  // 再生自体がブロックされた場合の救済策としてのretryPlaybackのみ用意する）。
+  // issue #497: ボタン操作は設けず常にオンとする。ブラウザの自動再生ポリシー対策として、
+  // トップページのルーム一覧クリック（App.jsxのjoinQuizRoom）での解錠に加え、
+  // この画面自体が開かれた後の最初のクリック/タップでも解錠する（下記useEffect。
+  // 招待URLからの直接アクセス等、参加操作のクリックを経ない場合の保険）
   // issue #498: 再生設定（repeatCount/speechRate/lang/voiceId/announceCategory）は
   // 参加者自身のlocalStorageではなく、管理者からのブロードキャスト内容（roomState.content）
   // に含まれる値を使い、全員が管理者と同じ内容で聞こえるようにする
-  const [playbackBlocked, setPlaybackBlocked] = useState(false);
   const lastPlayedKeyRef = useRef(null);
-  const lastAudioDataRef = useRef(null);
   const currentAudioRef = useRef(null);
+
+  useEffect(() => {
+    if (!wsBaseUrl) {
+      return undefined;
+    }
+    // ルームへの参加操作以外（招待URLからの直接アクセス等）で、ユーザー操作を伴う
+    // 参加ボタンのクリックを経ずに画面が開かれた場合の保険。画面内の最初のクリック/
+    // タップで解錠しておくことで、その後の自動再生（次の札の通知）が通りやすくなる
+    const handleFirstInteraction = () => unlockAudioPlayback();
+    document.addEventListener("click", handleFirstInteraction, { once: true });
+    document.addEventListener("touchstart", handleFirstInteraction, { once: true });
+    return () => {
+      document.removeEventListener("click", handleFirstInteraction);
+      document.removeEventListener("touchstart", handleFirstInteraction);
+    };
+  }, [wsBaseUrl]);
 
   useEffect(() => {
     if (roomState?.type !== "phrase" || !roomState.content?.id) {
@@ -100,20 +117,13 @@ function QuizRoomView({ setView, wsBaseUrl }) {
         if (cancelled || !response.ok || !data.audioData) {
           return;
         }
-        lastAudioDataRef.current = data.audioData;
         // 前の札の音声がまだ再生中なら、次の札の音声と重なって再生されないよう止める
         currentAudioRef.current?.pause();
         const audio = new Audio(data.audioData);
         currentAudioRef.current = audio;
         await audio.play();
-        if (!cancelled) {
-          setPlaybackBlocked(false);
-        }
       } catch (error) {
         console.error("Failed to play quiz room audio:", error);
-        if (!cancelled) {
-          setPlaybackBlocked(true);
-        }
       }
     })();
 
@@ -121,19 +131,6 @@ function QuizRoomView({ setView, wsBaseUrl }) {
       cancelled = true;
     };
   }, [roomState]);
-
-  // 自動再生がブラウザにブロックされた場合（ユーザー操作を伴わない再生）の救済策。
-  // 直近取得済みの音声データをこのクリック操作（ユーザー操作）を起点に再生し直す
-  const retryPlayback = () => {
-    if (!lastAudioDataRef.current) {
-      return;
-    }
-    const audio = new Audio(lastAudioDataRef.current);
-    currentAudioRef.current = audio;
-    audio.play()
-      .then(() => setPlaybackBlocked(false))
-      .catch(() => setPlaybackBlocked(true));
-  };
 
   if (!wsBaseUrl) {
     return (
@@ -152,11 +149,6 @@ function QuizRoomView({ setView, wsBaseUrl }) {
           <p className="text-muted small">ルーム: {joinRoomId}</p>
         </header>
         <p className="text-muted small mb-3">接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}</p>
-        {playbackBlocked && (
-          <button onClick={retryPlayback} className="btn btn-sm btn-outline-dark rounded-pill mb-3">
-            🔊 タップして音声を有効にする
-          </button>
-        )}
         {renderParticipantContent(roomState)}
         <div className="mt-5">
           <button onClick={() => setView("game")} className="btn btn-link text-muted text-decoration-none">← 戻る</button>

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -208,7 +208,7 @@ describe('QuizRoomView', () => {
     expect(screen.queryByText('🔇 音声OFF')).not.toBeInTheDocument();
   });
 
-  it('shows a retry button when playback is blocked (autoplay policy), and lets the participant retry with a tap', async () => {
+  it('does not show a "tap to enable audio" button even when playback is blocked by the autoplay policy (issue #497)', async () => {
     audioPlayImpl = () => Promise.reject(new Error('NotAllowedError'));
     fetch.mockResolvedValueOnce({ ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }) });
     window.history.pushState({}, '', '?roomId=ABC123');
@@ -217,18 +217,35 @@ describe('QuizRoomView', () => {
 
     emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
 
-    const retryButton = await screen.findByText('🔊 タップして音声を有効にする');
-    expect(audioInstances).toHaveLength(1);
-
-    audioPlayImpl = () => Promise.resolve();
-    fireEvent.click(retryButton);
-
     await act(async () => {
+      await Promise.resolve();
       await Promise.resolve();
     });
 
-    expect(audioInstances).toHaveLength(2);
-    expect(audioInstances[1].src).toBe('data:audio/mp3;base64,DUMMY');
+    expect(audioInstances).toHaveLength(1);
     expect(screen.queryByText('🔊 タップして音声を有効にする')).not.toBeInTheDocument();
+    expect(screen.queryByText('🔊 音声ON')).not.toBeInTheDocument();
+  });
+
+  it('unlocks audio playback (plays a silent clip) the first time the participant clicks or taps anywhere on the screen, as a fallback for deep-link visitors with no join click', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    expect(audioInstances).toHaveLength(0);
+
+    fireEvent.click(document.body);
+
+    expect(audioInstances).toHaveLength(1);
+    expect(audioInstances[0].play).toHaveBeenCalled();
+  });
+
+  it('unlocks audio playback when a participant joins via the manually entered room code button', () => {
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+
+    fireEvent.change(screen.getByPlaceholderText('ルームコード'), { target: { value: 'xyz789' } });
+    fireEvent.click(screen.getByText('参加する'));
+
+    expect(audioInstances).toHaveLength(1);
+    expect(audioInstances[0].play).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 概要
issue #497の追加対応（「管理者がめくった後、音声をオンにするボタンが表示され、音声が再生されない」の報告を受けて）。

## 経緯
前回（PR #504）はミュード切り替えボタンのみ廃止し、ブラウザの自動再生ポリシーで再生がブロックされた場合の救済策「🔊 タップして音声を有効にする」ボタンは残していた。しかし今回の報告により、issue #497の「ボタン操作なしで常にオンにする」という要望はこの救済ボタンも含めて指していたと判断し、対応した。

## 対応内容
- 「🔊 タップして音声を有効にする」ボタンと関連state（`playbackBlocked`）・`retryPlayback`を削除。
- 代わりに、ブラウザの自動再生ロックを事前に解除しておく「解錠」処理を2箇所に追加。
  - トップページのルーム一覧クリック（`App.jsx`の`joinQuizRoom`）に便乗して無音の音声を一度再生。
  - 参加者画面が開かれた後の最初のクリック/タップでも同様に解錠（招待URLへの直接アクセス等、参加操作のクリックを経ない導線への保険）。
- 共有関数`unlockAudioPlayback`は`frontend/src/utils/audioUnlock.js`に切り出した（`QuizRoomView.jsx`からコンポーネント以外をexportすると`react-refresh/only-export-components`のlintエラーになるため）。

## 既知の制約
ブラウザの自動再生ポリシー自体は回避できないハードな制約のため、解錠後も何らかの理由で再生が失敗した場合、その札の音声はボタンなしに失われる（コンソールへのエラーログのみ）。

## Test plan
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 全119件成功（再生ブロック時もボタンが表示されないこと、画面内の最初のクリック/タップでの解錠、ルーム一覧クリックでの解錠を検証するテストを追加）
- [x] `backend`: `npm run lint` エラー0件 / `npm test -- --run` 全1313件成功（変更なし）
- [ ] 実機ブラウザでの自動再生解錠の目視確認（このセッションからは未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_