### PR TITLE
feat(ui): 参加者登録UIを確定モーダルから読み札画面の任意ボタンへ移動する

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -105,6 +105,9 @@ function App() {
   const [historyByCategory, setHistoryByCategory] = useSessionStorageState(HISTORY_STORAGE_KEY, {});
   const [players, setPlayers] = useSessionStorageState(PLAYERS_STORAGE_KEY, []);
   const [newPlayerName, setNewPlayerName] = useState("");
+  // 「取った人を記録する」参加者登録は、カテゴリ確定時のモーダルではなく読み札画面の
+  // ボタンから任意に開閉する（issue #518）
+  const [showPlayerRegistration, setShowPlayerRegistration] = useState(false);
   const [scoresByCategory, setScoresByCategory] = useSessionStorageState(SCORES_STORAGE_KEY, {});
   const [currentRoundTakenBy, setCurrentRoundTakenBy] = useState(null);
 
@@ -1350,40 +1353,6 @@ function App() {
                       : "ゲームを開始しますか？"}
                   </h3>
 
-                  <div className="mb-4 text-start">
-                    <h4 className="h6 fw-bold mb-2">取った人を記録する参加者（任意）</h4>
-                    {players.length > 0 && (
-                      <div className="d-flex flex-wrap gap-2 mb-2">
-                        {players.map(name => (
-                          <span key={name} className="badge bg-secondary d-flex align-items-center gap-1 py-2 px-3 fs-6">
-                            {name}
-                            <button
-                              type="button"
-                              onClick={() => removePlayer(name)}
-                              className="btn-close btn-close-white"
-                              style={{ fontSize: "0.6rem" }}
-                              aria-label={`${name}を削除`}
-                            ></button>
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                    {players.length < MAX_PLAYERS && (
-                      <div className="d-flex gap-2">
-                        <input
-                          type="text"
-                          value={newPlayerName}
-                          onChange={(e) => setNewPlayerName(e.target.value)}
-                          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addPlayer(); } }}
-                          placeholder="名前を入力"
-                          className="form-control"
-                          maxLength={20}
-                        />
-                        <button type="button" onClick={addPlayer} disabled={!newPlayerName.trim()} className="btn btn-outline-primary">追加</button>
-                      </div>
-                    )}
-                  </div>
-
                   <div className="d-flex gap-2 justify-content-center">
                     <button onClick={confirmCategory} className="btn btn-primary btn-lg px-4 rounded-pill shadow-sm fs-6">はい</button>
                     <button onClick={cancelCategory} className="btn btn-outline-secondary btn-lg px-4 rounded-pill fs-6">いいえ</button>
@@ -1552,6 +1521,52 @@ function App() {
               {displayContent.type === 'result' && renderResult(displayContent.content)}
               {displayContent.type === 'initial' && renderInitial()}
             </div>
+
+            {division !== "kids" && (
+              <div className="mb-4">
+                <button
+                  type="button"
+                  onClick={() => setShowPlayerRegistration(prev => !prev)}
+                  className="btn btn-sm btn-outline-secondary rounded-pill px-3"
+                >
+                  {showPlayerRegistration ? "参加者登録を閉じる" : players.length > 0 ? "参加者を編集する" : "取った人を記録する参加者を登録する"}
+                </button>
+                {showPlayerRegistration && (
+                  <div className="mt-3 mx-auto text-start" style={{ maxWidth: "360px" }}>
+                    {players.length > 0 && (
+                      <div className="d-flex flex-wrap gap-2 mb-2">
+                        {players.map(name => (
+                          <span key={name} className="badge bg-secondary d-flex align-items-center gap-1 py-2 px-3 fs-6">
+                            {name}
+                            <button
+                              type="button"
+                              onClick={() => removePlayer(name)}
+                              className="btn-close btn-close-white"
+                              style={{ fontSize: "0.6rem" }}
+                              aria-label={`${name}を削除`}
+                            ></button>
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                    {players.length < MAX_PLAYERS && (
+                      <div className="d-flex gap-2">
+                        <input
+                          type="text"
+                          value={newPlayerName}
+                          onChange={(e) => setNewPlayerName(e.target.value)}
+                          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addPlayer(); } }}
+                          placeholder="名前を入力"
+                          className="form-control"
+                          maxLength={20}
+                        />
+                        <button type="button" onClick={addPlayer} disabled={!newPlayerName.trim()} className="btn btn-outline-primary">追加</button>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
 
             {displayContent.type === 'phrase' && division !== "kids" && players.length > 0 && (
               <div className="mb-4">

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2277,6 +2277,11 @@ describe('App', () => {
     fireEvent.click(screen.getByText(/決定/));
 
     await waitFor(() => screen.getByText(/「Cat1」をお手元に持っていますか？/));
+    fireEvent.click(screen.getByText('はい'));
+
+    // 参加者登録（issue #518）はカテゴリ確定モーダルではなく、読み札画面のボタンから行う
+    await waitFor(() => screen.getByText('次の札'));
+    fireEvent.click(screen.getByText('取った人を記録する参加者を登録する'));
 
     const nameInput = screen.getByPlaceholderText('名前を入力');
     fireEvent.change(nameInput, { target: { value: 'たろう' } });
@@ -2287,9 +2292,6 @@ describe('App', () => {
     expect(screen.getByText('たろう')).toBeInTheDocument();
     expect(screen.getByText('はなこ')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText('はい'));
-
-    await waitFor(() => screen.getByText('次の札'));
     fireEvent.click(screen.getByText('次の札'));
 
     await waitFor(() => {
@@ -2311,6 +2313,59 @@ describe('App', () => {
     const hanakoCard = screen.getByText('はなこ', { selector: 'span.fw-bold' }).parentElement;
     expect(within(hanakoCard).getByText(/0枚/)).toBeInTheDocument();
   }, 50000);
+
+  it('does not show the participant-registration UI in the category confirmation modal (issue #518)', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }] }),
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('エンジニア向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    fireEvent.click(screen.getByText(/決定/));
+
+    await waitFor(() => screen.getByText(/「Cat1」をお手元に持っていますか？/));
+
+    expect(screen.queryByPlaceholderText('名前を入力')).not.toBeInTheDocument();
+    expect(screen.queryByText('取った人を記録する参加者（任意）')).not.toBeInTheDocument();
+  });
+
+  it('lets the participant-registration panel on the reading screen be toggled open and closed, with the button label reflecting whether anyone is registered yet (issue #518)', async () => {
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1', phrase: '読み札1' }] }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('エンジニア向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    fireEvent.click(screen.getByText(/決定/));
+    await waitFor(() => screen.getByText(/「Cat1」をお手元に持っていますか？/));
+    fireEvent.click(screen.getByText('はい'));
+    await waitFor(() => screen.getByText('次の札'));
+
+    expect(screen.queryByPlaceholderText('名前を入力')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('取った人を記録する参加者を登録する'));
+    expect(screen.getByPlaceholderText('名前を入力')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('名前を入力'), { target: { value: 'たろう' } });
+    fireEvent.click(screen.getByText('追加'));
+
+    fireEvent.click(screen.getByText('参加者登録を閉じる'));
+    expect(screen.queryByPlaceholderText('名前を入力')).not.toBeInTheDocument();
+
+    // 登録済みの参加者がいる場合、再度開くボタンの文言が変わる
+    expect(screen.getByText('参加者を編集する')).toBeInTheDocument();
+  });
 
   it('does not show player registration or the taken-by buttons in kids mode even if players are already registered', async () => {
     sessionStorage.setItem('players', JSON.stringify(['たろう']));


### PR DESCRIPTION
## 概要

issue #518 対応。「取った人を記録する」参加者登録UIを、カテゴリ選択時に必ず表示される確定モーダルから、読み札画面の任意のトグルボタンへ移動する。

## 対応内容

- カテゴリ確定モーダル(`showConfirmModal`)から参加者登録UI（名前入力・追加・削除）を削除し、カテゴリ確認/所持確認のみを行う元来の役割に戻した
- 読み札画面に新しいトグルボタンを追加（`showPlayerRegistration`状態で開閉）。ボタンラベルは登録済み参加者の有無で「取った人を記録する参加者を登録する」/「参加者を編集する」を切り替える
- kids division では表示しない（既存の「取った人:」記録UIと同じ条件）
- 既存の「取った人:」記録機能(`recordTaken`)自体は変更なし

## Test plan

- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 137/137件成功
- [x] `backend`: `npm run lint` エラー0件
- [x] `backend`: `npm test -- --run` 1473/1473件成功
- [x] 確定モーダルに参加者登録UIが表示されないことのテストを追加
- [x] トグルボタンの開閉およびラベル切り替えのテストを追加

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_