### PR TITLE
fix(quiz-room): トップページに戻るたび開設中ルーム一覧を再取得する

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -351,9 +351,12 @@ function App() {
   }, []);
 
   // クイズ大会モード（issue #489）: トップページ下部に開設中のルーム一覧を表示するため、
-  // WebSocket未設定（機能自体が準備中）の場合は取得を試みない
+  // WebSocket未設定（機能自体が準備中）の場合は取得を試みない。
+  // 一覧は初回マウント時だけでなく、他画面から戻る等でトップページへ再度遷移した
+  // たびに再取得する（issue #531: 一度取得したきり更新されず古くなる不具合の対応）
+  const isOnTopPage = view === "game" && selectedCategories.length === 0;
   useEffect(() => {
-    if (!WS_BASE_URL) {
+    if (!WS_BASE_URL || !isOnTopPage) {
       return;
     }
     const fetchOpenQuizRooms = async () => {
@@ -368,7 +371,7 @@ function App() {
       }
     };
     fetchOpenQuizRooms();
-  }, []);
+  }, [isOnTopPage]);
 
   // カテゴリが選択されたら、選択中の全カテゴリの札IDリストを取得して結合する
   useEffect(() => {

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2813,4 +2813,50 @@ describe('App', () => {
     await screen.findByText('かるた読み上げアプリ');
     expect(screen.queryByText('開設中のクイズ大会ルーム')).not.toBeInTheDocument();
   });
+
+  it('re-fetches the open quiz room list every time the top page is shown again, not just on first mount (issue #531)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        MockWebSocket.instances.push(this);
+      }
+      send() {}
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    let quizRoomsCallCount = 0;
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('/quiz-rooms')) {
+        quizRoomsCallCount += 1;
+        const rooms = quizRoomsCallCount === 1
+          ? [{ roomId: 'ABC123', createdAt: 1, category: null }]
+          : [{ roomId: 'ABC123', createdAt: 1, category: null }, { roomId: 'NEW999', createdAt: 2, category: null }];
+        return { ok: true, json: async () => ({ rooms }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [] }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    await screen.findByText('ABC123');
+    expect(quizRoomsCallCount).toBe(1);
+    expect(screen.queryByText('NEW999')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('ABC123'));
+    await screen.findByText('クイズ大会モード（参加者）');
+    fireEvent.change(screen.getByPlaceholderText('お名前'), { target: { value: 'たろう' } });
+    fireEvent.click(screen.getByText('決定'));
+
+    fireEvent.click(screen.getByText('← 戻る'));
+
+    await waitFor(() => expect(quizRoomsCallCount).toBe(2));
+    expect(await screen.findByText('NEW999')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要

issue #531 対応。トップページ下部に表示している開設中のクイズ大会ルーム一覧が、一度表示された後は更新されない不具合を修正する。

## 対応内容

- `frontend/src/App.jsx`の一覧取得effectは依存配列`[]`のため初回マウント時にしか実行されず、クイズ大会画面等から「戻る」で再度トップページに戻っても一覧が更新されなかった
- `view === "game" && selectedCategories.length === 0`（トップページ表示中）を`isOnTopPage`として算出し、これが真になるたび（初回マウント時を含む）再取得するようeffectの依存配列を変更した
- ポーリングではなく、トップページへの遷移時のみ再取得するシンプルな方式とした

## Test plan

- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 146/146件成功
- [x] `backend`: `npm run lint` / `npm test -- --run` 1484/1484件成功（無関係のため変化なし）
- [x] 一覧から参加して「戻る」で再度トップページに戻ると、一覧が再取得され新しく開設されたルームが反映されることを検証するテストを追加

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_