### PR TITLE
feat(quiz-room): 早押し機能を追加する

### DIFF
--- a/backend/quizRoomHandler.js
+++ b/backend/quizRoomHandler.js
@@ -14,6 +14,7 @@ const ROOM_CODE_CHARS = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
 const ROOM_CODE_LENGTH = 6;
 const MAX_CREATE_ROOM_ATTEMPTS = 5; // ルームコード衝突時の再採番の上限
 const MAX_STATE_JSON_LENGTH = 8000; // 状態データの肥大化・課金濫用を防ぐ上限
+const MAX_NAME_LENGTH = 20; // 早押し機能（issue #510）: 参加者名の肥大化・表示崩れを防ぐ上限
 
 function generateRoomCode() {
   let code = "";
@@ -234,6 +235,16 @@ exports.syncQuizRoom = async (event) => {
       role: connection.Item.role,
     });
 
+    // 早押し機能（issue #510）: 再接続・遅れて参加した端末でも、現在のラウンドで
+    // 既に誰かが早押し済みであることが分かるようにする
+    if (room.Item.buzz) {
+      await postToConnection(managementApi, connectionId, {
+        type: "buzz",
+        name: room.Item.buzz.name,
+        connectionId: room.Item.buzz.connectionId,
+      });
+    }
+
     return { statusCode: 200, body: "" };
   } catch (error) {
     console.error(error);
@@ -262,10 +273,14 @@ exports.updateQuizRoomState = async (event) => {
     }
 
     const { roomId } = connection.Item;
+    // 早押し機能（issue #510）: 新しい札（次の問題）や、ゲームのリセット等で"initial"に
+    // 戻った場合は、前のラウンドの早押し結果をリセットする。result表示中だけは次の札が
+    // 出るまで回答者を表示し続けたいため、typeが"result"のときだけリセットしない
+    const resetBuzz = newState.type !== "result" ? " REMOVE buzz" : "";
     await docClient.send(new UpdateCommand({
       TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
       Key: { roomId },
-      UpdateExpression: "SET #state = :state, #ttl = :ttl",
+      UpdateExpression: `SET #state = :state, #ttl = :ttl${resetBuzz}`,
       ExpressionAttributeNames: { "#state": "state", "#ttl": "ttl" },
       ExpressionAttributeValues: {
         ":state": newState,
@@ -286,6 +301,97 @@ exports.updateQuizRoomState = async (event) => {
         type: "state",
         state: newState,
         role: conn.role,
+      }))
+    );
+
+    return { statusCode: 200, body: "" };
+  } catch (error) {
+    console.error(error);
+    return { statusCode: 500, body: "Internal Server Error" };
+  }
+};
+
+// WebSocketカスタムルート"setName"（早押し機能、issue #510）。参加者（管理者含む、
+// ただし実際に使うのは参加者のみ）が自分の表示名を接続情報へ保存する
+exports.setQuizRoomName = async (event) => {
+  try {
+    const connectionId = event.requestContext.connectionId;
+    const body = JSON.parse(event.body || "{}");
+    const name = typeof body.name === "string" ? body.name.trim().slice(0, MAX_NAME_LENGTH) : "";
+    if (!name) {
+      return { statusCode: 400, body: "Invalid name" };
+    }
+
+    await docClient.send(new UpdateCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      Key: { connectionId },
+      UpdateExpression: "SET #name = :name",
+      ExpressionAttributeNames: { "#name": "name" },
+      ExpressionAttributeValues: { ":name": name },
+      ConditionExpression: "attribute_exists(connectionId)",
+    }));
+
+    return { statusCode: 200, body: "" };
+  } catch (error) {
+    if (error.name === "ConditionalCheckFailedException") {
+      // 接続情報が既に無い（切断済み等）。名前の保存自体は無意味なので何もしない
+      return { statusCode: 200, body: "" };
+    }
+    console.error(error);
+    return { statusCode: 500, body: "Internal Server Error" };
+  }
+};
+
+// WebSocketカスタムルート"buzz"（早押し機能、issue #510）。参加者のみが押せる。
+// 同一ラウンド内で最初の1件だけを条件付き書き込みで確定させ、ルーム内の全接続へ
+// 回答者名をブロードキャストする（早押し結果のリセットはupdateQuizRoomState側で行う）
+exports.buzzQuizRoom = async (event) => {
+  try {
+    const connectionId = event.requestContext.connectionId;
+    const connection = await docClient.send(new GetCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      Key: { connectionId },
+    }));
+    if (!connection.Item || connection.Item.role !== "participant") {
+      return { statusCode: 403, body: "Forbidden" };
+    }
+
+    const { roomId, name } = connection.Item;
+    const buzz = {
+      connectionId,
+      name: name || "名無しさん",
+      buzzedAt: Date.now(),
+    };
+
+    try {
+      await docClient.send(new UpdateCommand({
+        TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+        Key: { roomId },
+        UpdateExpression: "SET buzz = :buzz",
+        ConditionExpression: "attribute_not_exists(buzz)",
+        ExpressionAttributeValues: { ":buzz": buzz },
+      }));
+    } catch (error) {
+      if (error.name === "ConditionalCheckFailedException") {
+        // 既に他の参加者が先に押している。早押しの結果は変えず、何もしない
+        return { statusCode: 200, body: "" };
+      }
+      throw error;
+    }
+
+    const connections = await docClient.send(new QueryCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      IndexName: "roomId-index",
+      KeyConditionExpression: "roomId = :roomId",
+      ExpressionAttributeValues: { ":roomId": roomId },
+    }));
+
+    const managementApi = buildManagementApiClient(event);
+    await Promise.allSettled(
+      (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
+        type: "buzz",
+        name: buzz.name,
+        connectionId: buzz.connectionId,
       }))
     );
 

--- a/backend/quizRoomHandler.test.js
+++ b/backend/quizRoomHandler.test.js
@@ -10,6 +10,8 @@ import {
   disconnectQuizRoom,
   syncQuizRoom,
   updateQuizRoomState,
+  setQuizRoomName,
+  buzzQuizRoom,
 } from './quizRoomHandler';
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
@@ -229,6 +231,42 @@ describe('syncQuizRoom', () => {
     expect(payload).toEqual({ type: 'state', state: { type: 'phrase', phrase: { id: 'p1' } }, role: 'participant' });
   });
 
