### PR TITLE
chore(ci): standards-checkジョブを有効化し、CI構成をドキュメント化する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,6 @@ jobs:
       frontend_dir: frontend
       backend_dir: backend
       enable_e2e_test: true
+      enable_standards_check: true
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-# dev-standards/.gitignore の共通部分をコピーしたもの。
-# .gitignore はGitHub側の制約でシンボリックリンクにできないため、
-# dev-standards/.gitignore を更新した場合は手動で同期すること。
-# プロジェクト固有のignoreエントリは backend/.gitignore 等に追加する。
-
 # Node dependencies
 node_modules/
 npm-debug.log*
@@ -29,7 +24,6 @@ Thumbs.db
 # Environment variables
 .env
 .env.*
-!.env.example
 
 # commit skill が下書きに使う一時ファイル
 commit_msg*.txt

--- a/docs/cicd-pipeline-specification.md
+++ b/docs/cicd-pipeline-specification.md
@@ -28,6 +28,22 @@ karutaの`main`は「変更は必ずPR経由」のリポジトリルールで保
 
 このリポジトリにはE2E専用のモックバックエンドが存在しないため、**E2Eテストは実際にデプロイ済みの本番相当AWS環境（`frontend/src/config.js`のAPI_BASE_URL/WS_BASE_URLが指すAPI Gateway・DynamoDB・WebSocket API）に対して実行する**。CI実行のたびに実際のクイズ大会モードのルームが作成されるが、ルームはDynamoDBのTTLにより24時間で自動失効するため、テスト実行のたびに残骸が蓄積し続けることはない。
 
+## 有効化・無効化しているジョブ（`ci.yml` 固有、issue #461）
+
+`reusable-ci.yml`が提供する任意ジョブのうち、karutaでは以下のように設定している。
+
+| ジョブ | 設定 | 理由 |
+|---|---|---|
+| `frontend-e2e-test` | `enable_e2e_test: true`（有効） | 上記「E2Eテスト」節を参照 |
+| `standards-check` | `enable_standards_check: true`（有効） | dev-standardsサブモジュールの`sync-manifest.json`に基づき、symlinkの欠落・リンク切れ・`.gitignore`等コピー対象ファイルの内容乾離を検知する。`node dev-standards/scripts/bootstrap.js --check`を実行する |
+| `package-test` | 未指定（無効、デフォルトのまま） | `inputs.packages`（frontend/backend以外の小さなパッケージをmatrix展開する仕組み）向けで、karutaは`frontend_dir`/`backend_dir`による固定2パッケージ構成のため対象がなく不要。パッケージ構成が増えた場合に改めて検討する |
+
+### `.gitignore`の同期について
+
+ルートの`.gitignore`は`standards-check`の`copies`対象（dev-standards側と内容が完全一致している必要がある）。GitHubの制約上symlinkにできないため、dev-standards側の`.gitignore`が更新された場合はこのファイルを手動で同期する必要がある。
+
+**プロジェクト固有のignoreルールはルートの`.gitignore`に追加せず、`frontend/.gitignore`・`backend/.gitignore`等、対象ディレクトリのgitignoreに追加すること**（gitのネストされた`.gitignore`は親ディレクトリのルールより優先されるため、`!`による打ち消しも問題なく機能する）。ルートに直接追記すると`standards-check`が内容乾離として検知し、CIが失敗する（issue #461で実際に`!.env.example`がルートに直接追記されており、これが原因でCIが失敗する状態になっていたため、`frontend/.gitignore`側へ移設した）。
+
 ## デプロイジョブ（`cd.yml` 固有）
 
 `release` ジョブ（共通、dev-standards の `reusable-cd.yml`）の成功後、`needs.release.outputs.new_release_published == 'true'` の場合のみ以下を実行する。

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -28,3 +28,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# ルートの.gitignore（dev-standardsとの同期対象、issue #461）で.env.*を
+# ignoreしているが、.env.exampleは実際の値を含まないテンプレートのため
+# 追跡対象にする
+!.env.example


### PR DESCRIPTION
## 概要

issue #461 対応。CI内の未使用ジョブ（standards-check・package-test）について、内容確認・設計妥当性確認を行い、必要な対応とドキュメント更新を行う。

## 調査結果と対応内容

- **standards-check**: 有効化する方針を確認いただいた上で有効化を試みたところ、`node dev-standards/scripts/bootstrap.js --check`の実行により、ルートの`.gitignore`が既にdev-standards側とドリフトしていることが判明した（説明コメントと`!.env.example`がコピー対象であるルートの`.gitignore`へ直接追記されており、そのまま有効化するとCIが即座に失敗する状態だった）
  - ルートの`.gitignore`をdev-standards側と完全一致するよう復元
  - `!.env.example`は本来対象とすべき`frontend/.gitignore`側へ移設（gitのネストされた`.gitignore`は親ディレクトリのルールより優先されるため、打ち消しは問題なく機能することを確認済み）
  - `.github/workflows/ci.yml`に`enable_standards_check: true`を追加
- **package-test**: 現状の2パッケージ（frontend/backend）固定構成では対象がなく不要と判断し、現状維持
- `docs/cicd-pipeline-specification.md`に、有効化/無効化しているジョブの一覧と理由、`.gitignore`同期時の注意点（プロジェクト固有ルールはルートではなく各パッケージのgitignoreに追加する）を追記

## Test plan

- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 145/145件成功
- [x] `backend`: `npm run lint` / `npm test -- --run` 1484/1484件成功
- [x] `node dev-standards/scripts/bootstrap.js --check` がローカルで18/18件OKになることを確認
- [x] `frontend/.env.example`の追跡状態（`git check-ignore`で非ignore）に変化がないことを確認
- [ ] 実際のCI上で`standards-check`ジョブが成功することを本PRで確認する

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_