### PR TITLE
feat(quiz-room): 早押し機能にポイント制を追加する

### DIFF
--- a/backend/quizRoomHandler.js
+++ b/backend/quizRoomHandler.js
@@ -247,6 +247,14 @@ exports.syncQuizRoom = async (event) => {
       });
     }
 
+    // ポイント制（issue #519）: 再接続・遅れて参加した端末にも現在の集計を伝える
+    if (room.Item.points) {
+      await postToConnection(managementApi, connectionId, {
+        type: "points",
+        points: room.Item.points,
+      });
+    }
+
     return { statusCode: 200, body: "" };
   } catch (error) {
     console.error(error);
@@ -275,18 +283,52 @@ exports.updateQuizRoomState = async (event) => {
     }
 
     const { roomId } = connection.Item;
+
+    const room = await docClient.send(new GetCommand({
+      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+      Key: { roomId },
+    }));
+
+    // 読み上げ設定の変更等で、ラウンドが進んだわけではなく同じ札のphraseが
+    // 再ブロードキャストされることがある（App.jsxのbroadcast effect参照）。
+    // このケースを新しいラウンドの開始と誤認すると、早押し結果を巻き戻す前に
+    // ポイントを加点してしまったり、まだ判定が済んでいない早押し記録を
+    // 消してしまったりするため、直前の状態と札のidを比較して区別する
+    const isSamePhraseRebroadcast = newState.type === "phrase"
+      && room.Item?.state?.type === "phrase"
+      && room.Item?.state?.content?.id === newState.content?.id;
+
+    // 早押しポイント制（issue #519）: 次の札（type="phrase"、かつラウンドが実際に
+    // 進んだ場合）に進むタイミングで、直前のラウンドで早押しが記録されていれば
+    // その人に1ポイント加点する。"initial"へ戻す場合（ゲームのリセット等）は
+    // お手つき等の可能性を否定できないため加点しない
+    let updatedPoints = null;
+    if (newState.type === "phrase" && !isSamePhraseRebroadcast) {
+      const buzzedName = room.Item?.buzz?.name;
+      if (buzzedName) {
+        updatedPoints = { ...(room.Item.points || {}) };
+        updatedPoints[buzzedName] = (updatedPoints[buzzedName] || 0) + 1;
+      }
+    }
+
     // 早押し機能（issue #510）: 新しい札（次の問題）や、ゲームのリセット等で"initial"に
-    // 戻った場合は、前のラウンドの早押し結果をリセットする。result表示中だけは次の札が
-    // 出るまで回答者を表示し続けたいため、typeが"result"のときだけリセットしない
-    const resetBuzz = newState.type !== "result" ? " REMOVE buzz" : "";
+    // 戻った場合は、前のラウンドの早押し結果をリセットする。result表示中や、同じ札の
+    // 再ブロードキャスト中は、まだそのラウンドの早押し結果を確定させたくないためリセットしない
+    const resetBuzz = newState.type !== "result" && !isSamePhraseRebroadcast ? " REMOVE buzz" : "";
+    const updatePointsExpr = updatedPoints ? ", #points = :points" : "";
     await docClient.send(new UpdateCommand({
       TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
       Key: { roomId },
-      UpdateExpression: `SET #state = :state, #ttl = :ttl${resetBuzz}`,
-      ExpressionAttributeNames: { "#state": "state", "#ttl": "ttl" },
+      UpdateExpression: `SET #state = :state, #ttl = :ttl${updatePointsExpr}${resetBuzz}`,
+      ExpressionAttributeNames: {
+        "#state": "state",
+        "#ttl": "ttl",
+        ...(updatedPoints ? { "#points": "points" } : {}),
+      },
       ExpressionAttributeValues: {
         ":state": newState,
         ":ttl": Math.floor(Date.now() / 1000) + ROOM_TTL_SECONDS,
+        ...(updatedPoints ? { ":points": updatedPoints } : {}),
       },
     }));
 
@@ -306,6 +348,15 @@ exports.updateQuizRoomState = async (event) => {
       }))
     );
 
