### PR TITLE
fix(quiz-room): 開設中ルーム一覧を最新5件に制限する

### DIFF
--- a/backend/quizRoomHandler.js
+++ b/backend/quizRoomHandler.js
@@ -15,6 +15,7 @@ const ROOM_CODE_LENGTH = 6;
 const MAX_CREATE_ROOM_ATTEMPTS = 5; // ルームコード衝突時の再採番の上限
 const MAX_STATE_JSON_LENGTH = 8000; // 状態データの肥大化・課金濫用を防ぐ上限
 const MAX_NAME_LENGTH = 20; // 早押し機能（issue #510）: 参加者名の肥大化・表示崩れを防ぐ上限
+const MAX_OPEN_ROOMS_DISPLAYED = 5; // トップページの一覧が無制限に肥大化しないための上限（issue #500）
 
 function generateRoomCode() {
   let code = "";
@@ -105,7 +106,8 @@ exports.listQuizRooms = async (event) => {
         createdAt: item.createdAt,
         category: item.state?.content?.category || null,
       }))
-      .sort((a, b) => b.createdAt - a.createdAt);
+      .sort((a, b) => b.createdAt - a.createdAt)
+      .slice(0, MAX_OPEN_ROOMS_DISPLAYED);
 
     return {
       statusCode: 200,

--- a/backend/quizRoomHandler.test.js
+++ b/backend/quizRoomHandler.test.js
@@ -95,6 +95,22 @@ describe('listQuizRooms', () => {
     expect(JSON.stringify(body)).not.toContain('secret-hash');
   });
 
+  it('returns only the latest 5 rooms even when more are open (issue #500)', async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: Array.from({ length: 8 }, (_, i) => ({
+        roomId: `ROOM0${i}`,
+        createdAt: i,
+        state: {},
+      })),
+    });
+
+    const response = await listQuizRooms({});
+    const body = JSON.parse(response.body);
+
+    expect(body.rooms).toHaveLength(5);
+    expect(body.rooms.map((r) => r.roomId)).toEqual(['ROOM07', 'ROOM06', 'ROOM05', 'ROOM04', 'ROOM03']);
+  });
+
   it('excludes rooms whose ttl has already passed via the filter expression', async () => {
     ddbMock.on(ScanCommand).resolves({ Items: [] });
 


### PR DESCRIPTION
## 概要

issue #500 対応。トップページ下部に表示している開設中のクイズ大会ルーム一覧について、件数の上限なく全件表示していたのを最新5件のみに制限する。

## 対応内容

- `backend/quizRoomHandler.js`の`listQuizRooms`（`GET /quiz-rooms`）で、`createdAt`降順ソート後に`MAX_OPEN_ROOMS_DISPLAYED`(5)件で`slice`し、最新5件のみ返すようにした
- フロントエンド（`frontend/src/App.jsx`）はレスポンスをそのまま表示しているだけなので変更不要

## Test plan

- [x] `backend`: `npm run lint` エラー0件
- [x] `backend`: `npm test -- --run` 1474/1474件成功
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 137/137件成功
- [x] 8件のルームが開設中の場合に最新5件のみが返ることを検証するテストを追加

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_