+  it('also sends the current buzz status to a reconnecting/late-joining participant when someone has already buzzed this round (issue #510)', async () => {
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
+      Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' },
+    });
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({
+      Item: {
+        roomId: 'ROOM01',
+        state: { type: 'phrase', content: { id: 'p1' } },
+        buzz: { connectionId: 'conn-2', name: 'たろう', buzzedAt: 1000 },
+      },
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    const response = await syncQuizRoom(wsEvent({ connectionId: 'conn-1' }));
+
+    expect(response.statusCode).toBe(200);
+    const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
+    expect(postCalls).toHaveLength(2);
+    const buzzPayload = JSON.parse(Buffer.from(postCalls[1].args[0].input.Data).toString('utf-8'));
+    expect(buzzPayload).toEqual({ type: 'buzz', name: 'たろう', connectionId: 'conn-2' });
+  });
+
+  it('does not send a buzz message when no one has buzzed this round', async () => {
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
+      Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' },
+    });
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({
+      Item: { roomId: 'ROOM01', state: { type: 'phrase', content: { id: 'p1' } } },
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    await syncQuizRoom(wsEvent({ connectionId: 'conn-1' }));
+
+    expect(managementApiMock.commandCalls(PostToConnectionCommand)).toHaveLength(1);
+  });
+
   it('handles errors', async () => {
     ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
     const response = await syncQuizRoom(wsEvent());
@@ -288,6 +326,42 @@ describe('updateQuizRoomState', () => {
     expect(payload.state).toEqual(newState);
   });
 
+  it('resets (removes) the buzz field when broadcasting a new phrase, so the next round starts unbuzzed (issue #510)', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' } });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const newState = { type: 'phrase', phrase: { id: 'p2', category: 'Cat1' } };
+    await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
+
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.UpdateExpression).toContain('REMOVE buzz');
+  });
+
+  it('does not reset the buzz field when broadcasting a result (so the responder stays visible during the result screen)', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' } });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const newState = { type: 'result', content: { time: 1.2 } };
+    await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
+
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.UpdateExpression).not.toContain('REMOVE buzz');
+  });
+
+  it('resets the buzz field when broadcasting back to the initial/idle state (e.g. the admin resets the game), so stale buzz info does not leak into the next round', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' } });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const newState = { type: 'initial' };
+    await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
+
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.UpdateExpression).toContain('REMOVE buzz');
+  });
+
   it('removes a stale connection record when broadcasting hits a GoneException, without failing the whole update', async () => {
     ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' } });
     ddbMock.on(UpdateCommand).resolves({});
@@ -306,6 +380,123 @@ describe('updateQuizRoomState', () => {
   it('handles unexpected errors', async () => {
     ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
     const response = await updateQuizRoomState(wsEvent({ body: { state: { type: 'phrase' } } }));
+    expect(response.statusCode).toBe(500);
+  });
+});
+
+describe('setQuizRoomName', () => {
+  it('saves a trimmed name on the connection record', async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+
+    const response = await setQuizRoomName(wsEvent({ connectionId: 'conn-1', body: { name: '  たろう  ' } }));
+
+    expect(response.statusCode).toBe(200);
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.Key).toEqual({ connectionId: 'conn-1' });
+    expect(updateCall.ExpressionAttributeValues[':name']).toBe('たろう');
+  });
+
+  it('truncates names longer than the configured limit', async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+
+    await setQuizRoomName(wsEvent({ body: { name: 'x'.repeat(50) } }));
+
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.ExpressionAttributeValues[':name']).toHaveLength(20);
+  });
+
+  it('rejects an empty (or whitespace-only) name', async () => {
+    const response = await setQuizRoomName(wsEvent({ body: { name: '   ' } }));
+    expect(response.statusCode).toBe(400);
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+  });
+
+  it('silently no-ops when the connection record no longer exists (e.g. already disconnected)', async () => {
+    ddbMock.on(UpdateCommand).rejects(Object.assign(new Error('cond failed'), { name: 'ConditionalCheckFailedException' }));
+
+    const response = await setQuizRoomName(wsEvent({ body: { name: 'たろう' } }));
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('handles unexpected errors', async () => {
+    ddbMock.on(UpdateCommand).rejects(new Error('DynamoDB error'));
+    const response = await setQuizRoomName(wsEvent({ body: { name: 'たろう' } }));
+    expect(response.statusCode).toBe(500);
+  });
+});
+
+describe('buzzQuizRoom', () => {
+  it('rejects when the caller is not a participant (e.g. the admin)', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' } });
+    const response = await buzzQuizRoom(wsEvent({ connectionId: 'conn-admin' }));
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('rejects when the connection record is missing', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+    const response = await buzzQuizRoom(wsEvent());
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('records the first buzz and broadcasts the responder name to every connection in the room', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { connectionId: 'conn-participant', roomId: 'ROOM01', role: 'participant', name: 'たろう' },
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+        { connectionId: 'conn-participant', roomId: 'ROOM01', role: 'participant' },
+      ],
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    const response = await buzzQuizRoom(wsEvent({ connectionId: 'conn-participant' }));
+
+    expect(response.statusCode).toBe(200);
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.Key).toEqual({ roomId: 'ROOM01' });
+    expect(updateCall.ConditionExpression).toBe('attribute_not_exists(buzz)');
+    expect(updateCall.ExpressionAttributeValues[':buzz']).toMatchObject({
+      connectionId: 'conn-participant',
+      name: 'たろう',
+    });
+
+    const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
+    expect(postCalls).toHaveLength(2);
+    const payload = JSON.parse(Buffer.from(postCalls[0].args[0].input.Data).toString('utf-8'));
+    expect(payload).toEqual({ type: 'buzz', name: 'たろう', connectionId: 'conn-participant' });
+  });
+
+  it('falls back to a default label when the participant never set a name', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { connectionId: 'conn-participant', roomId: 'ROOM01', role: 'participant' },
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    await buzzQuizRoom(wsEvent({ connectionId: 'conn-participant' }));
+
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.ExpressionAttributeValues[':buzz'].name).toBe('名無しさん');
+  });
+
+  it('silently no-ops (does not broadcast) when someone has already buzzed this round', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { connectionId: 'conn-participant', roomId: 'ROOM01', role: 'participant', name: 'はなこ' },
+    });
+    ddbMock.on(UpdateCommand).rejects(Object.assign(new Error('cond failed'), { name: 'ConditionalCheckFailedException' }));
+
+    const response = await buzzQuizRoom(wsEvent({ connectionId: 'conn-participant' }));
+
+    expect(response.statusCode).toBe(200);
+    expect(managementApiMock.commandCalls(PostToConnectionCommand)).toHaveLength(0);
+  });
+
+  it('handles unexpected errors', async () => {
+    ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
+    const response = await buzzQuizRoom(wsEvent());
     expect(response.statusCode).toBe(500);
   });
 });

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -57,10 +57,12 @@ provider:
             - dynamodb:Scan
           Resource:
             - !GetAtt QuizRoomsTable.Arn
-        - Effect: Allow # 追加（クイズ大会モード: 接続情報の読み書き・ルーム単位の一覧取得）
+        - Effect: Allow # 追加（クイズ大会モード: 接続情報の読み書き・ルーム単位の一覧取得。
+          # UpdateItemは早押し機能issue #510のsetQuizRoomName（参加者名の保存）で使用）
           Action:
             - dynamodb:GetItem
             - dynamodb:PutItem
+            - dynamodb:UpdateItem
             - dynamodb:DeleteItem
             - dynamodb:Query
           Resource:
@@ -216,6 +218,16 @@ functions:
     events:
       - websocket:
           route: updateState
+  setQuizRoomName: # 追加（早押し機能、issue #510）。参加者が自分の表示名を接続情報へ保存する
+    handler: quizRoomHandler.setQuizRoomName
+    events:
+      - websocket:
+          route: setName
+  buzzQuizRoom: # 追加（早押し機能、issue #510）。参加者の早押しを最初の1件だけ確定し、全接続へブロードキャストする
+    handler: quizRoomHandler.buzzQuizRoom
+    events:
+      - websocket:
+          route: buzz
 
 resources:
   Resources:

