### PR TITLE
fix(quiz-room): 名前入力画面の間は参加者に読み上げ音声を再生しない

### DIFF
--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -163,6 +163,14 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     }
     lastPlayedKeyRef.current = key;
 
+    // 名前入力画面（confirmedName未確定）の間は再生しない（issue #530）。
+    // 上のlastPlayedKeyRef更新は先に行っているため、名前確定後にこの同じ
+    // ラウンドが再度この画面に届いても、遡って再生されることはない
+    // （要望どおり「入室後、次の札へ切り替わったタイミング」からの再生になる）
+    if (!confirmedName) {
+      return;
+    }
+
     let cancelled = false;
     (async () => {
       try {
@@ -181,7 +189,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     return () => {
       cancelled = true;
     };
-  }, [roomState]);
+  }, [roomState, confirmedName]);
 
   if (!wsBaseUrl) {
     return (

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -284,6 +284,7 @@ describe('QuizRoomView', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
 
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
 
     emitState({
       type: 'phrase',
@@ -316,6 +317,7 @@ describe('QuizRoomView', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
 
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
 
     emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '3' } });
 
@@ -340,6 +342,7 @@ describe('QuizRoomView', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
 
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
 
     emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
     await act(async () => {
@@ -362,6 +365,49 @@ describe('QuizRoomView', () => {
     expect(audioInstances[0].src).toBe('data:audio/mp3;base64,DUMMY2');
   });
 
+  it('does not play audio for a phrase that was already in progress when joining, while still on the name entry screen, and does not play it retroactively once the name is confirmed (issue #530)', async () => {
+    fetch.mockResolvedValue({ ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }) });
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    // まだ名前を確定していない（名前入力画面のまま）
+    expect(screen.getByPlaceholderText('お名前')).toBeInTheDocument();
+
+    // 入室時点で既にホストが札を読み上げ中だったケース
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(fetch).not.toHaveBeenCalled();
+    expect(audioInstances).toHaveLength(0);
+
+    // 名前を確定しても、確定前から進行中だった同じラウンドの音声が遡って
+    // 再生されることはない（「次の札」からの再生という要望どおりの挙動）。
+    // 「決定」ボタンのクリック自体が共有<audio>要素の解錠（issue #497/#514）を
+    // 引き起こすため、audioInstancesは1件になるが、フレーズの取得（fetch）は
+    // 行われておらず、再生される音声も無音の解錠用データのままであることを確認する
+    confirmName();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(fetch).not.toHaveBeenCalled();
+    expect(audioInstances).toHaveLength(1);
+    expect(audioInstances[0].src).toBe('data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=');
+
+    // 名前確定後に届いた次の札からは通常どおり再生される（同じ共有要素のsrcが
+    // 差し替わる。issue #514）
+    emitState({ type: 'phrase', content: { id: 'p2', category: 'Cat1', phrase: '読み札2', level: '3' } });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(audioInstances).toHaveLength(1);
+    expect(audioInstances[0].src).toBe('data:audio/mp3;base64,DUMMY');
+  });
+
   it('does not show any manual "turn audio on" button, since audio playback is always on by default (issue #497)', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
 
@@ -377,6 +423,7 @@ describe('QuizRoomView', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
 
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
 
     emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
 


### PR DESCRIPTION
## 概要

issue #530 対応。クイズ大会モードに参加者として入室する際、名前入力画面（お名前を入力して「決定」を押す前の画面）の時点で読み上げ音声が再生されてしまう不具合を修正する。

## 対応内容

- `QuizRoomView.jsx`の音声再生effectは`roomState.type === "phrase"`のみを条件にしており、名前入力画面（`confirmedName`未確定）の段階でも、入室時点で既にホストが読み上げ中だった場合はsync応答で即座に音声が再生されてしまっていた
- 音声再生の直前に`confirmedName`の有無を確認し、未確定なら再生しないようにした
- 同一ラウンドの再生済み判定（`lastPlayedKeyRef`）は`confirmedName`のチェックより先に更新するため、名前確定後に同じラウンドの状態が再評価されても遡って再生されることはない（要望どおり「入室後、次の札へ切り替わったタイミング」からの再生になる）

## Test plan

- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 147/147件成功
- [x] `backend`: `npm run lint` / `npm test -- --run` 1484/1484件成功（無関係のため変化なし）
- [x] 名前確定前は再生されないこと、確定後も同じラウンドを遡って再生しないこと、次のラウンドからは通常どおり再生されることを検証する新規テストを追加
- [x] 既存の音声再生テスト3件を、名前確定前提の呼び出し順序に合わせて更新

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_