### PR TITLE
feat(quiz-room): 早押し正誤判定モーダルとポイント加算・再挑戦除外

### DIFF
--- a/backend/quizRoomHandler.js
+++ b/backend/quizRoomHandler.js
@@ -291,44 +291,31 @@ exports.updateQuizRoomState = async (event) => {
 
     // 読み上げ設定の変更等で、ラウンドが進んだわけではなく同じ札のphraseが
     // 再ブロードキャストされることがある（App.jsxのbroadcast effect参照）。
-    // このケースを新しいラウンドの開始と誤認すると、早押し結果を巻き戻す前に
-    // ポイントを加点してしまったり、まだ判定が済んでいない早押し記録を
-    // 消してしまったりするため、直前の状態と札のidを比較して区別する
+    // このケースを新しいラウンドの開始と誤認すると、まだ判定が済んでいない
+    // 早押し記録を消してしまうため、直前の状態と札のidを比較して区別する
     const isSamePhraseRebroadcast = newState.type === "phrase"
       && room.Item?.state?.type === "phrase"
       && room.Item?.state?.content?.id === newState.content?.id;
 
-    // 早押しポイント制（issue #519）: 次の札（type="phrase"、かつラウンドが実際に
-    // 進んだ場合）に進むタイミングで、直前のラウンドで早押しが記録されていれば
-    // その人に1ポイント加点する。"initial"へ戻す場合（ゲームのリセット等）は
-    // お手つき等の可能性を否定できないため加点しない
-    let updatedPoints = null;
-    if (newState.type === "phrase" && !isSamePhraseRebroadcast) {
-      const buzzedName = room.Item?.buzz?.name;
-      if (buzzedName) {
-        updatedPoints = { ...(room.Item.points || {}) };
-        updatedPoints[buzzedName] = (updatedPoints[buzzedName] || 0) + 1;
-      }
-    }
-
-    // 早押し機能（issue #510）: 新しい札（次の問題）や、ゲームのリセット等で"initial"に
-    // 戻った場合は、前のラウンドの早押し結果をリセットする。result表示中や、同じ札の
-    // 再ブロードキャスト中は、まだそのラウンドの早押し結果を確定させたくないためリセットしない
-    const resetBuzz = newState.type !== "result" && !isSamePhraseRebroadcast ? " REMOVE buzz" : "";
-    const updatePointsExpr = updatedPoints ? ", #points = :points" : "";
+    // 早押し正誤判定（issue #546）: ポイント付与は管理者の正誤判定
+    // （judgeQuizRoomBuzz）でのみ行う。「次の札」へ進んだ時点でまだ判定されて
+    // いない早押しがあっても加点しない（未判定は無効試行として扱う）。
+    // 新しい札（次の問題）や、ゲームのリセット等で"initial"に戻った場合は、
+    // 前のラウンドの早押し・除外状態をリセットする。result表示中や、同じ札の
+    // 再ブロードキャスト中は、まだそのラウンドの判定を確定させたくないため
+    // リセットしない
+    const resetRound = newState.type !== "result" && !isSamePhraseRebroadcast;
+    const updateExpression = resetRound
+      ? "SET #state = :state, #ttl = :ttl REMOVE buzz, excludedNames"
+      : "SET #state = :state, #ttl = :ttl";
     await docClient.send(new UpdateCommand({
       TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
       Key: { roomId },
-      UpdateExpression: `SET #state = :state, #ttl = :ttl${updatePointsExpr}${resetBuzz}`,
-      ExpressionAttributeNames: {
-        "#state": "state",
-        "#ttl": "ttl",
-        ...(updatedPoints ? { "#points": "points" } : {}),
-      },
+      UpdateExpression: updateExpression,
+      ExpressionAttributeNames: { "#state": "state", "#ttl": "ttl" },
       ExpressionAttributeValues: {
         ":state": newState,
         ":ttl": Math.floor(Date.now() / 1000) + ROOM_TTL_SECONDS,
-        ...(updatedPoints ? { ":points": updatedPoints } : {}),
       },
     }));
 
@@ -348,11 +335,78 @@ exports.updateQuizRoomState = async (event) => {
       }))
     );
 