--- a/frontend/e2e/quiz-room.spec.js
+++ b/frontend/e2e/quiz-room.spec.js
@@ -27,6 +27,9 @@ test('admin creates a quiz room and a participant sees the same card update in r
   await participantPage.goto(`/?view=quiz-room&roomId=${roomCode}`);
 
   await expect(participantPage.getByText('クイズ大会モード（参加者）')).toBeVisible();
+  // 早押し機能（issue #510）: 参加者はまず名前を入力してから通常の参加者画面へ進む
+  await participantPage.getByPlaceholder('お名前').fill('たろう');
+  await participantPage.getByText('決定').click();
   await expect(participantPage.getByText('接続状態: 接続済み')).toBeVisible({ timeout: 15000 });
   await expect(participantPage.getByText('ホストの操作を待っています...')).toBeVisible();
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -119,6 +119,11 @@ function App() {
   const [quizRoomCreateError, setQuizRoomCreateError] = useState(null);
   // トップページ下部に表示する、開設中のクイズ大会ルーム一覧（issue #489）
   const [openQuizRooms, setOpenQuizRooms] = useState([]);
+  // 早押し機能（issue #510）: 現在のラウンドで最初に回答した参加者名。次の札が
+  // 出題されたらリセットする（下記のブロードキャストeffect内。quizRoomBuzzRoundKeyは
+  // QuizRoomView.jsxのbuzzRoundKeyと同じ考え方で、resultの間はリセットしない）
+  const [quizRoomBuzzedBy, setQuizRoomBuzzedBy] = useState(null);
+  const [quizRoomBuzzRoundKey, setQuizRoomBuzzRoundKey] = useState(null);
 
   // コメント投稿用の状態
   const [commentText, setCommentText] = useState("");
@@ -893,6 +898,7 @@ function App() {
     roomId: quizRoom?.roomId,
     adminToken: quizRoom?.adminToken,
     onState: noop,
+    onBuzz: setQuizRoomBuzzedBy,
   });
 
   // 表示中の札・結果画面が変わるたびクイズ大会モードの参加者へ状態をブロードキャストする。
@@ -910,6 +916,15 @@ function App() {
       // 実際に聞いている音声」とズレるため
       const settings = displayContent.playbackSettings
         ?? { repeatCount, speechRate, lang, voiceId, announceCategory: isMultiCategorySelection };
+      // 早押し機能（issue #510）: 新しい札が出題されたら、前のラウンドの回答者表示を
+      // リセットする（サーバー側もこの同じタイミングで早押し状態をリセットしている）。
+      // ラウンドキーで判定するのは、設定変更等で同じ札が再ブロードキャストされた際に
+      // 既に記録済みの回答者表示を誤って消さないようにするため
+      const roundKey = `${p.category}:${p.id}`;
+      if (roundKey !== quizRoomBuzzRoundKey) {
+        setQuizRoomBuzzRoundKey(roundKey);
+        setQuizRoomBuzzedBy(null);
+      }
       broadcastQuizRoomState({
         type: "phrase",
         content: {
@@ -927,9 +942,15 @@ function App() {
         content: { time: r.time, isFast: r.isFast, difficulty: r.difficulty, answer: r.answer },
       });
     } else {
+      // 早押し機能（issue #510）: ゲームのリセット等で"initial"に戻った場合は、
+      // 古い回答者情報が次のラウンドへ持ち越されないようリセットする
+      if (quizRoomBuzzRoundKey !== null) {
+        setQuizRoomBuzzRoundKey(null);
+        setQuizRoomBuzzedBy(null);
+      }
       broadcastQuizRoomState({ type: "initial" });
     }
-  }, [quizRoom, displayContent, broadcastQuizRoomState, repeatCount, speechRate, lang, voiceId, isMultiCategorySelection]);
+  }, [quizRoom, displayContent, broadcastQuizRoomState, repeatCount, speechRate, lang, voiceId, isMultiCategorySelection, quizRoomBuzzRoundKey]);
 
   useEffect(() => {
     if (view === "comments") {
@@ -1653,7 +1674,12 @@ function App() {
         <button onClick={resetGame} className="btn btn-outline-dark px-4 rounded-pill">かるたの種類を選び直す</button>
       </div>
       {quizRoom ? (
-        <QuizRoomInfoPanel roomId={quizRoom.roomId} />
+        <div className="mb-4">
+          <QuizRoomInfoPanel roomId={quizRoom.roomId} />
+          {quizRoomBuzzedBy && (
+            <p className="fw-bold text-dark">🔔 {quizRoomBuzzedBy.name} さんが回答しました</p>
+          )}
+        </div>
       ) : (
         <div className="mb-4">
           <button

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import App from './App';
+import { resetSharedAudioForTests } from './utils/audioUnlock';
 
 window.alert = vi.fn();
 
@@ -17,8 +18,13 @@ window.Audio = vi.fn().mockImplementation(function (url) {
     play: vi.fn().mockResolvedValue(),
     pause: vi.fn(),
     load: vi.fn(),
+    _src: undefined,
+    get src() {
+      return this._src;
+    },
     // Simulate successful loading
     set src(url) {
+      this._src = url;
       setTimeout(() => {
         if (this.oncanplaythrough) this.oncanplaythrough();
         // Simulate audio ending immediately for tests
@@ -41,6 +47,9 @@ describe('App', () => {
     window.history.pushState({}, '', '/');
     // 読み上げ履歴の永続化先（sessionStorage）をテスト間で引き継がないようにする
     sessionStorage.clear();
+    // 共有<audio>要素（issue #514）はモジュールスコープのシングルトンなので、
+    // テスト間で使い回されないようリセットする
+    resetSharedAudioForTests();
   });
 
   it('renders division selection screen initially', async () => {
@@ -2605,11 +2614,13 @@ describe('App', () => {
       constructor(url) {
         this.url = url;
         this.readyState = 0;
+        MockWebSocket.instances.push(this);
       }
       send() {}
       close() {}
     }
     MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
     window.WebSocket = MockWebSocket;
 
     fetch.mockImplementation(async (url) => {
@@ -2625,6 +2636,9 @@ describe('App', () => {
         };
       }
       if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [] }) };
+      if (url.includes('/get-phrase?')) {
+        return { ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }) };
+      }
       return { ok: false };
     });
 
@@ -2646,12 +2660,32 @@ describe('App', () => {
     fireEvent.click(screen.getByText('決定'));
     expect(screen.getByText('ルーム: ABC123')).toBeInTheDocument();
 
-    // ブラウザの自動再生ポリシー対策（issue #497）: 一覧からの参加クリックに便乗して
-    // 無音再生による解錠を行っていることを確認する
-    const silentAudioCall = window.Audio.mock.calls.find(
-      ([src]) => typeof src === 'string' && src.startsWith('data:audio/wav')
-    );
-    expect(silentAudioCall).toBeDefined();
+    // ブラウザの自動再生ポリシー対策（issue #497, #514）: 一覧からの参加クリックに便乗して、
+    // 共有<audio>要素（issue #514）に無音再生による解錠を行っていることを確認する
+    const unlockedInstance = window.Audio.mock.results
+      .map((result) => result.value)
+      .find((audio) => typeof audio.src === 'string' && audio.src.startsWith('data:audio/wav'));
+    expect(unlockedInstance).toBeDefined();
+
+    // issue #514: 一覧クリック（App.jsx）で解錠した要素と、参加者画面（QuizRoomView.jsx）が
+    // 実際に札の音声を再生する要素が、同一の（=解錠済みの）要素であることを確認する。
+    // 別々のAudioインスタンスを使っていると、解錠の効果が実際の再生に及ばずSafari等で
+    // ブロックされ続けてしまう
+    const participantWs = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+    await act(async () => {
+      participantWs.onmessage?.({
+        data: JSON.stringify({
+          type: 'state',
+          state: { type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } },
+          role: 'participant',
+        }),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(unlockedInstance.src).toBe('data:audio/mp3;base64,DUMMY');
+    expect(window.Audio).toHaveBeenCalledTimes(1);
   });
 
   it('does not show the open-room list section when there are no open quiz rooms', async () => {

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2412,6 +2412,128 @@ describe('App', () => {
     });
   }, 40000);
 
+  it('shows the responder\'s name to the admin when a participant buzzes in, and resets it once the next card is shown (issue #510)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }, { id: 'p2', category: 'Cat1' }] }) };
+      if (url.includes('/get-phrase?')) {
+        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', audioData: 'dummy' }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    const ws = MockWebSocket.instances[0];
+    act(() => {
+      ws.readyState = MockWebSocket.OPEN;
+      ws.onopen?.();
+    });
+
+    act(() => {
+      ws.onmessage?.({ data: JSON.stringify({ type: 'buzz', name: 'はなこ', connectionId: 'conn-2' }) });
+    });
+
+    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('🔔 はなこ さんが回答しました')).not.toBeInTheDocument();
+    }, { timeout: 20000 });
+  }, 40000);
+
+  it('does not clear the responder shown to the admin when the same card is re-broadcast (e.g. a settings change re-sends the same phrase), only when the round actually changes (issue #510)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }, { id: 'p2', category: 'Cat1' }] }) };
+      if (url.includes('/get-phrase?')) {
+        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', audioData: 'dummy' }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    const ws = MockWebSocket.instances[0];
+    act(() => {
+      ws.readyState = MockWebSocket.OPEN;
+      ws.onopen?.();
+    });
+
+    fireEvent.click(screen.getByText('次の札'));
+    await waitFor(() => {
+      expect(ws.sent.find((msg) => msg.includes('"type":"phrase"'))).toBeDefined();
+    }, { timeout: 20000 });
+
+    act(() => {
+      ws.onmessage?.({ data: JSON.stringify({ type: 'buzz', name: 'はなこ', connectionId: 'conn-2' }) });
+    });
+    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+
+    // 同じ札を表示したまま設定を変える（再ブロードキャストが発生するが、ラウンドは
+    // 変わっていないので回答者表示は消えてはならない）
+    fireEvent.click(screen.getByText('はやい'));
+
+    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+  }, 40000);
+
   it('broadcasts the settings actually used to fetch the admin\'s own audio, even if the admin changes the voice while that card is still being read out (issue #498)', async () => {
     localStorage.setItem('repeatCount', '2');
     localStorage.setItem('speechRate', '80%');
@@ -2519,6 +2641,9 @@ describe('App', () => {
     fireEvent.click(screen.getByText('ABC123'));
 
     expect(await screen.findByText('クイズ大会モード（参加者）')).toBeInTheDocument();
+    // 早押し機能（issue #510）: 参加者はまず名前を入力してから通常の参加者画面へ進む
+    fireEvent.change(screen.getByPlaceholderText('お名前'), { target: { value: 'たろう' } });
+    fireEvent.click(screen.getByText('決定'));
     expect(screen.getByText('ルーム: ABC123')).toBeInTheDocument();
 
     // ブラウザの自動再生ポリシー対策（issue #497）: 一覧からの参加クリックに便乗して

--- a/frontend/src/hooks/useQuizRoomSync.js
+++ b/frontend/src/hooks/useQuizRoomSync.js
@@ -9,12 +9,15 @@ const SYNC_POLL_INTERVAL_MS = 5000;
 
 // クイズ大会モード（issue #470）のWebSocket接続を管理する。adminTokenを渡すと管理者として、
 // 渡さなければ参加者（閲覧専用）として接続する。サーバーから状態（{type:"state", state, role}）を
-// 受け取るたびonStateを呼ぶ。管理者はbroadcastStateで新しい状態を送信できる
-export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState }) {
+// 受け取るたびonStateを呼ぶ。管理者はbroadcastStateで新しい状態を送信できる。
+// 早押し機能（issue #510）: サーバーから{type:"buzz", name, connectionId}を受け取るたび
+// onBuzzを呼ぶ。参加者はsetParticipantNameで表示名を、buzzで早押しを送信できる
+export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz }) {
   const [internalStatus, setInternalStatus] = useState("idle"); // connecting|connected|error（idleはwsBaseUrl/roomId未設定時に導出する）
   const connectionStatus = (!wsBaseUrl || !roomId) ? "idle" : internalStatus;
   const wsRef = useRef(null);
   const onStateRef = useRef(onState);
+  const onBuzzRef = useRef(onBuzz);
   const reconnectAttemptsRef = useRef(0);
   const reconnectTimeoutRef = useRef(null);
   const closedByCleanupRef = useRef(false);
@@ -24,10 +27,16 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState }) {
   // それまではreadyState !== OPENのため送信が黙って失われ、参加者側の画面が
   // 永久に更新されない不具合があった。openのたびにこの値を送り直すことで解消する
   const pendingStateRef = useRef(null);
+  // setParticipantNameも同様に、接続確立前に呼ばれた場合に備えて再送する（issue #510）
+  const pendingNameRef = useRef(null);
 
   useEffect(() => {
     onStateRef.current = onState;
   }, [onState]);
+
+  useEffect(() => {
+    onBuzzRef.current = onBuzz;
+  }, [onBuzz]);
 
   useEffect(() => {
     if (!wsBaseUrl || !roomId) {
@@ -58,6 +67,9 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState }) {
         if (pendingStateRef.current !== null) {
           ws.send(JSON.stringify({ action: "updateState", state: pendingStateRef.current }));
         }
+        if (pendingNameRef.current !== null) {
+          ws.send(JSON.stringify({ action: "setName", name: pendingNameRef.current }));
+        }
         pollTimerRef.current = setInterval(() => {
           if (ws.readyState === WebSocket.OPEN) {
             ws.send(JSON.stringify({ action: "sync" }));
@@ -70,6 +82,8 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState }) {
           const data = JSON.parse(event.data);
           if (data?.type === "state") {
             onStateRef.current?.(data.state, data.role);
+          } else if (data?.type === "buzz") {
+            onBuzzRef.current?.({ name: data.name, connectionId: data.connectionId });
           }
         } catch (error) {
           console.error("Failed to parse quiz room message:", error);
@@ -119,5 +133,20 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState }) {
     }
   }, []);
 
-  return { connectionStatus, broadcastState };
+  // 早押し機能（issue #510）: 参加者が自分の表示名をサーバーへ保存する
+  const setParticipantName = useCallback((name) => {
+    pendingNameRef.current = name;
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ action: "setName", name }));
+    }
+  }, []);
+
+  // 早押し機能（issue #510）: 参加者が早押しボタンを押したことをサーバーへ送信する
+  const buzz = useCallback(() => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ action: "buzz" }));
+    }
+  }, []);
+
+  return { connectionStatus, broadcastState, setParticipantName, buzz };
 }

