### PR TITLE
fix(pwa): PDF生成中はオフライン利用可能メッセージを抑制する

### DIFF
--- a/frontend/src/PwaUpdatePrompt.jsx
+++ b/frontend/src/PwaUpdatePrompt.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useRegisterSW } from "virtual:pwa-register/react";
+import { usePdfExportInProgress } from "./pdfExportStatus";
 import "./PwaUpdatePrompt.css";
 
 // オフライン利用可能通知は操作を要求しない情報表示のため、この時間が経てば自動的に消す。
@@ -19,6 +20,9 @@ function PwaUpdatePrompt() {
   const offlineReady = sw?.offlineReady?.[0] || false;
   const setOfflineReady = sw?.offlineReady?.[1] || noop;
   const updateServiceWorker = sw?.updateServiceWorker || noop;
+  // PDF出力（generate-efuda-pdf）はバックエンドAPIへの通信が必須でオフラインでは
+  // 動作しないため、生成中に「オフラインで利用可能になりました」を出すと誤解を招く（issue #473）
+  const isPdfExportInProgress = usePdfExportInProgress();
 
   const close = () => {
     setOfflineReady(false);
@@ -55,7 +59,7 @@ function PwaUpdatePrompt() {
     );
   }
 
-  if (offlineReady) {
+  if (offlineReady && !isPdfExportInProgress) {
     return (
       <div className="pwa-update-prompt" role="alert">
         <span>オフラインで利用可能になりました</span>

--- a/frontend/src/PwaUpdatePrompt.test.jsx
+++ b/frontend/src/PwaUpdatePrompt.test.jsx
@@ -8,6 +8,7 @@ vi.mock("virtual:pwa-register/react", () => ({
 }));
 
 import PwaUpdatePrompt from "./PwaUpdatePrompt.jsx";
+import { setPdfExportInProgress } from "./pdfExportStatus";
 
 describe("PwaUpdatePrompt", () => {
   beforeEach(() => {
@@ -16,6 +17,8 @@ describe("PwaUpdatePrompt", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    // pdfExportStatusはモジュール単位で状態を共有するため、他テストへ漏れないよう戻す
+    setPdfExportInProgress(false);
   });
 
   it("更新が不要な場合は何も表示しない", () => {
@@ -103,6 +106,33 @@ describe("PwaUpdatePrompt", () => {
 
     expect(setOfflineReady).toHaveBeenCalledWith(false);
     vi.useRealTimers();
+  });
+
+  it("PDF生成中はオフライン利用可能でもメッセージを表示しない（issue #473）", () => {
+    setPdfExportInProgress(true);
+    useRegisterSWMock.mockReturnValue({
+      needRefresh: [false, vi.fn()],
+      offlineReady: [true, vi.fn()],
+      updateServiceWorker: vi.fn(),
+    });
+
+    const { container } = render(<PwaUpdatePrompt />);
+
+    expect(screen.queryByText("オフラインで利用可能になりました")).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("PDF生成が終わればオフライン利用可能メッセージが表示される（issue #473）", () => {
+    setPdfExportInProgress(false);
+    useRegisterSWMock.mockReturnValue({
+      needRefresh: [false, vi.fn()],
+      offlineReady: [true, vi.fn()],
+      updateServiceWorker: vi.fn(),
+    });
+
+    render(<PwaUpdatePrompt />);
+
+    expect(screen.getByText("オフラインで利用可能になりました")).toBeInTheDocument();
   });
 
   it("更新が必要な場合（ユーザーの判断を要する）は自動では消えない", () => {

--- a/frontend/src/pdfExportStatus.js
+++ b/frontend/src/pdfExportStatus.js
@@ -1,0 +1,22 @@
+import { useSyncExternalStore } from "react";
+
+// PrintEfudaView（PDF出力の実行元）とPwaUpdatePrompt（main.jsxでAppの兄弟として
+// グローバルにマウントされており、propsで直接つなげない）との間で、
+// 「PDF生成中かどうか」だけを共有するための最小限のstore（issue #473）
+let isExporting = false;
+const listeners = new Set();
+
+export function setPdfExportInProgress(value) {
+  isExporting = value;
+  listeners.forEach((listener) => listener());
+}
+
+export function usePdfExportInProgress() {
+  return useSyncExternalStore(
+    (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    () => isExporting
+  );
+}

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { API_BASE_URL } from "../config";
 import { serializeCategoriesParam } from "../hooks/useUrlQuerySync";
+import { setPdfExportInProgress, usePdfExportInProgress } from "../pdfExportStatus";
 
 const getEfudaText = (p) => (p.answer && p.answer !== "-") ? p.answer : p.phrase;
 
@@ -59,7 +60,7 @@ const resolvePhraseIndex = (slotIndex, printSide) => {
 };
 
 function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrasesForCategory, efudaPages, efudaPerPage }) {
-  const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
+  const isGeneratingPdf = usePdfExportInProgress();
   // 表面（読み札の内容）と裏面（種別・レベル）は用紙を裏返して2回に分けて印刷する運用を想定し、
   // 同じページ構成をどちらの内容で描画するかだけをこのstateで切り替える。
   // バックエンドのrenderEfudaPdfWorkerがヘッドレスブラウザでこの画面をディープリンク
@@ -77,7 +78,7 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
   );
 
   const downloadPdf = async () => {
-    setIsGeneratingPdf(true);
+    setPdfExportInProgress(true);
     try {
       const categoryParam = serializeCategoriesParam(selectedCategories);
       const startResponse = await fetch(`${API_BASE_URL}/generate-efuda-pdf`, {
@@ -120,7 +121,7 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
       console.error("Error generating PDF:", error);
       alert("PDFの生成に失敗しました。");
     } finally {
-      setIsGeneratingPdf(false);
+      setPdfExportInProgress(false);
     }
   };
 


### PR DESCRIPTION
## 概要

issue #473 対応。絵札のPDF出力中に「オフラインで利用可能になりました」というPWAメッセージが表示され、紛らわしいのを解消する。PDF生成（`generate-efuda-pdf`）はバックエンドAPIへの通信が必須でオフラインでは動作しないため、生成中にこのメッセージが出ること自体が誤解を招く。

## 対応内容

- `frontend/src/pdfExportStatus.js`（新規）: `PrintEfudaView`（PDF出力の実行元）と`PwaUpdatePrompt`（`main.jsx`でAppの兄弟としてグローバルにマウントされておりpropsで直接つなげない）との間で「PDF生成中かどうか」を共有する最小限のstore（`useSyncExternalStore`採用）
- `PrintEfudaView.jsx`: ローカルの`isGeneratingPdf` stateをこの共有storeに置き換え
- `PwaUpdatePrompt.jsx`: PDF生成中は「オフラインで利用可能になりました」メッセージの表示を抑制する（更新通知`needRefresh`の挙動は変更なし）

## Test plan

- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 139/139件成功
- [x] `backend`: `npm run lint` エラー0件
- [x] `backend`: `npm test -- --run` 1474/1474件成功
- [x] PDF生成中はオフライン利用可能メッセージを表示しないことを検証するテストを追加
- [x] PDF生成終了後は通常どおり表示されることを検証するテストを追加

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_