-    if (updatedPoints) {
+    return { statusCode: 200, body: "" };
+  } catch (error) {
+    console.error(error);
+    return { statusCode: 500, body: "Internal Server Error" };
+  }
+};
+
+// WebSocketカスタムルート"judgeBuzz"（issue #546）。管理者のみが早押しの正誤を
+// 判定できる。正解の場合はその参加者に1ポイント加点し、buzz/excludedNamesを
+// リセットする（次のラウンドまで早押しは確定済みのまま据え置かれる）。
+// 不正解の場合はbuzzのみリセットして他の参加者が再度早押しできるようにしつつ、
+// 誤答した本人は今ラウンドの早押し対象から除外し、ルーム内の全接続へ
+// ラウンドリセットを通知する
+exports.judgeQuizRoomBuzz = async (event) => {
+  try {
+    const connectionId = event.requestContext.connectionId;
+    const connection = await docClient.send(new GetCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      Key: { connectionId },
+    }));
+    if (!connection.Item || connection.Item.role !== "admin") {
+      return { statusCode: 403, body: "Forbidden" };
+    }
+
+    const body = JSON.parse(event.body || "{}");
+    const correct = body.correct === true;
+    const { roomId } = connection.Item;
+
+    const room = await docClient.send(new GetCommand({
+      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+      Key: { roomId },
+    }));
+    const buzzedName = room.Item?.buzz?.name;
+    if (!buzzedName) {
+      // 判定対象の早押しが既に無い（タイミングのズレ等）。何もしない
+      return { statusCode: 200, body: "" };
+    }
+
+    const connections = await docClient.send(new QueryCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      IndexName: "roomId-index",
+      KeyConditionExpression: "roomId = :roomId",
+      ExpressionAttributeValues: { ":roomId": roomId },
+    }));
+    const managementApi = buildManagementApiClient(event);
+
+    if (correct) {
+      const updatedPoints = { ...(room.Item.points || {}) };
+      updatedPoints[buzzedName] = (updatedPoints[buzzedName] || 0) + 1;
+      await docClient.send(new UpdateCommand({
+        TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+        Key: { roomId },
+        UpdateExpression: "SET points = :points REMOVE buzz, excludedNames",
+        ExpressionAttributeValues: { ":points": updatedPoints },
+      }));
       await Promise.allSettled(
         (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
           type: "points",
           points: updatedPoints,
+        }))
+      );
+    } else {
+      await docClient.send(new UpdateCommand({
+        TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+        Key: { roomId },
+        UpdateExpression: "REMOVE buzz ADD excludedNames :names",
+        ExpressionAttributeValues: { ":names": new Set([buzzedName]) },
+      }));
+      await Promise.allSettled(
+        (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
+          type: "roundReset",
+          excludedName: buzzedName,
         }))
       );
     }
