### PR TITLE
fix(quiz-room): 「戻る」で離脱時にURLの?roomId=を除去する

### DIFF
--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -81,6 +81,19 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     setConfirmedName("");
   };
 
+  // 通常のゲーム画面へ戻る（issue #532）。URLに残った?roomId=をそのままにすると、
+  // 次にトップページの汎用的な「クイズ大会に参加する」リンクを押した際、
+  // QuizRoomViewが再マウント時にこの残留したroomIdを読み取ってしまい、
+  // ルームコード入力画面ではなく以前のルームへ入室しようとする画面になってしまう。
+  // そのため離脱時に明示的にクエリから取り除く（他のクエリパラメータは保持する）
+  const goBack = () => {
+    const params = new URLSearchParams(window.location.search);
+    params.delete("roomId");
+    const query = params.toString();
+    window.history.pushState({}, "", query ? `?${query}` : window.location.pathname);
+    setView("game");
+  };
+
   const { connectionStatus, setParticipantName, buzz } = useQuizRoomSync({
     wsBaseUrl,
     roomId: joinRoomId,
@@ -195,7 +208,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     return (
       <div className="container py-5 mx-auto text-center">
         <p className="text-muted mb-4">クイズ大会モードは現在準備中です。しばらくお待ちください。</p>
-        <button onClick={() => setView("game")} className="btn btn-outline-dark rounded-pill">← 戻る</button>
+        <button onClick={goBack} className="btn btn-outline-dark rounded-pill">← 戻る</button>
       </div>
     );
   }
@@ -228,7 +241,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
             </button>
           </div>
           <div className="text-center mt-5">
-            <button onClick={() => setView("game")} className="btn btn-link text-muted text-decoration-none">← 戻る</button>
+            <button onClick={goBack} className="btn btn-link text-muted text-decoration-none">← 戻る</button>
           </div>
         </main>
       </div>
@@ -255,7 +268,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
           </div>
         )}
         <div className="mt-5">
-          <button onClick={() => setView("game")} className="btn btn-link text-muted text-decoration-none">← 戻る</button>
+          <button onClick={goBack} className="btn btn-link text-muted text-decoration-none">← 戻る</button>
         </div>
       </div>
     );
@@ -286,7 +299,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
           </button>
         </div>
         <div className="text-center mt-5">
-          <button onClick={() => setView("game")} className="btn btn-link text-muted text-decoration-none">← 戻る</button>
+          <button onClick={goBack} className="btn btn-link text-muted text-decoration-none">← 戻る</button>
         </div>
       </main>
     </div>

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -168,6 +168,36 @@ describe('QuizRoomView', () => {
     expect(setView).toHaveBeenCalledWith('game');
   });
 
+  it('removes the roomId query param when leaving via "戻る", so a later generic join attempt shows the room-code entry screen instead of re-entering the previous room (issue #532)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    const { unmount } = render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    // 名前入力画面（joinRoomIdが設定されている状態）から「戻る」で離脱する
+    fireEvent.click(screen.getByText('← 戻る'));
+
+    expect(new URLSearchParams(window.location.search).has('roomId')).toBe(false);
+
+    // アプリ内遷移を模して再マウントする（App.jsxの「クイズ大会に参加する」リンクは
+    // roomIdを指定せずQuizRoomViewを再マウントする）。残留roomIdが無いため、
+    // 以前のルームへ直接入室する画面ではなくルームコード入力画面が表示されるべき
+    unmount();
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+
+    expect(screen.getByText('クイズ大会に参加する')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('ルームコード')).toBeInTheDocument();
+  });
+
+  it('preserves other query params when removing roomId on leaving via "戻る"', () => {
+    window.history.pushState({}, '', '?roomId=ABC123&foo=bar');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    fireEvent.click(screen.getByText('← 戻る'));
+
+    const params = new URLSearchParams(window.location.search);
+    expect(params.has('roomId')).toBe(false);
+    expect(params.get('foo')).toBe('bar');
+  });
+
   it('shows a name entry screen before the participant screen, and does not let the participant confirm an empty name (issue #510)', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
 


### PR DESCRIPTION
## 概要

issue #532 対応。トップページの「クイズ大会に参加する」リンク（ルームコード手動入力用）を押すと、ルームコード入力画面ではなく以前参加したルームへそのまま入室しようとする不具合を修正する。

## 原因

開設中ルーム一覧からの参加（`joinQuizRoom`）はURLへ`?roomId=...`を追加してから`QuizRoomView`へ遷移するが、`QuizRoomView`側の「戻る」ボタンは`setView("game")`を呼ぶのみでこのクエリを除去していなかった。そのため一度ルームへ参加して「戻る」で抜けると`?roomId=`がURLに残り続け、次にトップページの汎用的な「クイズ大会に参加する」リンク（`roomId`を指定せず`QuizRoomView`を再マウントするだけ）を押した際、この残留した`roomId`を読み取ってしまい、ルームコード入力画面ではなく以前のルームへ入室しようとする画面になっていた。

## 対応内容

- 4箇所ある「戻る」ボタンすべてに共通の`goBack`ハンドラを用意し、`setView`の前にURLから`roomId`のみを削除して`history.pushState`し直すようにした（他のクエリパラメータは保持する）
- 招待URL（`?roomId=...`付きでの直接アクセス）は初回マウント時に`joinRoomId`へ取り込み済みのため、離脱時にクエリを消してもその回の参加自体には影響しない

## Test plan

- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 149/149件成功
- [x] `backend`: `npm run lint` / `npm test -- --run` 1484/1484件成功（無関係のため変化なし）
- [x] 「戻る」で`roomId`クエリが除去されることを検証するテストを追加
- [x] 除去後に再マウントするとルームコード入力画面が表示されることを検証するテストを追加
- [x] 他のクエリパラメータは保持されることを検証するテストを追加

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_