### PR TITLE
fix(app): fetchOpenQuizRoomsでresponse.okを確認してからjsonを読む

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -362,10 +362,11 @@ function App() {
     const fetchOpenQuizRooms = async () => {
       try {
         const response = await fetch(`${API_BASE_URL}/quiz-rooms`);
-        const data = await response.json();
-        if (response.ok) {
-          setOpenQuizRooms(data.rooms || []);
+        if (!response.ok) {
+          return;
         }
+        const data = await response.json();
+        setOpenQuizRooms(data.rooms || []);
       } catch (error) {
         console.error("Failed to fetch open quiz rooms:", error);
       }

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2814,6 +2814,28 @@ describe('App', () => {
     expect(screen.queryByText('開設中のクイズ大会ルーム')).not.toBeInTheDocument();
   });
 
+  it('does not log an error when the quiz-rooms endpoint responds with a non-JSON-bearing failure (e.g. no response body at all)', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetch.mockImplementation(async (url) => {
+      // レスポンスがok:falseのみで、jsonメソッドを持たないケース（例えば502等で
+      // ボディがJSONではない場合）を模す。response.okを確認する前にresponse.json()を
+      // 呼んでいると、ここで"response.json is not a function"が投げられてしまう
+      if (url.includes('/quiz-rooms')) return { ok: false };
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [] }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    await screen.findByText('かるた読み上げアプリ');
+    const quizRoomsErrors = consoleErrorSpy.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && call[0].includes('Failed to fetch open quiz rooms')
+    );
+    expect(quizRoomsErrors).toHaveLength(0);
+  });
+
   it('re-fetches the open quiz room list every time the top page is shown again, not just on first mount (issue #531)', async () => {
     class MockWebSocket {
       constructor(url) {


### PR DESCRIPTION
## 概要

フロントエンドのCIテストログに大量のエラーが出ている件を調査し、原因を修正する。

## 調査結果

直近のmainブランチCI実行（`ci / frontend-test`ジョブ）のログを確認したところ、`Failed to fetch open quiz rooms: TypeError: response.json is not a function`が1回のCI実行で62件出力されていた。

原因は`App.jsx`の`fetchOpenQuizRooms`（issue #531で最近変更した箇所）が`response.ok`を確認する前に`response.json()`を呼んでおり、`App.test.jsx`内の多くのテスト（`/quiz-rooms`を明示的にモックしていないテスト）のfetchモックが`{ ok: false }`（`json`メソッドを持たない）を返すたびにTypeErrorが発生し、catchブロックで`console.error`が呼ばれていたため。issue #531でこの取得effectを「トップページ表示のたびに再実行」するよう変更したことで、この既存の潜在バグがヒットする頻度が大幅に増えたと見られる。

## 対応内容

- `response.ok`を先に確認し、falseなら早期returnするよう順序を入れ替えた
- 本番環境でも、エラー応答のボディが必ずしもJSONとは限らない（504等のゲートウェイエラーページ等）ため、この順序変更自体がより堅牢な実装になる

## Test plan

- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 150/150件成功
- [x] `backend`: `npm run lint` / `npm test -- --run` 1484/1484件成功（無関係のため変化なし）
- [x] 修正前のコードでは実際にテストが失敗する（`console.error`が呼ばれる）ことを確認した上で、`response.ok`がfalseかつ`json`メソッドを持たない応答でもエラーを出力しないことを検証する回帰テストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_