@@ -427,7 +481,9 @@ exports.setQuizRoomName = async (event) => {
 
 // WebSocketカスタムルート"buzz"（早押し機能、issue #510）。参加者のみが押せる。
 // 同一ラウンド内で最初の1件だけを条件付き書き込みで確定させ、ルーム内の全接続へ
-// 回答者名をブロードキャストする（早押し結果のリセットはupdateQuizRoomState側で行う）
+// 回答者名をブロードキャストする（早押し結果のリセットはupdateQuizRoomState側で行う）。
+// 正誤判定（issue #546）で不正解と判定された参加者は、そのラウンド中は
+// 再度早押しできない（excludedNamesに含まれる名前を条件付き書き込みで弾く）
 exports.buzzQuizRoom = async (event) => {
   try {
     const connectionId = event.requestContext.connectionId;
@@ -451,12 +507,13 @@ exports.buzzQuizRoom = async (event) => {
         TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
         Key: { roomId },
         UpdateExpression: "SET buzz = :buzz",
-        ConditionExpression: "attribute_not_exists(buzz)",
-        ExpressionAttributeValues: { ":buzz": buzz },
+        ConditionExpression: "attribute_not_exists(buzz) AND (attribute_not_exists(excludedNames) OR NOT contains(excludedNames, :name))",
+        ExpressionAttributeValues: { ":buzz": buzz, ":name": buzz.name },
       }));
     } catch (error) {
       if (error.name === "ConditionalCheckFailedException") {
-        // 既に他の参加者が先に押している。早押しの結果は変えず、何もしない
+        // 既に他の参加者が先に押している、またはこのラウンドで不正解判定済みで
+        // 除外されている。いずれも早押しの結果は変えず、何もしない
         return { statusCode: 200, body: "" };
       }
       throw error;

--- a/backend/quizRoomHandler.test.js
+++ b/backend/quizRoomHandler.test.js
@@ -12,6 +12,7 @@ import {
   updateQuizRoomState,
   setQuizRoomName,
   buzzQuizRoom,
+  judgeQuizRoomBuzz,
 } from './quizRoomHandler';
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
@@ -373,7 +374,7 @@ describe('updateQuizRoomState', () => {
     expect(payload.state).toEqual(newState);
   });
 
-  it('resets (removes) the buzz field when broadcasting a new phrase, so the next round starts unbuzzed (issue #510)', async () => {
+  it('resets (removes) the buzz and excludedNames fields when broadcasting a new phrase, so the next round starts unbuzzed (issue #510, #546)', async () => {
     ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' } });
     ddbMock.on(UpdateCommand).resolves({});
     ddbMock.on(QueryCommand).resolves({ Items: [] });
@@ -382,7 +383,7 @@ describe('updateQuizRoomState', () => {
     await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
 
     const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
-    expect(updateCall.UpdateExpression).toContain('REMOVE buzz');
+    expect(updateCall.UpdateExpression).toContain('REMOVE buzz, excludedNames');
   });
 
   it('does not reset the buzz field when broadcasting a result (so the responder stays visible during the result screen)', async () => {
@@ -394,7 +395,7 @@ describe('updateQuizRoomState', () => {
     await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
 
     const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
-    expect(updateCall.UpdateExpression).not.toContain('REMOVE buzz');
+    expect(updateCall.UpdateExpression).not.toContain('REMOVE');
   });
 
   it('resets the buzz field when broadcasting back to the initial/idle state (e.g. the admin resets the game), so stale buzz info does not leak into the next round', async () => {
@@ -406,10 +407,10 @@ describe('updateQuizRoomState', () => {
     await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
 
     const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
-    expect(updateCall.UpdateExpression).toContain('REMOVE buzz');
+    expect(updateCall.UpdateExpression).toContain('REMOVE buzz, excludedNames');
   });
 
-  it('awards a point to the buzzer when advancing to a new phrase after someone buzzed (issue #519)', async () => {
+  it('does not touch points when advancing to a new phrase, even if someone had buzzed (points are only awarded via judgeQuizRoomBuzz, issue #546)', async () => {
     ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
       Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
     });
@@ -430,67 +431,17 @@ describe('updateQuizRoomState', () => {
 
     expect(response.statusCode).toBe(200);
     const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
-    expect(updateCall.ExpressionAttributeValues[':points']).toEqual({ たろう: 1 });
-    expect(updateCall.UpdateExpression).toContain('#points = :points');
+    expect(updateCall.ExpressionAttributeValues[':points']).toBeUndefined();
+    expect(updateCall.UpdateExpression).not.toContain('points');
 
     const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
     const pointsMessages = postCalls
       .map((call) => JSON.parse(Buffer.from(call.args[0].input.Data).toString('utf-8')))
       .filter((payload) => payload.type === 'points');
-    expect(pointsMessages).toHaveLength(2);
-    expect(pointsMessages[0]).toEqual({ type: 'points', points: { たろう: 1 } });
+    expect(pointsMessages).toHaveLength(0);
   });
 
-  it('accumulates points across rounds for the same participant', async () => {
-    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
-      Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
-    });
-    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({
-      Item: {
-        roomId: 'ROOM01',
-        buzz: { connectionId: 'conn-p', name: 'たろう', buzzedAt: 1000 },
-        points: { たろう: 2, はなこ: 1 },
-      },
-    });
-    ddbMock.on(UpdateCommand).resolves({});
-    ddbMock.on(QueryCommand).resolves({ Items: [] });
-
-    const newState = { type: 'phrase', phrase: { id: 'p3', category: 'Cat1' } };
-    await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
-
-    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
-    expect(updateCall.ExpressionAttributeValues[':points']).toEqual({ たろう: 3, はなこ: 1 });
-  });
-
-  it('does not award a point when advancing to a new phrase if no one buzzed in the previous round', async () => {
-    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
-      Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
-    });
-    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({ Item: { roomId: 'ROOM01' } });
-    ddbMock.on(UpdateCommand).resolves({});
-    ddbMock.on(QueryCommand).resolves({ Items: [] });
-
-    const newState = { type: 'phrase', phrase: { id: 'p4', category: 'Cat1' } };
-    await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
-
-    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
-    expect(updateCall.ExpressionAttributeValues[':points']).toBeUndefined();
-    expect(updateCall.UpdateExpression).not.toContain('#points');
-  });
-
-  it('does not award a point when resetting to the initial state even if someone had buzzed (avoids scoring an aborted round)', async () => {
-    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' } });
-    ddbMock.on(UpdateCommand).resolves({});
-    ddbMock.on(QueryCommand).resolves({ Items: [] });
-
-    const newState = { type: 'initial' };
-    await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
-
-    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
-    expect(updateCall.ExpressionAttributeValues[':points']).toBeUndefined();
-  });
-
-  it('does not award a point or reset the buzz field when the same phrase is merely re-broadcast (e.g. a mid-round settings change), since the round has not actually advanced (issue #519)', async () => {
+  it('does not reset the buzz/excludedNames fields when the same phrase is merely re-broadcast (e.g. a mid-round settings change), since the round has not actually advanced (issue #519, #546)', async () => {
     ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
       Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
     });
@@ -509,12 +460,10 @@ describe('updateQuizRoomState', () => {
     await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
 
     const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
-    expect(updateCall.ExpressionAttributeValues[':points']).toBeUndefined();
-    expect(updateCall.UpdateExpression).not.toContain('#points');
-    expect(updateCall.UpdateExpression).not.toContain('REMOVE buzz');
+    expect(updateCall.UpdateExpression).not.toContain('REMOVE');
   });
 
-  it('does award a point and reset the buzz field when a genuinely new phrase follows one that was re-broadcast (issue #519)', async () => {
+  it('resets the buzz/excludedNames fields when a genuinely new phrase follows one that was re-broadcast (issue #519, #546)', async () => {
     ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
       Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
     });
@@ -532,8 +481,7 @@ describe('updateQuizRoomState', () => {
     await updateQuizRoomState(wsEvent({ connectionId: 'conn-admin', body: { state: newState } }));
 
     const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
-    expect(updateCall.ExpressionAttributeValues[':points']).toEqual({ たろう: 1 });
-    expect(updateCall.UpdateExpression).toContain('REMOVE buzz');
+    expect(updateCall.UpdateExpression).toContain('REMOVE buzz, excludedNames');
   });
 
   it('removes a stale connection record when broadcasting hits a GoneException, without failing the whole update', async () => {
@@ -669,7 +617,7 @@ describe('buzzQuizRoom', () => {
     expect(response.statusCode).toBe(200);
     const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
     expect(updateCall.Key).toEqual({ roomId: 'ROOM01' });
-    expect(updateCall.ConditionExpression).toBe('attribute_not_exists(buzz)');
+    expect(updateCall.ConditionExpression).toBe('attribute_not_exists(buzz) AND (attribute_not_exists(excludedNames) OR NOT contains(excludedNames, :name))');
     expect(updateCall.ExpressionAttributeValues[':buzz']).toMatchObject({
       connectionId: 'conn-participant',
       name: 'たろう',
@@ -706,9 +654,116 @@ describe('buzzQuizRoom', () => {
     expect(managementApiMock.commandCalls(PostToConnectionCommand)).toHaveLength(0);
   });
 
+  it('includes the participant name in the condition check, so a participant excluded this round (judged incorrect, issue #546) cannot re-buzz', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { connectionId: 'conn-participant', roomId: 'ROOM01', role: 'participant', name: 'はなこ' },
+    });
+    ddbMock.on(UpdateCommand).rejects(Object.assign(new Error('cond failed'), { name: 'ConditionalCheckFailedException' }));
+
+    const response = await buzzQuizRoom(wsEvent({ connectionId: 'conn-participant' }));
+
+    expect(response.statusCode).toBe(200);
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.ExpressionAttributeValues[':name']).toBe('はなこ');
+    expect(managementApiMock.commandCalls(PostToConnectionCommand)).toHaveLength(0);
+  });
+
   it('handles unexpected errors', async () => {
     ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
     const response = await buzzQuizRoom(wsEvent());
+    expect(response.statusCode).toBe(500);
+  });
+});
+
+describe('judgeQuizRoomBuzz', () => {
+  it('rejects when the caller is not an admin', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' } });
+    const response = await judgeQuizRoomBuzz(wsEvent({ body: { correct: true } }));
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('rejects when the connection record is missing', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+    const response = await judgeQuizRoomBuzz(wsEvent({ body: { correct: true } }));
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('does nothing when there is no active buzz to judge (e.g. timing mismatch)', async () => {
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
+      Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+    });
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({ Item: { roomId: 'ROOM01' } });
+
+    const response = await judgeQuizRoomBuzz(wsEvent({ connectionId: 'conn-admin', body: { correct: true } }));
+
+    expect(response.statusCode).toBe(200);
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+  });
+
+  it('awards a point to the buzzer, clears buzz/excludedNames, and broadcasts updated points when judged correct', async () => {
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
+      Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+    });
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({
+      Item: { roomId: 'ROOM01', buzz: { connectionId: 'conn-p', name: 'たろう', buzzedAt: 1000 }, points: { たろう: 1 } },
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+        { connectionId: 'conn-p', roomId: 'ROOM01', role: 'participant' },
+      ],
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    const response = await judgeQuizRoomBuzz(wsEvent({ connectionId: 'conn-admin', body: { correct: true } }));
+
+    expect(response.statusCode).toBe(200);
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.Key).toEqual({ roomId: 'ROOM01' });
+    expect(updateCall.ExpressionAttributeValues[':points']).toEqual({ たろう: 2 });
+    expect(updateCall.UpdateExpression).toBe('SET points = :points REMOVE buzz, excludedNames');
+
+    const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
+    expect(postCalls).toHaveLength(2);
+    const payload = JSON.parse(Buffer.from(postCalls[0].args[0].input.Data).toString('utf-8'));
+    expect(payload).toEqual({ type: 'points', points: { たろう: 2 } });
+  });
+
+  it('clears buzz, excludes the participant from the round, and broadcasts a roundReset when judged incorrect', async () => {
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
+      Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+    });
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({
+      Item: { roomId: 'ROOM01', buzz: { connectionId: 'conn-p', name: 'たろう', buzzedAt: 1000 } },
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+        { connectionId: 'conn-p', roomId: 'ROOM01', role: 'participant' },
+      ],
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    const response = await judgeQuizRoomBuzz(wsEvent({ connectionId: 'conn-admin', body: { correct: false } }));
+
+    expect(response.statusCode).toBe(200);
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.Key).toEqual({ roomId: 'ROOM01' });
+    expect(updateCall.UpdateExpression).toBe('REMOVE buzz ADD excludedNames :names');
+    expect(updateCall.ExpressionAttributeValues[':names']).toEqual(new Set(['たろう']));
+    expect(updateCall.ExpressionAttributeValues[':points']).toBeUndefined();
+
+    const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
+    expect(postCalls).toHaveLength(2);
+    const payload = JSON.parse(Buffer.from(postCalls[0].args[0].input.Data).toString('utf-8'));
+    expect(payload).toEqual({ type: 'roundReset', excludedName: 'たろう' });
+  });
+
+  it('handles unexpected errors', async () => {
+    ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
+    const response = await judgeQuizRoomBuzz(wsEvent({ body: { correct: true } }));
     expect(response.statusCode).toBe(500);
   });
 });

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -228,6 +228,11 @@ functions:
     events:
       - websocket:
           route: buzz
+  judgeQuizRoomBuzz: # 追加（早押し正誤判定、issue #546）。管理者のみ早押しの正誤を判定でき、正解なら加点、不正解なら他の参加者に早押しを再開させる
+    handler: quizRoomHandler.judgeQuizRoomBuzz
+    events:
+      - websocket:
+          route: judgeBuzz
 
 resources:
   Resources:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -903,7 +903,7 @@ function App() {
   useWakeLock(view === "game" && selectedCategories.length > 0);
 
   // クイズ大会モード: quizRoomが設定されている（管理者としてルームを開設した）間だけ接続する
-  const { broadcastState: broadcastQuizRoomState } = useQuizRoomSync({
+  const { broadcastState: broadcastQuizRoomState, judgeBuzz } = useQuizRoomSync({
     wsBaseUrl: WS_BASE_URL,
     roomId: quizRoom?.roomId,
     adminToken: quizRoom?.adminToken,
@@ -911,6 +911,14 @@ function App() {
     onBuzz: setQuizRoomBuzzedBy,
     onPoints: setQuizRoomPoints,
   });
+
+  // 早押し正誤判定（issue #546）: 「正解」「不正解」を選んだら判定結果をサーバーへ
+  // 送信し、モーダルはローカルで即座に閉じる（roundResetのブロードキャストは
+  // 参加者側の早押しボタン復活・除外に使われる）
+  const judgeQuizRoomBuzz = (correct) => {
+    judgeBuzz(correct);
+    setQuizRoomBuzzedBy(null);
+  };
 
   // 表示中の札・結果画面が変わるたびクイズ大会モードの参加者へ状態をブロードキャストする。
   // audioData等の重量級フィールドは送らず、表示に必要な項目だけを抜き出す
@@ -1700,7 +1708,19 @@ function App() {
         <div className="mb-4">
           <QuizRoomInfoPanel roomId={quizRoom.roomId} />
           {quizRoomBuzzedBy && (
-            <p className="fw-bold text-dark">🔔 {quizRoomBuzzedBy.name} さんが回答しました</p>
+            <div className="modal fade show d-block modal-overlay" tabIndex="-1">
+              <div className="modal-dialog modal-dialog-centered">
+                <div className="modal-content rounded-4 border-0 shadow">
+                  <div className="modal-body p-5 text-center">
+                    <h3 className="h5 mb-4 fw-bold">🔔 {quizRoomBuzzedBy.name} さんが回答しました</h3>
+                    <div className="d-flex gap-2 justify-content-center">
+                      <button onClick={() => judgeQuizRoomBuzz(true)} className="btn btn-primary btn-lg px-4 rounded-pill shadow-sm fs-6">正解</button>
+                      <button onClick={() => judgeQuizRoomBuzz(false)} className="btn btn-outline-secondary btn-lg px-4 rounded-pill fs-6">不正解</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           )}
           {Object.keys(quizRoomPoints).length > 0 && (
             <div className="mx-auto mt-3 text-start" style={{ maxWidth: "320px" }}>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2548,6 +2548,66 @@ describe('App', () => {
     }, { timeout: 20000 });
   }, 40000);
 
+  it('shows a judgment modal with 正解/不正解 buttons when a participant buzzes in, and sends the judgment over the WebSocket while closing the modal (issue #546)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      if (url.includes('/get-phrase?')) {
+        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', audioData: 'dummy' }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    const ws = MockWebSocket.instances[0];
+    act(() => {
+      ws.readyState = MockWebSocket.OPEN;
+      ws.onopen?.();
+    });
+
+    act(() => {
+      ws.onmessage?.({ data: JSON.stringify({ type: 'buzz', name: 'はなこ', connectionId: 'conn-2' }) });
+    });
+
+    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+    expect(screen.getByText('正解')).toBeInTheDocument();
+    expect(screen.getByText('不正解')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('不正解'));
+
+    expect(ws.sent).toContainEqual(JSON.stringify({ action: 'judgeBuzz', correct: false }));
+    expect(screen.queryByText('🔔 はなこ さんが回答しました')).not.toBeInTheDocument();
+  }, 40000);
+
   it('does not clear the responder shown to the admin when the same card is re-broadcast (e.g. a settings change re-sends the same phrase), only when the round actually changes (issue #510)', async () => {
     class MockWebSocket {
       constructor(url) {

--- a/frontend/src/hooks/useQuizRoomSync.js
+++ b/frontend/src/hooks/useQuizRoomSync.js
@@ -15,7 +15,9 @@ const SYNC_POLL_INTERVAL_MS = 5000;
 // ポイント制（issue #519）: サーバーから{type:"points", points}（名前→累計ポイントの
 // マップ）を受け取るたびonPointsを呼ぶ。名前が同一ルーム内で重複していた場合は
 // {type:"nameError", message}が返るのでonNameErrorを呼ぶ
-export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz, onPoints, onNameError }) {
+// 早押し正誤判定（issue #546）: 管理者はjudgeBuzzで正誤を送信できる。不正解と判定
+// されたときはサーバーから{type:"roundReset", excludedName}が返るのでonRoundResetを呼ぶ
+export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz, onPoints, onNameError, onRoundReset }) {
   const [internalStatus, setInternalStatus] = useState("idle"); // connecting|connected|error（idleはwsBaseUrl/roomId未設定時に導出する）
   const connectionStatus = (!wsBaseUrl || !roomId) ? "idle" : internalStatus;
   const wsRef = useRef(null);
@@ -23,6 +25,7 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
   const onBuzzRef = useRef(onBuzz);
   const onPointsRef = useRef(onPoints);
   const onNameErrorRef = useRef(onNameError);
+  const onRoundResetRef = useRef(onRoundReset);
   const reconnectAttemptsRef = useRef(0);
   const reconnectTimeoutRef = useRef(null);
   const closedByCleanupRef = useRef(false);
@@ -50,6 +53,10 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
   useEffect(() => {
     onNameErrorRef.current = onNameError;
   }, [onNameError]);
+
+  useEffect(() => {
+    onRoundResetRef.current = onRoundReset;
+  }, [onRoundReset]);
 
   useEffect(() => {
     if (!wsBaseUrl || !roomId) {
@@ -101,6 +108,8 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
             onPointsRef.current?.(data.points);
           } else if (data?.type === "nameError") {
             onNameErrorRef.current?.(data.message);
+          } else if (data?.type === "roundReset") {
+            onRoundResetRef.current?.({ excludedName: data.excludedName });
           }
         } catch (error) {
           console.error("Failed to parse quiz room message:", error);
@@ -165,5 +174,12 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
     }
   }, []);
 
-  return { connectionStatus, broadcastState, setParticipantName, buzz };
+  // 早押し正誤判定（issue #546）: 管理者が早押しの正誤を判定してサーバーへ送信する
+  const judgeBuzz = useCallback((correct) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ action: "judgeBuzz", correct }));
+    }
+  }, []);
+
+  return { connectionStatus, broadcastState, setParticipantName, buzz, judgeBuzz };
 }

--- a/frontend/src/hooks/useQuizRoomSync.test.js
+++ b/frontend/src/hooks/useQuizRoomSync.test.js
@@ -153,6 +153,36 @@ describe('useQuizRoomSync', () => {
     expect(onNameError).toHaveBeenCalledWith('その名前は既に使われています。');
   });
 
+  it('calls onRoundReset when a roundReset message is received (issue #546)', () => {
+    const onRoundReset = vi.fn();
+    renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn(), onRoundReset }));
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+      MockWebSocket.instances[0].triggerMessage({ type: 'roundReset', excludedName: 'たろう' });
+    });
+
+    expect(onRoundReset).toHaveBeenCalledWith({ excludedName: 'たろう' });
+  });
+
+  it('judgeBuzz sends judgeBuzz with the correct flag only while the connection is open', () => {
+    const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+    act(() => {
+      result.current.judgeBuzz(true);
+    });
+    expect(MockWebSocket.instances[0].sent).toEqual([]);
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+    });
+    act(() => {
+      result.current.judgeBuzz(false);
+    });
+
+    expect(MockWebSocket.instances[0].sent).toContainEqual(JSON.stringify({ action: 'judgeBuzz', correct: false }));
+  });
+
   it('setParticipantName sends setName only while the connection is open, and resends it once the socket opens if called earlier', () => {
     const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
 

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -70,6 +70,9 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   const [nameError, setNameError] = useState(null);
   const [buzzedBy, setBuzzedBy] = useState(null);
   const [lastBuzzRoundKey, setLastBuzzRoundKey] = useState(null);
+  // 早押し正誤判定（issue #546）: 不正解と判定された場合、そのラウンド中は
+  // 自分だけ早押しボタンを再表示しない
+  const [excludedThisRound, setExcludedThisRound] = useState(false);
   // ポイント制（issue #519）: 名前→累計ポイントのマップ。集計単位はconnectionIdではなく
   // name（早押し機能の実装参照）なので、自分のポイントはpoints[confirmedName]で引く
   const [points, setPoints] = useState({});
@@ -94,6 +97,18 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     setView("game");
   };
 
+  // 早押し正誤判定（issue #546）: 不正解と判定されると、サーバーはbuzzを
+  // リセットして{type:"roundReset", excludedName}を返す。除外されたのが
+  // 自分自身であれば早押しボタンを再表示せず、それ以外の参加者なら
+  // buzzedByをクリアして再度早押しできるようにする
+  const handleRoundReset = ({ excludedName }) => {
+    if (excludedName === confirmedName) {
+      setExcludedThisRound(true);
+    } else {
+      setBuzzedBy(null);
+    }
+  };
+
   const { connectionStatus, setParticipantName, buzz } = useQuizRoomSync({
     wsBaseUrl,
     roomId: joinRoomId,
@@ -101,6 +116,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     onBuzz: setBuzzedBy,
     onPoints: setPoints,
     onNameError: handleNameError,
+    onRoundReset: handleRoundReset,
   });
 
   // 早押し結果表示のリセット判定（issue #510）。ラウンドを表す値（buzzRoundKey）を
@@ -120,6 +136,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   if (currentBuzzRoundKey !== lastBuzzRoundKey) {
     setLastBuzzRoundKey(currentBuzzRoundKey);
     setBuzzedBy(null);
+    setExcludedThisRound(false);
   }
 
   const handleConfirmName = () => {
@@ -189,8 +206,11 @@ function QuizRoomView({ setView, wsBaseUrl }) {
       try {
         const apiUrl = `${API_BASE_URL}/get-phrase?id=${id}&category=${encodeURIComponent(category)}&repeatCount=${repeatCount ?? 2}&speechRate=${encodeURIComponent(speechRate ?? "80%")}&lang=${lang ?? "ja"}&voiceId=${encodeURIComponent(voiceId ?? "Mizuki")}&announceCategory=${!!announceCategory}`;
         const response = await fetch(apiUrl);
+        if (cancelled || !response.ok) {
+          return;
+        }
         const data = await response.json();
-        if (cancelled || !response.ok || !data.audioData) {
+        if (cancelled || !data.audioData) {
           return;
         }
         await playSharedAudio(data.audioData);
@@ -260,7 +280,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
         {renderParticipantContent(roomState)}
         {buzzedBy ? (
           <p className="fw-bold text-dark mt-4">🔔 {buzzedBy.name} さんが回答しました</p>
-        ) : roomState?.type === "phrase" && (
+        ) : roomState?.type === "phrase" && !excludedThisRound && (
           <div className="mt-4">
             <button onClick={buzz} className="btn btn-danger btn-lg rounded-pill px-5">
               回答する

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -7,16 +7,18 @@ const onStateCallbacks = [];
 const onBuzzCallbacks = [];
 const onPointsCallbacks = [];
 const onNameErrorCallbacks = [];
+const onRoundResetCallbacks = [];
 let mockConnectionStatus = 'connected';
 const setParticipantNameMock = vi.fn();
 const buzzMock = vi.fn();
 
 vi.mock('../hooks/useQuizRoomSync', () => ({
-  useQuizRoomSync: ({ onState, onBuzz, onPoints, onNameError }) => {
+  useQuizRoomSync: ({ onState, onBuzz, onPoints, onNameError, onRoundReset }) => {
     onStateCallbacks.push(onState);
     onBuzzCallbacks.push(onBuzz);
     onPointsCallbacks.push(onPoints);
     onNameErrorCallbacks.push(onNameError);
+    onRoundResetCallbacks.push(onRoundReset);
     return {
       connectionStatus: mockConnectionStatus,
       broadcastState: vi.fn(),
@@ -52,6 +54,12 @@ function emitNameError(message) {
   });
 }
 
+function emitRoundReset(payload) {
+  act(() => {
+    onRoundResetCallbacks[onRoundResetCallbacks.length - 1]?.(payload);
+  });
+}
+
 // 早押し機能（issue #510）: 参加者画面は名前入力を先に確定させないと通常画面へ進まないため、
 // 名前を関係しないテストではこのヘルパーで確定させておく
 function confirmName(name = 'たろう') {
@@ -77,6 +85,7 @@ beforeEach(() => {
   onBuzzCallbacks.length = 0;
   onPointsCallbacks.length = 0;
   onNameErrorCallbacks.length = 0;
+  onRoundResetCallbacks.length = 0;
   mockConnectionStatus = 'connected';
   setParticipantNameMock.mockClear();
   buzzMock.mockClear();
@@ -235,6 +244,52 @@ describe('QuizRoomView', () => {
     emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
     expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
     expect(screen.queryByText('回答する')).not.toBeInTheDocument();
+  });
+
+  it('lets other participants buzz in again after a roundReset (incorrect judgment), but not the participant who was judged incorrect (issue #546)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName('はなこ');
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+    fireEvent.click(screen.getByText('回答する'));
+    emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
+    expect(screen.queryByText('回答する')).not.toBeInTheDocument();
+
+    emitRoundReset({ excludedName: 'はなこ' });
+
+    // 不正解と判定された本人は、そのラウンド中は早押しボタンが再表示されない
+    expect(screen.queryByText('回答する')).not.toBeInTheDocument();
+  });
+
+  it('shows the buzz button again for a participant not excluded after a roundReset (issue #546)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName('はなこ');
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+    emitBuzz({ name: 'たろう', connectionId: 'conn-2' });
+    expect(screen.queryByText('回答する')).not.toBeInTheDocument();
+
+    emitRoundReset({ excludedName: 'たろう' });
+
+    expect(screen.getByText('回答する')).toBeInTheDocument();
+  });
+
+  it('re-allows buzzing once a genuinely new round starts, even for a participant excluded in the previous round (issue #546)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName('はなこ');
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+    fireEvent.click(screen.getByText('回答する'));
+    emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
+    emitRoundReset({ excludedName: 'はなこ' });
+    expect(screen.queryByText('回答する')).not.toBeInTheDocument();
+
+    emitState({ type: 'phrase', content: { id: 'p2', category: 'Cat1', phrase: '読み札2', level: '3' } });
+
+    expect(screen.getByText('回答する')).toBeInTheDocument();
   });
 
   it('shows the participant their own accumulated points as "points" messages arrive, keyed by their confirmed name (issue #519)', () => {


### PR DESCRIPTION
## 概要

早押しがあった際、管理者画面に正誤判定モーダルを自動表示し、正解/不正解ボタンでその場で判定できるようにする（issue #546）。

## 対応内容

- 早押し発生時、管理者画面に回答者名入り判定モーダルを自動ポップアップ
  - 正解: 該当参加者にポイント加算し、`buzz`/`excludedNames`をクリアして早押しを再開可能にする
  - 不正解: 誤答した本人のみ今回のラウンドから除外し、他の参加者は早押しを再開できるようにする
- 誤答者の除外はDynamoDBのString Set（`excludedNames`）で管理し、`buzzQuizRoom`の`ConditionExpression`に`contains()`チェックを追加して原子的に弾く
- WebSocketに新ルート`judgeBuzz`と新メッセージ種別`roundReset`を追加し、`useQuizRoomSync`/`QuizRoomView`/`App`で判定モーダル・除外状態を同期
- 既存のissue #519由来の「次の札へ進んだ時点の自動加点」ロジックは、今回の即時判定モーダルと二重加点になるため削除し、`resetRound`時に`buzz`と`excludedNames`を併せてREMOVEする形に統合
- ついでに`QuizRoomView.jsx`の音声取得effectで、`response.json()`を`response.ok`判定前に呼んでいた既存の不具合（`App.jsx`の`fetchOpenQuizRooms`で既に修正済みの同種バグ）も修正

## 設計判断（issue内で要確認だった3点、ユーザーに確認済み）

- 不正解時に早押しを再開できるのは本人を除く全員
- 管理者が判定せず「次の札」へ進んだ場合は加点しない
- 管理者側の通知は早押しのたびに自動ポップアップ

## Test plan

- [x] backend: `npm run lint` エラー0件
- [x] backend: `npm test -- --run` 1488/1488件成功
- [x] frontend: `npm run lint` エラー0件
- [x] frontend: `npm test -- --run` 156/156件成功

Closes #546


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_