+    if (updatedPoints) {
+      await Promise.allSettled(
+        (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
+          type: "points",
+          points: updatedPoints,
+        }))
+      );
+    }
+
     return { statusCode: 200, body: "" };
   } catch (error) {
     console.error(error);
@@ -322,6 +373,36 @@ exports.setQuizRoomName = async (event) => {
     const name = typeof body.name === "string" ? body.name.trim().slice(0, MAX_NAME_LENGTH) : "";
     if (!name) {
       return { statusCode: 400, body: "Invalid name" };
+    }
+
+    const connection = await docClient.send(new GetCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      Key: { connectionId },
+    }));
+    if (!connection.Item) {
+      // 接続情報が既に無い（切断済み等）。名前の保存自体は無意味なので何もしない
+      return { statusCode: 200, body: "" };
+    }
+
+    // ポイント制（issue #519）はnameを集計キーにするため、同一ルーム内で名前が
+    // 重複すると他人のポイントと混ざってしまう。参加時点で重複を禁止する
+    const { roomId } = connection.Item;
+    const connections = await docClient.send(new QueryCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      IndexName: "roomId-index",
+      KeyConditionExpression: "roomId = :roomId",
+      ExpressionAttributeValues: { ":roomId": roomId },
+    }));
+    const isDuplicate = (connections.Items || []).some(
+      (conn) => conn.connectionId !== connectionId && conn.name === name
+    );
+    if (isDuplicate) {
+      const managementApi = buildManagementApiClient(event);
+      await postToConnection(managementApi, connectionId, {
+        type: "nameError",
+        message: "その名前は既に使われています。別の名前を入力してください。",
+      });
+      return { statusCode: 200, body: "" };
     }
 
     await docClient.send(new UpdateCommand({

--- a/backend/quizRoomHandler.test.js
+++ b/backend/quizRoomHandler.test.js
@@ -283,6 +283,37 @@ describe('syncQuizRoom', () => {
     expect(managementApiMock.commandCalls(PostToConnectionCommand)).toHaveLength(1);
   });
 
+  it('also sends the current point standings to a reconnecting/late-joining participant (issue #519)', async () => {
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
+      Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' },
+    });
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({
+      Item: { roomId: 'ROOM01', state: { type: 'phrase', content: { id: 'p1' } }, points: { たろう: 2, はなこ: 1 } },
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    await syncQuizRoom(wsEvent({ connectionId: 'conn-1' }));
+
+    const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
+    expect(postCalls).toHaveLength(2);
+    const pointsPayload = JSON.parse(Buffer.from(postCalls[1].args[0].input.Data).toString('utf-8'));
+    expect(pointsPayload).toEqual({ type: 'points', points: { たろう: 2, はなこ: 1 } });
+  });
+
+  it('does not send a points message when no one has scored yet', async () => {
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
+      Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' },
+    });
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({
+      Item: { roomId: 'ROOM01', state: { type: 'phrase', content: { id: 'p1' } } },
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    await syncQuizRoom(wsEvent({ connectionId: 'conn-1' }));
+
+    expect(managementApiMock.commandCalls(PostToConnectionCommand)).toHaveLength(1);
+  });
+
   it('handles errors', async () => {
     ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
     const response = await syncQuizRoom(wsEvent());
@@ -378,6 +409,133 @@ describe('updateQuizRoomState', () => {
     expect(updateCall.UpdateExpression).toContain('REMOVE buzz');
   });
 
+  it('awards a point to the buzzer when advancing to a new phrase after someone buzzed (issue #519)', async () => {
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
+      Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+    });
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({
+      Item: { roomId: 'ROOM01', buzz: { connectionId: 'conn-p', name: 'たろう', buzzedAt: 1000 } },
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+        { connectionId: 'conn-p', roomId: 'ROOM01', role: 'participant' },
+      ],
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    const newState = { type: 'phrase', phrase: { id: 'p2', category: 'Cat1' } };
+    const response = await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
+
+    expect(response.statusCode).toBe(200);
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.ExpressionAttributeValues[':points']).toEqual({ たろう: 1 });
+    expect(updateCall.UpdateExpression).toContain('#points = :points');
+
+    const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
+    const pointsMessages = postCalls
+      .map((call) => JSON.parse(Buffer.from(call.args[0].input.Data).toString('utf-8')))
+      .filter((payload) => payload.type === 'points');
+    expect(pointsMessages).toHaveLength(2);
+    expect(pointsMessages[0]).toEqual({ type: 'points', points: { たろう: 1 } });
+  });
+
+  it('accumulates points across rounds for the same participant', async () => {
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
+      Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+    });
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({
+      Item: {
+        roomId: 'ROOM01',
+        buzz: { connectionId: 'conn-p', name: 'たろう', buzzedAt: 1000 },
+        points: { たろう: 2, はなこ: 1 },
+      },
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const newState = { type: 'phrase', phrase: { id: 'p3', category: 'Cat1' } };
+    await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
+
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.ExpressionAttributeValues[':points']).toEqual({ たろう: 3, はなこ: 1 });
+  });
+
+  it('does not award a point when advancing to a new phrase if no one buzzed in the previous round', async () => {
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
+      Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+    });
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({ Item: { roomId: 'ROOM01' } });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const newState = { type: 'phrase', phrase: { id: 'p4', category: 'Cat1' } };
+    await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
+
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.ExpressionAttributeValues[':points']).toBeUndefined();
+    expect(updateCall.UpdateExpression).not.toContain('#points');
+  });
+
+  it('does not award a point when resetting to the initial state even if someone had buzzed (avoids scoring an aborted round)', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' } });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const newState = { type: 'initial' };
+    await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
+
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.ExpressionAttributeValues[':points']).toBeUndefined();
+  });
+
+  it('does not award a point or reset the buzz field when the same phrase is merely re-broadcast (e.g. a mid-round settings change), since the round has not actually advanced (issue #519)', async () => {
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
+      Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+    });
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({
+      Item: {
+        roomId: 'ROOM01',
+        state: { type: 'phrase', content: { id: 'p1', category: 'Cat1' } },
+        buzz: { connectionId: 'conn-p', name: 'たろう', buzzedAt: 1000 },
+      },
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    // 同じ札(id: 'p1')が、speechRate等の変更により再ブロードキャストされたケース
+    const newState = { type: 'phrase', content: { id: 'p1', category: 'Cat1' } };
+    await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
+
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.ExpressionAttributeValues[':points']).toBeUndefined();
+    expect(updateCall.UpdateExpression).not.toContain('#points');
+    expect(updateCall.UpdateExpression).not.toContain('REMOVE buzz');
+  });
+
+  it('does award a point and reset the buzz field when a genuinely new phrase follows one that was re-broadcast (issue #519)', async () => {
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
+      Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+    });
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({
+      Item: {
+        roomId: 'ROOM01',
+        state: { type: 'phrase', content: { id: 'p1', category: 'Cat1' } },
+        buzz: { connectionId: 'conn-p', name: 'たろう', buzzedAt: 1000 },
+      },
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const newState = { type: 'phrase', content: { id: 'p2', category: 'Cat1' } };
+    await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
+
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.ExpressionAttributeValues[':points']).toEqual({ たろう: 1 });
+    expect(updateCall.UpdateExpression).toContain('REMOVE buzz');
+  });
+
   it('removes a stale connection record when broadcasting hits a GoneException, without failing the whole update', async () => {
     ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' } });
     ddbMock.on(UpdateCommand).resolves({});
@@ -402,6 +560,8 @@ describe('updateQuizRoomState', () => {
 
 describe('setQuizRoomName', () => {
   it('saves a trimmed name on the connection record', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' } });
+    ddbMock.on(QueryCommand).resolves({ Items: [{ connectionId: 'conn-1', roomId: 'ROOM01' }] });
     ddbMock.on(UpdateCommand).resolves({});
 
     const response = await setQuizRoomName(wsEvent({ connectionId: 'conn-1', body: { name: '  たろう  ' } }));
@@ -413,6 +573,8 @@ describe('setQuizRoomName', () => {
   });
 
   it('truncates names longer than the configured limit', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' } });
+    ddbMock.on(QueryCommand).resolves({ Items: [{ connectionId: 'conn-1', roomId: 'ROOM01' }] });
     ddbMock.on(UpdateCommand).resolves({});
 
     await setQuizRoomName(wsEvent({ body: { name: 'x'.repeat(50) } }));
@@ -428,15 +590,49 @@ describe('setQuizRoomName', () => {
   });
 
   it('silently no-ops when the connection record no longer exists (e.g. already disconnected)', async () => {
-    ddbMock.on(UpdateCommand).rejects(Object.assign(new Error('cond failed'), { name: 'ConditionalCheckFailedException' }));
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
 
     const response = await setQuizRoomName(wsEvent({ body: { name: 'たろう' } }));
 
     expect(response.statusCode).toBe(200);
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+  });
+
+  it('rejects a name already used by another connection in the same room, without saving it (issue #519)', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-2', roomId: 'ROOM01', role: 'participant' } });
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { connectionId: 'conn-1', roomId: 'ROOM01', name: 'たろう' },
+        { connectionId: 'conn-2', roomId: 'ROOM01' },
+      ],
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    const response = await setQuizRoomName(wsEvent({ connectionId: 'conn-2', body: { name: 'たろう' } }));
+
+    expect(response.statusCode).toBe(200);
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+    const postCall = managementApiMock.commandCalls(PostToConnectionCommand)[0].args[0].input;
+    expect(postCall.ConnectionId).toBe('conn-2');
+    const payload = JSON.parse(Buffer.from(postCall.Data).toString('utf-8'));
+    expect(payload.type).toBe('nameError');
+  });
+
+  it('allows re-saving the same name for the same connection (not a duplicate of itself)', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant', name: 'たろう' } });
+    ddbMock.on(QueryCommand).resolves({
+      Items: [{ connectionId: 'conn-1', roomId: 'ROOM01', name: 'たろう' }],
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+
+    const response = await setQuizRoomName(wsEvent({ connectionId: 'conn-1', body: { name: 'たろう' } }));
+
+    expect(response.statusCode).toBe(200);
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(1);
   });
 
   it('handles unexpected errors', async () => {
-    ddbMock.on(UpdateCommand).rejects(new Error('DynamoDB error'));
+    ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
     const response = await setQuizRoomName(wsEvent({ body: { name: 'たろう' } }));
     expect(response.statusCode).toBe(500);
   });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -127,6 +127,9 @@ function App() {
   // QuizRoomView.jsxのbuzzRoundKeyと同じ考え方で、resultの間はリセットしない）
   const [quizRoomBuzzedBy, setQuizRoomBuzzedBy] = useState(null);
   const [quizRoomBuzzRoundKey, setQuizRoomBuzzRoundKey] = useState(null);
+  // ポイント制（issue #519）: 名前→累計ポイントのマップ。管理者には参加者ごとの
+  // ポイントを一覧表示する
+  const [quizRoomPoints, setQuizRoomPoints] = useState({});
 
   // コメント投稿用の状態
   const [commentText, setCommentText] = useState("");
@@ -902,6 +905,7 @@ function App() {
     adminToken: quizRoom?.adminToken,
     onState: noop,
     onBuzz: setQuizRoomBuzzedBy,
+    onPoints: setQuizRoomPoints,
   });
 
   // 表示中の札・結果画面が変わるたびクイズ大会モードの参加者へ状態をブロードキャストする。
@@ -1693,6 +1697,20 @@ function App() {
           <QuizRoomInfoPanel roomId={quizRoom.roomId} />
           {quizRoomBuzzedBy && (
             <p className="fw-bold text-dark">🔔 {quizRoomBuzzedBy.name} さんが回答しました</p>
+          )}
+          {Object.keys(quizRoomPoints).length > 0 && (
+            <div className="mx-auto mt-3 text-start" style={{ maxWidth: "320px" }}>
+              <p className="text-muted small mb-2">参加者ごとのポイント</p>
+              <div className="d-flex flex-wrap gap-2 justify-content-center">
+                {Object.entries(quizRoomPoints)
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([name, point]) => (
+                    <div key={name} className="bg-white rounded-3 shadow-sm px-3 py-2">
+                      <span className="fw-bold notranslate">{name}</span>: {point}pt
+                    </div>
+                  ))}
+              </div>
+            </div>
           )}
         </div>
       ) : (

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2598,6 +2598,62 @@ describe('App', () => {
     expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
   }, 40000);
 
+  it('shows each participant\'s points to the admin as a "points" message arrives, sorted from highest to lowest (issue #519)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      if (url.includes('/get-phrase?')) {
+        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', audioData: 'dummy' }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    const ws = MockWebSocket.instances[0];
+    act(() => {
+      ws.readyState = MockWebSocket.OPEN;
+      ws.onopen?.();
+    });
+
+    act(() => {
+      ws.onmessage?.({ data: JSON.stringify({ type: 'points', points: { はなこ: 1, たろう: 3 } }) });
+    });
+
+    expect(screen.getByText('参加者ごとのポイント')).toBeInTheDocument();
+    const points = screen.getAllByText(/pt$/).map((el) => el.textContent);
+    // たろう(3pt)がはなこ(1pt)より先（降順）に表示される
+    expect(points).toEqual(['たろう: 3pt', 'はなこ: 1pt']);
+  }, 40000);
+
   it('broadcasts the settings actually used to fetch the admin\'s own audio, even if the admin changes the voice while that card is still being read out (issue #498)', async () => {
     localStorage.setItem('repeatCount', '2');
     localStorage.setItem('speechRate', '80%');

--- a/frontend/src/hooks/useQuizRoomSync.js
+++ b/frontend/src/hooks/useQuizRoomSync.js
@@ -12,12 +12,17 @@ const SYNC_POLL_INTERVAL_MS = 5000;
 // 受け取るたびonStateを呼ぶ。管理者はbroadcastStateで新しい状態を送信できる。
 // 早押し機能（issue #510）: サーバーから{type:"buzz", name, connectionId}を受け取るたび
 // onBuzzを呼ぶ。参加者はsetParticipantNameで表示名を、buzzで早押しを送信できる
-export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz }) {
+// ポイント制（issue #519）: サーバーから{type:"points", points}（名前→累計ポイントの
+// マップ）を受け取るたびonPointsを呼ぶ。名前が同一ルーム内で重複していた場合は
+// {type:"nameError", message}が返るのでonNameErrorを呼ぶ
+export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz, onPoints, onNameError }) {
   const [internalStatus, setInternalStatus] = useState("idle"); // connecting|connected|error（idleはwsBaseUrl/roomId未設定時に導出する）
   const connectionStatus = (!wsBaseUrl || !roomId) ? "idle" : internalStatus;
   const wsRef = useRef(null);
   const onStateRef = useRef(onState);
   const onBuzzRef = useRef(onBuzz);
+  const onPointsRef = useRef(onPoints);
+  const onNameErrorRef = useRef(onNameError);
   const reconnectAttemptsRef = useRef(0);
   const reconnectTimeoutRef = useRef(null);
   const closedByCleanupRef = useRef(false);
@@ -37,6 +42,14 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
   useEffect(() => {
     onBuzzRef.current = onBuzz;
   }, [onBuzz]);
+
+  useEffect(() => {
+    onPointsRef.current = onPoints;
+  }, [onPoints]);
+
+  useEffect(() => {
+    onNameErrorRef.current = onNameError;
+  }, [onNameError]);
 
   useEffect(() => {
     if (!wsBaseUrl || !roomId) {
@@ -84,6 +97,10 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
             onStateRef.current?.(data.state, data.role);
           } else if (data?.type === "buzz") {
             onBuzzRef.current?.({ name: data.name, connectionId: data.connectionId });
+          } else if (data?.type === "points") {
+            onPointsRef.current?.(data.points);
+          } else if (data?.type === "nameError") {
+            onNameErrorRef.current?.(data.message);
           }
         } catch (error) {
           console.error("Failed to parse quiz room message:", error);

--- a/frontend/src/hooks/useQuizRoomSync.test.js
+++ b/frontend/src/hooks/useQuizRoomSync.test.js
@@ -129,6 +129,30 @@ describe('useQuizRoomSync', () => {
     expect(onState).not.toHaveBeenCalled();
   });
 
+  it('calls onPoints when a points message is received (issue #519)', () => {
+    const onPoints = vi.fn();
+    renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn(), onPoints }));
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+      MockWebSocket.instances[0].triggerMessage({ type: 'points', points: { たろう: 2, はなこ: 1 } });
+    });
+
+    expect(onPoints).toHaveBeenCalledWith({ たろう: 2, はなこ: 1 });
+  });
+
+  it('calls onNameError when a nameError message is received (issue #519)', () => {
+    const onNameError = vi.fn();
+    renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn(), onNameError }));
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+      MockWebSocket.instances[0].triggerMessage({ type: 'nameError', message: 'その名前は既に使われています。' });
+    });
+
+    expect(onNameError).toHaveBeenCalledWith('その名前は既に使われています。');
+  });
+
   it('setParticipantName sends setName only while the connection is open, and resends it once the socket opens if called earlier', () => {
     const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
 

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -67,14 +67,27 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   // confirmedNameが空の間は名前入力画面を表示し、決定後にのみ通常の参加者画面へ進む
   const [confirmedName, setConfirmedName] = useState("");
   const [nameDraft, setNameDraft] = useState("");
+  const [nameError, setNameError] = useState(null);
   const [buzzedBy, setBuzzedBy] = useState(null);
   const [lastBuzzRoundKey, setLastBuzzRoundKey] = useState(null);
+  // ポイント制（issue #519）: 名前→累計ポイントのマップ。集計単位はconnectionIdではなく
+  // name（早押し機能の実装参照）なので、自分のポイントはpoints[confirmedName]で引く
+  const [points, setPoints] = useState({});
+
+  // ポイント制（issue #519）: サーバーは同一ルーム内での名前重複を拒否する。拒否された
+  // 場合は名前入力画面に戻し、別の名前を選び直してもらう
+  const handleNameError = (message) => {
+    setNameError(message);
+    setConfirmedName("");
+  };
 
   const { connectionStatus, setParticipantName, buzz } = useQuizRoomSync({
     wsBaseUrl,
     roomId: joinRoomId,
     onState: setRoomState,
     onBuzz: setBuzzedBy,
+    onPoints: setPoints,
+    onNameError: handleNameError,
   });
 
   // 早押し結果表示のリセット判定（issue #510）。ラウンドを表す値（buzzRoundKey）を
@@ -101,6 +114,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     if (!trimmed) {
       return;
     }
+    setNameError(null);
     setConfirmedName(trimmed);
     setParticipantName(trimmed);
   };
@@ -186,6 +200,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
         </header>
         <main className="mx-auto text-center" style={{ maxWidth: "360px" }}>
           <p className="text-muted small mb-2">早押し対決で使うお名前を入力してください</p>
+          {nameError && <p className="text-danger small mb-2">{nameError}</p>}
           <div className="d-flex gap-2 justify-content-center">
             <input
               type="text"
@@ -220,6 +235,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
           <p className="text-muted small">ルーム: {joinRoomId}</p>
         </header>
         <p className="text-muted small mb-3">接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}</p>
