### PR TITLE
test(frontend): 未モックのfetch呼び出しがconsole.errorを出さないようにする

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -53,9 +53,9 @@ describe('App', () => {
   });
 
   it('renders division selection screen initially', async () => {
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ categories: [] }),
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [] }) };
+      return { ok: false };
     });
 
     await act(async () => {
@@ -68,7 +68,10 @@ describe('App', () => {
   });
 
   it('shows a get-categories-specific error message when fetching categories fails, instead of the generic submit-failure message', async () => {
-    fetch.mockRejectedValueOnce(new Error('network error'));
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) throw new Error('network error');
+      return { ok: false };
+    });
 
     await act(async () => {
       render(<App />);
@@ -78,14 +81,19 @@ describe('App', () => {
   });
 
   it('shows the matching category list after choosing a division', async () => {
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        categories: [
-          { name: 'いろはかるた', group: 'kids' },
-          { name: 'テスト用', group: 'kids' },
-        ],
-      }),
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        return {
+          ok: true,
+          json: async () => ({
+            categories: [
+              { name: 'いろはかるた', group: 'kids' },
+              { name: 'テスト用', group: 'kids' },
+            ],
+          }),
+        };
+      }
+      return { ok: false };
     });
 
     await act(async () => {
@@ -101,14 +109,19 @@ describe('App', () => {
   });
 
   it('only shows categories belonging to the selected division', async () => {
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        categories: [
-          { name: 'KidsCat', group: 'kids' },
-          { name: 'EngCat', group: 'engineer' },
-        ],
-      }),
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        return {
+          ok: true,
+          json: async () => ({
+            categories: [
+              { name: 'KidsCat', group: 'kids' },
+              { name: 'EngCat', group: 'engineer' },
+            ],
+          }),
+        };
+      }
+      return { ok: false };
     });
 
     await act(async () => {
@@ -124,11 +137,11 @@ describe('App', () => {
   });
 
   it('shows an empty-state message instead of a dead decide button when a division has no categories', async () => {
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        categories: [{ name: 'EngCat', group: 'engineer' }],
-      }),
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        return { ok: true, json: async () => ({ categories: [{ name: 'EngCat', group: 'engineer' }] }) };
+      }
+      return { ok: false };
     });
 
     await act(async () => {
@@ -144,9 +157,9 @@ describe('App', () => {
   });
 
   it('keeps the secondary navigation links reachable from the category selection screen', async () => {
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }),
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      return { ok: false };
     });
 
     await act(async () => {

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -81,6 +81,11 @@ beforeEach(() => {
   setParticipantNameMock.mockClear();
   buzzMock.mockClear();
   fetch.mockReset();
+  // 個別のテストが/get-phrase等を明示的にモックしなかった場合のデフォルト応答。
+  // 未設定のままだとfetch()がundefinedを返し、レスポンスのプロパティアクセスで
+  // 無用なTypeErrorがログに出てしまう（本番のfetch()はResponseかrejectのいずれかで、
+  // undefinedを返すことはないため、これはテスト側の既定値の問題）
+  fetch.mockResolvedValue({ ok: false });
   audioInstances.length = 0;
   audioPlayImpl = () => Promise.resolve();
   localStorage.clear();


### PR DESCRIPTION
## 概要

PR #542でのfetchOpenQuizRoomsの修正後もCIログに残っていた同種のエラーを解消する追加対応。

## 調査結果

PR #542マージ後のCI実行ログ（`ci / frontend-test`）を確認したところ、`Failed to fetch open quiz rooms: TypeError: Cannot read properties of undefined (reading 'ok')`がまだ約6件残っていた。

原因は`App.test.jsx`内の6つの古いテストが`fetch.mockResolvedValueOnce`（1回限りのモック）を使っており、2回目以降のfetch呼び出し（`/quiz-rooms`）が未モックのまま`undefined`を返していたため。

同様に`QuizRoomView.test.jsx`でも、`/get-phrase`を明示的にモックしないテスト（buzz・responder表示のテスト等）でfetchが`undefined`を返し、「Failed to play quiz room audio」のTypeErrorが出ていた。

## 対応内容

- `App.test.jsx`の該当6テストを、他のテストと同じ`fetch.mockImplementation`＋catch-all（`return { ok: false }`）パターンに統一した
- `QuizRoomView.test.jsx`の`beforeEach`で`fetch.mockResolvedValue({ ok: false })`を既定値として設定し、個別のテストが必要に応じて上書きできるようにした
- 本番の`fetch()`はResponseを返すかrejectするかのいずれかで`undefined`を返すことはないため、production側に防御的なnullチェックを追加するのではなく、テスト側のモック不足を修正する方針とした

## Test plan

- [x] `frontend`: `npm run lint` エラー0件
- [x] `frontend`: `npm test -- --run` 150/150件成功
- [x] `backend`: `npm run lint` / `npm test -- --run` 1484/1484件成功（無関係のため変化なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_