### PR TITLE
fix(pwa): 絵札PDF印刷画面を開いている間はオフライン利用可能メッセージを抑制する

### DIFF
--- a/frontend/src/PwaUpdatePrompt.jsx
+++ b/frontend/src/PwaUpdatePrompt.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useRegisterSW } from "virtual:pwa-register/react";
-import { usePdfExportInProgress } from "./pdfExportStatus";
+import { useIsPrintScreenActive } from "./pdfExportStatus";
 import "./PwaUpdatePrompt.css";
 
 // オフライン利用可能通知は操作を要求しない情報表示のため、この時間が経てば自動的に消す。
@@ -20,9 +20,10 @@ function PwaUpdatePrompt() {
   const offlineReady = sw?.offlineReady?.[0] || false;
   const setOfflineReady = sw?.offlineReady?.[1] || noop;
   const updateServiceWorker = sw?.updateServiceWorker || noop;
-  // PDF出力（generate-efuda-pdf）はバックエンドAPIへの通信が必須でオフラインでは
-  // 動作しないため、生成中に「オフラインで利用可能になりました」を出すと誤解を招く（issue #473）
-  const isPdfExportInProgress = usePdfExportInProgress();
+  // 絵札PDF印刷画面（PrintEfudaView）はバックエンドAPIへの通信が必須でオフラインでは
+  // 動作しないため、この画面を開いている間に「オフラインで利用可能になりました」を
+  // 出すと誤解を招く（issue #473）
+  const isPrintScreenActive = useIsPrintScreenActive();
 
   const close = () => {
     setOfflineReady(false);
@@ -59,7 +60,7 @@ function PwaUpdatePrompt() {
     );
   }
 
-  if (offlineReady && !isPdfExportInProgress) {
+  if (offlineReady && !isPrintScreenActive) {
     return (
       <div className="pwa-update-prompt" role="alert">
         <span>オフラインで利用可能になりました</span>

--- a/frontend/src/PwaUpdatePrompt.test.jsx
+++ b/frontend/src/PwaUpdatePrompt.test.jsx
@@ -8,7 +8,7 @@ vi.mock("virtual:pwa-register/react", () => ({
 }));
 
 import PwaUpdatePrompt from "./PwaUpdatePrompt.jsx";
-import { setPdfExportInProgress } from "./pdfExportStatus";
+import { setPrintScreenActive } from "./pdfExportStatus";
 
 describe("PwaUpdatePrompt", () => {
   beforeEach(() => {
@@ -18,7 +18,7 @@ describe("PwaUpdatePrompt", () => {
   afterEach(() => {
     vi.useRealTimers();
     // pdfExportStatusはモジュール単位で状態を共有するため、他テストへ漏れないよう戻す
-    setPdfExportInProgress(false);
+    setPrintScreenActive(false);
   });
 
   it("更新が不要な場合は何も表示しない", () => {
@@ -108,8 +108,8 @@ describe("PwaUpdatePrompt", () => {
     vi.useRealTimers();
   });
 
-  it("PDF生成中はオフライン利用可能でもメッセージを表示しない（issue #473）", () => {
-    setPdfExportInProgress(true);
+  it("絵札PDF印刷画面を開いている間はオフライン利用可能でもメッセージを表示しない（issue #473）", () => {
+    setPrintScreenActive(true);
     useRegisterSWMock.mockReturnValue({
       needRefresh: [false, vi.fn()],
       offlineReady: [true, vi.fn()],
@@ -122,8 +122,8 @@ describe("PwaUpdatePrompt", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("PDF生成が終わればオフライン利用可能メッセージが表示される（issue #473）", () => {
-    setPdfExportInProgress(false);
+  it("絵札PDF印刷画面を開いていなければオフライン利用可能メッセージが表示される（issue #473）", () => {
+    setPrintScreenActive(false);
     useRegisterSWMock.mockReturnValue({
       needRefresh: [false, vi.fn()],
       offlineReady: [true, vi.fn()],

--- a/frontend/src/pdfExportStatus.js
+++ b/frontend/src/pdfExportStatus.js
@@ -1,22 +1,29 @@
 import { useSyncExternalStore } from "react";
 
-// PrintEfudaView（PDF出力の実行元）とPwaUpdatePrompt（main.jsxでAppの兄弟として
-// グローバルにマウントされており、propsで直接つなげない）との間で、
-// 「PDF生成中かどうか」だけを共有するための最小限のstore（issue #473）
-let isExporting = false;
+// PwaUpdatePrompt（main.jsxでAppの兄弟としてグローバルにマウントされておりpropsで
+// 直接つなげない）に、「絵札PDF印刷画面を開いている間かどうか」を伝えるための
+// 最小限のstore（issue #473）。絵札PDFのサーバーサイド生成はバックエンドAPIへの
+// 通信が必須でオフラインでは動作しないため、この画面を開いている間に「オフラインで
+// 利用可能になりました」という表示が出ると誤解を招く。
+// 当初はPDF生成中（fetch/ポーリング中）だけに絞って抑制していたが、それだと
+// 画面を開いた直後や生成完了直後にオフライン通知が出るタイミングまでは
+// 抑制できず、実際には解消していなかった（issue #473の再オープン）。
+// この画面を開いている間ずっと抑制する方が、実際に再現するタイミングをより広く
+// カバーできる
+let isPrintScreenActive = false;
 const listeners = new Set();
 
-export function setPdfExportInProgress(value) {
-  isExporting = value;
+export function setPrintScreenActive(value) {
+  isPrintScreenActive = value;
   listeners.forEach((listener) => listener());
 }
 
-export function usePdfExportInProgress() {
+export function useIsPrintScreenActive() {
   return useSyncExternalStore(
     (listener) => {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
-    () => isExporting
+    () => isPrintScreenActive
   );
 }

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -1,7 +1,7 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { API_BASE_URL } from "../config";
 import { serializeCategoriesParam } from "../hooks/useUrlQuerySync";
-import { setPdfExportInProgress, usePdfExportInProgress } from "../pdfExportStatus";
+import { setPrintScreenActive } from "../pdfExportStatus";
 
 const getEfudaText = (p) => (p.answer && p.answer !== "-") ? p.answer : p.phrase;
 
@@ -60,7 +60,14 @@ const resolvePhraseIndex = (slotIndex, printSide) => {
 };
 
 function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrasesForCategory, efudaPages, efudaPerPage }) {
-  const isGeneratingPdf = usePdfExportInProgress();
+  const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
+
+  // この画面を開いている間、PwaUpdatePromptの「オフラインで利用可能になりました」
+  // 表示を抑制する（issue #473）
+  useEffect(() => {
+    setPrintScreenActive(true);
+    return () => setPrintScreenActive(false);
+  }, []);
   // 表面（読み札の内容）と裏面（種別・レベル）は用紙を裏返して2回に分けて印刷する運用を想定し、
   // 同じページ構成をどちらの内容で描画するかだけをこのstateで切り替える。
   // バックエンドのrenderEfudaPdfWorkerがヘッドレスブラウザでこの画面をディープリンク
@@ -78,7 +85,7 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
   );
 
   const downloadPdf = async () => {
-    setPdfExportInProgress(true);
+    setIsGeneratingPdf(true);
     try {
       const categoryParam = serializeCategoriesParam(selectedCategories);
       const startResponse = await fetch(`${API_BASE_URL}/generate-efuda-pdf`, {
@@ -121,7 +128,7 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
       console.error("Error generating PDF:", error);
       alert("PDFの生成に失敗しました。");
     } finally {
-      setPdfExportInProgress(false);
+      setIsGeneratingPdf(false);
     }
   };
 

--- a/frontend/src/views/PrintEfudaView.test.jsx
+++ b/frontend/src/views/PrintEfudaView.test.jsx
@@ -1,0 +1,42 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import PrintEfudaView from "./PrintEfudaView";
+import { useIsPrintScreenActive, setPrintScreenActive } from "../pdfExportStatus";
+
+// pdfExportStatusの現在値を画面に出すだけの補助コンポーネント（issue #473）。
+// PwaUpdatePromptはmain.jsxでAppの兄弟としてマウントされておりPrintEfudaViewの
+// props経由では確認できないため、共有storeの値を直接検証する
+function IsPrintScreenActiveProbe() {
+  const isActive = useIsPrintScreenActive();
+  return <span data-testid="probe">{isActive ? "active" : "inactive"}</span>;
+}
+
+afterEach(() => {
+  // モジュール単位で状態を共有するため、他テストへ漏れないよう戻す
+  setPrintScreenActive(false);
+});
+
+describe("PrintEfudaView", () => {
+  it("marks the print screen as active while mounted, and inactive again once unmounted (issue #473)", () => {
+    const { getByTestId, unmount } = render(
+      <>
+        <PrintEfudaView
+          categoryLabel="テスト"
+          setView={() => {}}
+          selectedCategories={[]}
+          allPhrasesForCategory={[]}
+          efudaPages={[]}
+          efudaPerPage={10}
+        />
+        <IsPrintScreenActiveProbe />
+      </>
+    );
+
+    expect(getByTestId("probe").textContent).toBe("active");
+
+    unmount();
+
+    const { getByTestId: getByTestIdAfter } = render(<IsPrintScreenActiveProbe />);
+    expect(getByTestIdAfter("probe").textContent).toBe("inactive");
+  });
+});


### PR DESCRIPTION
## 概要

issue #473 再対応。当初の修正（PR #524、マージ済み）はPDF生成中（fetch/ポーリング中）だけに絞ってオフライン利用可能メッセージを抑制していたが、ユーザーが再現確認したところ解消していなかった（issueが再オープンされた）。

## 原因

「オフラインで利用可能になりました」はService Workerの初回キャッシュ完了時に一度だけ表示されるものだが、そのタイミングはPDF生成中（fetch/ポーリング中）のごく短い区間に限らず、画面を開いた直後や生成完了直後など様々でありうる。当初の修正はこの区間だけを対象にしていたため、実際に再現するタイミングをカバーできていなかった。

## 対応内容

- `frontend/src/pdfExportStatus.js`の共有storeの意味を「PDF生成中かどうか」から「絵札PDF印刷画面（PrintEfudaView）を開いている間かどうか」に変更
- `PrintEfudaView.jsx`のマウント〜アンマウントの間ずっと、`PwaUpdatePrompt`のオフライン利用可能メッセージを抑制するようにした
- ボタンの「PDF生成中...」表示・disabled状態は画面滞在中フラグとは別の関心事のため、ローカルstateに戻した

## Test plan

- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 145/145件成功
- [x] `backend`: `npm run lint` / `npm test -- --run` 1484/1484件成功（無関係のため変化なし）
- [x] 画面を開いている間はメッセージを表示しないこと、閉じていれば表示されることを検証するテストを更新
- [x] PrintEfudaViewのマウント/アンマウントでフラグが切り替わることを検証する新規テストを追加

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_