+        <p className="fw-bold text-dark">獲得ポイント: {points[confirmedName] || 0}</p>
         {renderParticipantContent(roomState)}
         {buzzedBy ? (
           <p className="fw-bold text-dark mt-4">🔔 {buzzedBy.name} さんが回答しました</p>

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -5,14 +5,18 @@ import { resetSharedAudioForTests } from '../utils/audioUnlock';
 
 const onStateCallbacks = [];
 const onBuzzCallbacks = [];
+const onPointsCallbacks = [];
+const onNameErrorCallbacks = [];
 let mockConnectionStatus = 'connected';
 const setParticipantNameMock = vi.fn();
 const buzzMock = vi.fn();
 
 vi.mock('../hooks/useQuizRoomSync', () => ({
-  useQuizRoomSync: ({ onState, onBuzz }) => {
+  useQuizRoomSync: ({ onState, onBuzz, onPoints, onNameError }) => {
     onStateCallbacks.push(onState);
     onBuzzCallbacks.push(onBuzz);
+    onPointsCallbacks.push(onPoints);
+    onNameErrorCallbacks.push(onNameError);
     return {
       connectionStatus: mockConnectionStatus,
       broadcastState: vi.fn(),
@@ -33,6 +37,18 @@ function emitState(state) {
 function emitBuzz(buzz) {
   act(() => {
     onBuzzCallbacks[onBuzzCallbacks.length - 1]?.(buzz);
+  });
+}
+
+function emitPoints(points) {
+  act(() => {
+    onPointsCallbacks[onPointsCallbacks.length - 1]?.(points);
+  });
+}
+
+function emitNameError(message) {
+  act(() => {
+    onNameErrorCallbacks[onNameErrorCallbacks.length - 1]?.(message);
   });
 }
 
@@ -59,6 +75,8 @@ window.Audio = vi.fn().mockImplementation(function (src) {
 beforeEach(() => {
   onStateCallbacks.length = 0;
   onBuzzCallbacks.length = 0;
+  onPointsCallbacks.length = 0;
+  onNameErrorCallbacks.length = 0;
   mockConnectionStatus = 'connected';
   setParticipantNameMock.mockClear();
   buzzMock.mockClear();
@@ -182,6 +200,30 @@ describe('QuizRoomView', () => {
     emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
     expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
     expect(screen.queryByText('回答する')).not.toBeInTheDocument();
+  });
+
+  it('shows the participant their own accumulated points as "points" messages arrive, keyed by their confirmed name (issue #519)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName('はなこ');
+
+    expect(screen.getByText('獲得ポイント: 0')).toBeInTheDocument();
+
+    emitPoints({ はなこ: 2, たろう: 5 });
+    expect(screen.getByText('獲得ポイント: 2')).toBeInTheDocument();
+  });
+
+  it('sends the participant back to the name entry screen with an error when the server rejects a duplicate name (issue #519)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName('はなこ');
+    expect(screen.getByText('クイズ大会モード（参加者）')).toBeInTheDocument();
+    expect(screen.getByText('ルーム: ABC123')).toBeInTheDocument();
+
+    emitNameError('その名前は既に使われています。別の名前を入力してください。');
+
+    expect(screen.getByText('その名前は既に使われています。別の名前を入力してください。')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('お名前')).toBeInTheDocument();
   });
 
   it('keeps showing the responder during the result screen, but resets it once a new (different) phrase is broadcast', () => {


### PR DESCRIPTION
## 概要

issue #519 対応。早押し機能（issue #510）の延長として、ポイント制を追加する。

## 対応内容

- 参加者が早押し回答し、次の札に進んだ時点でその人に1ポイント加点する（ゲームのリセット等で"initial"へ戻す場合はお手つきの可能性があるため加点しない）
- ポイントは参加者名をキーにルームの状態（`points`）へ累積保存し、加点のたびにルーム内の全接続へ`{type:"points", points}`をブロードキャスト。再接続・遅れて参加した端末にもsync時に現在の集計を送る
- 読み上げ設定の変更等で同じ札が再ブロードキャストされるケースを新しいラウンドの開始と誤認しないよう、直前の状態と札のidを比較し、ラウンドが実際に進んだ場合のみ加点・早押しリセットを行う
- ポイント集計は参加者名がキーになるため、同一ルーム内での名前の重複登録を`setQuizRoomName`で禁止し、拒否時は参加者を名前入力画面へ戻す
- フロントエンド: 参加者には常時自分の獲得ポイントを表示、管理者には参加者ごとのポイントを降順で一覧表示

## Test plan

- [x] `backend`: `npm run lint` エラー0件
- [x] `backend`: `npm test -- --run` 1484/1484件成功
- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 144/144件成功
- [x] ポイント加点・累積、同一ラウンド再ブロードキャスト時の非加点を検証するテストを追加
- [x] 名前重複拒否、ポイントの再送・表示を検証するテストを追加

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_