--- a/frontend/src/hooks/useQuizRoomSync.test.js
+++ b/frontend/src/hooks/useQuizRoomSync.test.js
@@ -115,6 +115,54 @@ describe('useQuizRoomSync', () => {
     expect(onState).not.toHaveBeenCalled();
   });
 
+  it('calls onBuzz when a buzz message is received, without invoking onState (issue #510)', () => {
+    const onState = vi.fn();
+    const onBuzz = vi.fn();
+    renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState, onBuzz }));
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+      MockWebSocket.instances[0].triggerMessage({ type: 'buzz', name: 'たろう', connectionId: 'conn-2' });
+    });
+
+    expect(onBuzz).toHaveBeenCalledWith({ name: 'たろう', connectionId: 'conn-2' });
+    expect(onState).not.toHaveBeenCalled();
+  });
+
+  it('setParticipantName sends setName only while the connection is open, and resends it once the socket opens if called earlier', () => {
+    const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+    act(() => {
+      result.current.setParticipantName('たろう');
+    });
+    expect(MockWebSocket.instances[0].sent).toEqual([]);
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+    });
+
+    expect(MockWebSocket.instances[0].sent).toEqual([
+      JSON.stringify({ action: 'sync' }),
+      JSON.stringify({ action: 'setName', name: 'たろう' }),
+    ]);
+  });
+
+  it('buzz sends the buzz action only while the connection is open', () => {
+    const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+    act(() => {
+      result.current.buzz();
+    });
+    expect(MockWebSocket.instances[0].sent).toEqual([]);
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+      result.current.buzz();
+    });
+
+    expect(MockWebSocket.instances[0].sent).toContain(JSON.stringify({ action: 'buzz' }));
+  });
+
   it('broadcastState sends updateState only while the connection is open', () => {
     const { result } = renderHook(() => useQuizRoomSync({
       wsBaseUrl: 'wss://example.com/dev',

--- a/frontend/src/utils/audioUnlock.js
+++ b/frontend/src/utils/audioUnlock.js
@@ -1,13 +1,52 @@
-// ブラウザの自動再生ポリシー対策（issue #497）: ユーザー操作（クリック/タップ）を
-// 伴わないaudio.play()は多くのブラウザでブロックされる。無音の音声をユーザー操作の
-// 延長として一度再生しておくと、以降のWebSocket通知に応じた自動再生（ユーザー操作を
-// 伴わない再生）が許可されやすくなるため、ボタンを出す代わりにこれで解決を図る
+// ブラウザの自動再生ポリシー対策（issue #497, #514）。
+//
+// Safari（iOS/macOS）は、HTMLAudioElementごとに「ユーザー操作の中で一度でも再生された
+// 要素かどうか」を見て、以降の非同期文脈（fetch完了後のコールバック等）でのplay()を
+// 許可するかどうかを判断する。参加者側の音声再生は「WebSocketで通知を受けてから
+// /get-phraseを取得し、取得できたらplay()する」という非同期処理のため、その都度
+// `new Audio(...)`していると、その要素自体は一度もユーザー操作中に再生されておらず
+// Safariにブロックされ続けてしまう。
+//
+// そのため、ページ内で使い回す単一の<audio>要素（シングルトン）を用意し、
+// クリック等のユーザー操作の中でこの要素自身を一度再生しておく（unlockAudioPlayback）。
+// 以降は同じ要素のsrcを差し替えてplay()し直す（playSharedAudio）ことで、非同期文脈からの
+// 再生であってもSafariに許可される。ユーザー操作の発生箇所（トップページのルーム一覧
+// クリック等）と、実際に音声を再生する箇所（参加者画面）が別のReactコンポーネントの
+// ライフサイクルにまたがるため、コンポーネントのrefではなくモジュールスコープの
+// シングルトンとして保持する
 const SILENT_AUDIO_DATA_URI = "data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=";
 
+let sharedAudio = null;
+
+function getSharedAudio() {
+  if (!sharedAudio) {
+    sharedAudio = new Audio();
+  }
+  return sharedAudio;
+}
+
+// ユーザー操作（クリック/タップ）のハンドラ内から同期的に呼び出すことで、共有<audio>要素を
+// 解錠する。非同期処理を挟むとSafariでは解錠扱いにならないため、呼び出し側でawaitの前に
+// 呼ぶこと
 export function unlockAudioPlayback() {
   try {
-    new Audio(SILENT_AUDIO_DATA_URI).play().catch(() => {});
+    const audio = getSharedAudio();
+    audio.src = SILENT_AUDIO_DATA_URI;
+    audio.play().catch(() => {});
   } catch {
     // 対応していないブラウザでは何もしない
   }
+}
+
+// 解錠済みの共有<audio>要素でsrcを再生する。前の再生と重ならないよう、切り替え前に一旦止める
+export function playSharedAudio(src) {
+  const audio = getSharedAudio();
+  audio.pause();
+  audio.src = src;
+  return audio.play();
+}
+
+// テスト専用: モジュールスコープのシングルトンをテスト間で共有してしまわないようにリセットする
+export function resetSharedAudioForTests() {
+  sharedAudio = null;
 }

--- a/frontend/src/utils/audioUnlock.test.js
+++ b/frontend/src/utils/audioUnlock.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { unlockAudioPlayback, playSharedAudio, resetSharedAudioForTests } from './audioUnlock';
+
+const audioInstances = [];
+let audioPlayImpl = () => Promise.resolve();
+
+// App.test.jsxと同様の理由でアロー関数ではなく通常の関数式を使う（newで呼び出すため）
+window.Audio = vi.fn().mockImplementation(function (src) {
+  this.src = src;
+  this.play = vi.fn(() => audioPlayImpl());
+  this.pause = vi.fn();
+  audioInstances.push(this);
+});
+
+beforeEach(() => {
+  audioInstances.length = 0;
+  audioPlayImpl = () => Promise.resolve();
+  vi.clearAllMocks();
+  resetSharedAudioForTests();
+});
+
+describe('audioUnlock', () => {
+  it('unlockAudioPlayback creates a single shared <audio> element and plays a silent clip on it', () => {
+    unlockAudioPlayback();
+
+    expect(audioInstances).toHaveLength(1);
+    expect(audioInstances[0].src).toMatch(/^data:audio\/wav/);
+    expect(audioInstances[0].play).toHaveBeenCalled();
+  });
+
+  it('does not create a new element on repeated unlockAudioPlayback calls (issue #514: reuses the same element)', () => {
+    unlockAudioPlayback();
+    unlockAudioPlayback();
+
+    expect(audioInstances).toHaveLength(1);
+  });
+
+  it('playSharedAudio reuses the element that was already unlocked, pausing it and swapping the src, instead of creating a new Audio (issue #514)', async () => {
+    unlockAudioPlayback();
+    const unlockedInstance = audioInstances[0];
+
+    await playSharedAudio('data:audio/mp3;base64,DUMMY');
+
+    expect(audioInstances).toHaveLength(1);
+    expect(audioInstances[0]).toBe(unlockedInstance);
+    expect(unlockedInstance.pause).toHaveBeenCalled();
+    expect(unlockedInstance.src).toBe('data:audio/mp3;base64,DUMMY');
+    expect(unlockedInstance.play).toHaveBeenCalled();
+  });
+
+  it('playSharedAudio lazily creates the shared element if unlockAudioPlayback was never called', async () => {
+    await playSharedAudio('data:audio/mp3;base64,DUMMY');
+
+    expect(audioInstances).toHaveLength(1);
+    expect(audioInstances[0].src).toBe('data:audio/mp3;base64,DUMMY');
+  });
+
+  it('propagates a rejected play() (e.g. NotAllowedError) so callers can handle a still-blocked autoplay', async () => {
+    audioPlayImpl = () => Promise.reject(new Error('NotAllowedError'));
+
+    await expect(playSharedAudio('data:audio/mp3;base64,DUMMY')).rejects.toThrow('NotAllowedError');
+  });
+
+  it('resetSharedAudioForTests makes the next call create a fresh element, so tests do not leak state into each other', () => {
+    unlockAudioPlayback();
+    resetSharedAudioForTests();
+    unlockAudioPlayback();
+
+    expect(audioInstances).toHaveLength(2);
+  });
+});

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuizRoomSync } from "../hooks/useQuizRoomSync";
 import { API_BASE_URL } from "../config";
-import { unlockAudioPlayback } from "../utils/audioUnlock";
+import { unlockAudioPlayback, playSharedAudio } from "../utils/audioUnlock";
 
 // クイズ大会モード（issue #470）の参加者用入口（閲覧専用）。
 // ルームコードの直接入力、または招待URL（?roomId=...）からの参加に対応する。
@@ -116,8 +116,11 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   // issue #498: 再生設定（repeatCount/speechRate/lang/voiceId/announceCategory）は
   // 参加者自身のlocalStorageではなく、管理者からのブロードキャスト内容（roomState.content）
   // に含まれる値を使い、全員が管理者と同じ内容で聞こえるようにする
+  // issue #514: 音声の再生自体は`playSharedAudio`（frontend/src/utils/audioUnlock.js）で
+  // ユーザー操作により解錠済みの単一<audio>要素を使い回す。fetch完了後の非同期文脈で
+  // 毎回`new Audio(...)`していると、その要素自体はユーザー操作中に一度も再生されておらず、
+  // Safari等では再生がブロックされ続けてしまうため
   const lastPlayedKeyRef = useRef(null);
-  const currentAudioRef = useRef(null);
 
   useEffect(() => {
     if (!wsBaseUrl) {
@@ -155,11 +158,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
         if (cancelled || !response.ok || !data.audioData) {
           return;
         }
-        // 前の札の音声がまだ再生中なら、次の札の音声と重なって再生されないよう止める
-        currentAudioRef.current?.pause();
-        const audio = new Audio(data.audioData);
-        currentAudioRef.current = audio;
-        await audio.play();
+        await playSharedAudio(data.audioData);
       } catch (error) {
         console.error("Failed to play quiz room audio:", error);
       }

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -15,6 +15,8 @@ const CONNECTION_STATUS_LABEL = {
   error: "接続できませんでした",
 };
 
+const MAX_NAME_LENGTH = 20; // backend/quizRoomHandler.jsのMAX_NAME_LENGTHと合わせる（早押し機能、issue #510）
+
 function renderParticipantContent(roomState) {
   // ルーム作成直後（まだ一度もupdateStateが呼ばれていない）は、サーバー側の状態が
   // 空オブジェクト{}のままsyncで返ってくる。typeを持たない・未知のtypeの場合は
@@ -61,11 +63,47 @@ function QuizRoomView({ setView, wsBaseUrl }) {
 
   const [roomState, setRoomState] = useState(null);
 
-  const { connectionStatus } = useQuizRoomSync({
+  // 早押し機能（issue #510）: 参加者名は入室のたびに入力してもらう（永続化しない）。
+  // confirmedNameが空の間は名前入力画面を表示し、決定後にのみ通常の参加者画面へ進む
+  const [confirmedName, setConfirmedName] = useState("");
+  const [nameDraft, setNameDraft] = useState("");
+  const [buzzedBy, setBuzzedBy] = useState(null);
+  const [lastBuzzRoundKey, setLastBuzzRoundKey] = useState(null);
+
+  const { connectionStatus, setParticipantName, buzz } = useQuizRoomSync({
     wsBaseUrl,
     roomId: joinRoomId,
     onState: setRoomState,
+    onBuzz: setBuzzedBy,
   });
+
+  // 早押し結果表示のリセット判定（issue #510）。ラウンドを表す値（buzzRoundKey）を
+  // 状態種別ごとに導出し、前回と異なれば新しいラウンドとみなしてリセットする。
+  // - "phrase": 札ごとの一意キー（同じ札の再ブロードキャスト＝設定変更等では変わらない）
+  // - "result": 直前のラウンドキーを維持する（result表示中も回答者表示を残したいため）
+  // - それ以外（"initial"等）: ラウンドなし（null）とし、管理者がゲームをリセットした
+  //   場合等に、古い回答者情報が次のラウンドへ持ち越されないようにする
+  // レンダー中に前回値と比較して直接更新する、Reactが推奨する「レンダー中のstate調整」
+  // パターン（useEffect内でのsetStateはeslintのreact-hooks/set-state-in-effectに抵触するため使わない）
+  let currentBuzzRoundKey = lastBuzzRoundKey;
+  if (roomState?.type === "phrase" && roomState.content?.id) {
+    currentBuzzRoundKey = `${roomState.content.category}:${roomState.content.id}`;
+  } else if (roomState?.type !== "result") {
+    currentBuzzRoundKey = null;
+  }
+  if (currentBuzzRoundKey !== lastBuzzRoundKey) {
+    setLastBuzzRoundKey(currentBuzzRoundKey);
+    setBuzzedBy(null);
+  }
+
+  const handleConfirmName = () => {
+    const trimmed = nameDraft.trim();
+    if (!trimmed) {
+      return;
+    }
+    setConfirmedName(trimmed);
+    setParticipantName(trimmed);
+  };
 
   // issue #490: 音声同期再生は明示的にスコープ外だった（管理者端末でのみ再生）ため、
   // 参加者側は通知（roomState）を受けて自分自身で/get-phraseを呼び直し、取得した
@@ -141,6 +179,40 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     );
   }
 
+  if (joinRoomId && !confirmedName) {
+    return (
+      <div className="container py-5 mx-auto text-center">
+        <header className="mb-4">
+          <h1 className="h4 fw-bold">クイズ大会モード（参加者）</h1>
+        </header>
+        <main className="mx-auto text-center" style={{ maxWidth: "360px" }}>
+          <p className="text-muted small mb-2">早押し対決で使うお名前を入力してください</p>
+          <div className="d-flex gap-2 justify-content-center">
+            <input
+              type="text"
+              value={nameDraft}
+              onChange={(e) => setNameDraft(e.target.value)}
+              placeholder="お名前"
+              maxLength={MAX_NAME_LENGTH}
+              className="form-control"
+              style={{ maxWidth: "200px" }}
+            />
+            <button
+              onClick={handleConfirmName}
+              disabled={!nameDraft.trim()}
+              className="btn btn-outline-dark rounded-pill"
+            >
+              決定
+            </button>
+          </div>
+          <div className="text-center mt-5">
+            <button onClick={() => setView("game")} className="btn btn-link text-muted text-decoration-none">← 戻る</button>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
   if (joinRoomId) {
     return (
       <div className="container py-5 mx-auto text-center">
@@ -150,6 +222,15 @@ function QuizRoomView({ setView, wsBaseUrl }) {
         </header>
         <p className="text-muted small mb-3">接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}</p>
         {renderParticipantContent(roomState)}
+        {buzzedBy ? (
+          <p className="fw-bold text-dark mt-4">🔔 {buzzedBy.name} さんが回答しました</p>
+        ) : roomState?.type === "phrase" && (
+          <div className="mt-4">
+            <button onClick={buzz} className="btn btn-danger btn-lg rounded-pill px-5">
+              回答する
+            </button>
+          </div>
+        )}
         <div className="mt-5">
           <button onClick={() => setView("game")} className="btn btn-link text-muted text-decoration-none">← 戻る</button>
         </div>

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import QuizRoomView from './QuizRoomView';
+import { resetSharedAudioForTests } from '../utils/audioUnlock';
 
 const onStateCallbacks = [];
 const onBuzzCallbacks = [];
@@ -65,6 +66,9 @@ beforeEach(() => {
   audioInstances.length = 0;
   audioPlayImpl = () => Promise.resolve();
   localStorage.clear();
+  // 共有<audio>要素（issue #514）はモジュールスコープのシングルトンなので、
+  // テスト間で使い回されないようリセットする
+  resetSharedAudioForTests();
 });
 
 afterEach(() => {
@@ -286,8 +290,11 @@ describe('QuizRoomView', () => {
     expect(requestedUrl).toContain('announceCategory=false');
   });
 
-  it('stops the still-playing previous phrase audio when the next phrase arrives, to avoid overlapping playback', async () => {
-    fetch.mockResolvedValue({ ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }) });
+  it('stops the still-playing previous phrase audio when the next phrase arrives, to avoid overlapping playback (issue #514: reuses the same unlocked <audio> element rather than creating a new one)', async () => {
+    fetch.mockImplementation(async (url) => {
+      const audioData = url.includes('id=p2') ? 'data:audio/mp3;base64,DUMMY2' : 'data:audio/mp3;base64,DUMMY1';
+      return { ok: true, json: async () => ({ audioData }) };
+    });
     window.history.pushState({}, '', '?roomId=ABC123');
 
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
@@ -298,6 +305,7 @@ describe('QuizRoomView', () => {
       await Promise.resolve();
     });
     expect(audioInstances).toHaveLength(1);
+    expect(audioInstances[0].src).toBe('data:audio/mp3;base64,DUMMY1');
 
     emitState({ type: 'phrase', content: { id: 'p2', category: 'Cat1', phrase: '読み札2', level: '3' } });
     await act(async () => {
@@ -305,8 +313,11 @@ describe('QuizRoomView', () => {
       await Promise.resolve();
     });
 
-    expect(audioInstances).toHaveLength(2);
+    // 新しいAudioインスタンスを作るのではなく、同じ（ユーザー操作で解錠済みの）要素を
+    // 使い回すことで、非同期文脈からの再生でもSafari等でブロックされないようにしている
+    expect(audioInstances).toHaveLength(1);
     expect(audioInstances[0].pause).toHaveBeenCalled();
+    expect(audioInstances[0].src).toBe('data:audio/mp3;base64,DUMMY2');
   });
 
   it('does not show any manual "turn audio on" button, since audio playback is always on by default (issue #497)', () => {

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -3,12 +3,21 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import QuizRoomView from './QuizRoomView';
 
 const onStateCallbacks = [];
+const onBuzzCallbacks = [];
 let mockConnectionStatus = 'connected';
+const setParticipantNameMock = vi.fn();
+const buzzMock = vi.fn();
 
 vi.mock('../hooks/useQuizRoomSync', () => ({
-  useQuizRoomSync: ({ onState }) => {
+  useQuizRoomSync: ({ onState, onBuzz }) => {
     onStateCallbacks.push(onState);
-    return { connectionStatus: mockConnectionStatus, broadcastState: vi.fn() };
+    onBuzzCallbacks.push(onBuzz);
+    return {
+      connectionStatus: mockConnectionStatus,
+      broadcastState: vi.fn(),
+      setParticipantName: setParticipantNameMock,
+      buzz: buzzMock,
+    };
   },
 }));
 
@@ -18,6 +27,19 @@ function emitState(state) {
   act(() => {
     onStateCallbacks[onStateCallbacks.length - 1]?.(state);
   });
+}
+
+function emitBuzz(buzz) {
+  act(() => {
+    onBuzzCallbacks[onBuzzCallbacks.length - 1]?.(buzz);
+  });
+}
+
+// 早押し機能（issue #510）: 参加者画面は名前入力を先に確定させないと通常画面へ進まないため、
+// 名前を関係しないテストではこのヘルパーで確定させておく
+function confirmName(name = 'たろう') {
+  fireEvent.change(screen.getByPlaceholderText('お名前'), { target: { value: name } });
+  fireEvent.click(screen.getByText('決定'));
 }
 
 window.fetch = vi.fn();
@@ -35,7 +57,10 @@ window.Audio = vi.fn().mockImplementation(function (src) {
 
 beforeEach(() => {
   onStateCallbacks.length = 0;
+  onBuzzCallbacks.length = 0;
   mockConnectionStatus = 'connected';
+  setParticipantNameMock.mockClear();
+  buzzMock.mockClear();
   fetch.mockReset();
   audioInstances.length = 0;
   audioPlayImpl = () => Promise.resolve();
@@ -55,21 +80,25 @@ describe('QuizRoomView', () => {
     expect(screen.getByText('クイズ大会モードは現在準備中です。しばらくお待ちください。')).toBeInTheDocument();
   });
 
-  it('lets a participant join via a manually entered room code', () => {
+  it('lets a participant join via a manually entered room code, after confirming a name', () => {
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
 
     expect(screen.getByText('クイズ大会に参加する')).toBeInTheDocument();
     fireEvent.change(screen.getByPlaceholderText('ルームコード'), { target: { value: 'xyz789' } });
     fireEvent.click(screen.getByText('参加する'));
 
+    confirmName('たろう');
+
     expect(screen.getByText('クイズ大会モード（参加者）')).toBeInTheDocument();
     expect(screen.getByText('ルーム: XYZ789')).toBeInTheDocument();
+    expect(setParticipantNameMock).toHaveBeenCalledWith('たろう');
   });
 
   it('renders the participant view from a ?roomId= deep link and updates as state is broadcast', () => {
     window.history.pushState({}, '', '?view=quiz-room&roomId=ABC123');
 
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
 
     expect(screen.getByText('クイズ大会モード（参加者）')).toBeInTheDocument();
     expect(screen.getByText('ホストの操作を待っています...')).toBeInTheDocument();
@@ -90,6 +119,7 @@ describe('QuizRoomView', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
 
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
 
     emitState({});
 
@@ -101,6 +131,7 @@ describe('QuizRoomView', () => {
     mockConnectionStatus = 'error';
 
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
 
     expect(screen.getByText('接続状態: 接続できませんでした')).toBeInTheDocument();
   });
@@ -113,6 +144,85 @@ describe('QuizRoomView', () => {
     fireEvent.click(screen.getByText('← 戻る'));
 
     expect(setView).toHaveBeenCalledWith('game');
+  });
+
+  it('shows a name entry screen before the participant screen, and does not let the participant confirm an empty name (issue #510)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+
+    expect(screen.getByText('早押し対決で使うお名前を入力してください')).toBeInTheDocument();
+    expect(screen.queryByText('クイズ大会モード（参加者）', { selector: 'h1' })).toBeInTheDocument();
+    expect(screen.queryByText('ルーム:', { exact: false })).not.toBeInTheDocument();
+    expect(screen.getByText('決定')).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText('お名前'), { target: { value: '   ' } });
+    expect(screen.getByText('決定')).toBeDisabled();
+
+    confirmName('はなこ');
+    expect(screen.getByText('ルーム: ABC123')).toBeInTheDocument();
+    expect(setParticipantNameMock).toHaveBeenCalledWith('はなこ');
+  });
+
+  it('lets a participant buzz in while a phrase is being read, and shows the responder\'s name once someone has buzzed (issue #510)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+    expect(screen.getByText('回答する')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('回答する'));
+    expect(buzzMock).toHaveBeenCalled();
+
+    emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
+    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+    expect(screen.queryByText('回答する')).not.toBeInTheDocument();
+  });
+
+  it('keeps showing the responder during the result screen, but resets it once a new (different) phrase is broadcast', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+    emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
+    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+
+    emitState({ type: 'result', content: { time: 1.2, answer: '答え1' } });
+    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+
+    emitState({ type: 'phrase', content: { id: 'p2', category: 'Cat1', phrase: '読み札2', level: '3' } });
+    expect(screen.queryByText('🔔 はなこ さんが回答しました')).not.toBeInTheDocument();
+    expect(screen.getByText('回答する')).toBeInTheDocument();
+  });
+
+  it('resets the responder display when the room goes back to the initial/idle state (e.g. the admin resets the game), not just when a new phrase is broadcast', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+    emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
+    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+
+    emitState({ type: 'initial' });
+    expect(screen.queryByText('🔔 はなこ さんが回答しました')).not.toBeInTheDocument();
+  });
+
+  it('does not clear an already-recorded responder when the same phrase is re-broadcast (e.g. the admin changed a setting mid-round)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3', speechRate: '80%' } });
+    emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
+    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+
+    // 同じ札（id/categoryが同一）が設定変更等で再ブロードキャストされても、
+    // 既に記録済みの回答者表示を誤って消してはならない
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3', speechRate: '100%' } });
+    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
   });
 
   it('fetches and plays audio for a broadcast phrase using the settings broadcast by the admin, not the participant\'s own local settings (issue #490, #498)', async () => {


### PR DESCRIPTION
## 概要
issue #510対応。クイズ大会モードに早押し機能を追加した。
追加コミットでissue #514（参加者モードで音声が再生されない）にも対応した。

## 対応内容（早押し機能、issue #510）
- 参加者はルーム参加時（招待URL・ルームコード入力・トップページの一覧クリック、いずれの導線でも）に表示名を入力する画面を挟む。
- 出題中（`roomState.type === "phrase"`）のみ「回答する」ボタンが表示され、押すと早押しできる。
- 早押しはDynamoDBの条件付き書き込み（`ConditionExpression: attribute_not_exists(buzz)`）で同一ラウンド内の最初の1件だけを確定させ、ルーム内の全接続（管理者・他の参加者）へ回答者名をブロードキャストする。
- 管理者側は`QuizRoomInfoPanel`の下に「🔔 ◯◯さんが回答しました」と表示する。
- 新しい札の出題時・ゲームリセット等で"initial"に戻ったときに早押し結果をリセットする（result表示中は次の札が出るまで回答者を表示し続ける）。
- 再接続・遅れて参加した端末にも、現在のラウンドで既に誰かが早押し済みなら追って通知する。

### レビューで見つけて修正したバグ
早押し結果表示のリセットを単純に「typeが"phrase"なら常にリセット」としていたため、(1) 管理者が設定変更で同じ札を再ブロードキャストすると回答者表示が消える、(2) ゲームリセット（"initial"復帰）後に古い早押し情報が新しい参加者に残る、という不具合があった。「ラウンドキー」（phraseはカテゴリ:ID、resultは直前のラウンドキーを維持、それ以外はnull）の変化で判定するように修正し、両方のケースをテストで確認した。

## 対応内容（参加者モードで音声が出ない、issue #514）
issue #497/#498対応後もなお発生していた「参加者モードで読み上げ音声が出ない」報告への追加対応。

- **推定原因**: Safari（iOS/macOS）はHTMLAudioElementごとに「ユーザー操作の中で一度でも再生された要素かどうか」で以降の非同期文脈でのplay()許可を判断する。参加者側の音声再生は「WebSocket通知→`/get-phrase`取得→play()」という非同期処理のため、その都度`new Audio(...)`していると、その要素自体はユーザー操作中に一度も再生されておらず、参加操作のクリックが何度あってもSafariにブロックされ続ける構造的な問題があった。
- **対応**: モジュールスコープのシングルトンとして保持する単一の`<audio>`要素を使い回す方式（`frontend/src/utils/audioUnlock.js`の`playSharedAudio`）に変更した。ユーザー操作（ルーム一覧クリック・参加ボタンクリック・画面内の最初のクリック/タップ）ではこの同じ共有要素を解錠し、以降の実際の音声再生も同じ要素のsrcを差し替えて行う。
- **注記**: このセッションからは実機Safari/iOSでの目視確認ができないため、これがissue #514の唯一の原因である確証はない。有力な仮説に基づく修正である。

## 対応方針・スコープ外
- 早押しの公平性はサーバー到達順（DynamoDBの条件付き書き込み）で確定する方式とした。クライアント間の通信遅延によるズレは許容する（issueのTODOに記載した既知の制約）。

## Test plan
- [x] `backend`: `npm run lint` エラー0件 / `npm test -- --run` 全1329件成功
- [x] `frontend`: `npm run lint` エラー0件 / `npm test -- --run` 全135件成功（早押し機能一式に加え、共有audio要素の解錠・使い回しを検証するテストを追加）
- [ ] 実機ブラウザ・複数端末での早押し対決／Safari等での音声再生の目視確認（このセッションからは未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_