### PR TITLE
feat(quiz-room): 参加者一覧をリアルタイムで管理者・参加者双方の画面に表示

### DIFF
--- a/backend/quizRoomHandler.js
+++ b/backend/quizRoomHandler.js
@@ -172,10 +172,39 @@ exports.connectQuizRoom = async (event) => {
 // WebSocket $disconnect
 exports.disconnectQuizRoom = async (event) => {
   try {
+    const connectionId = event.requestContext.connectionId;
+    const connection = await docClient.send(new GetCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      Key: { connectionId },
+    }));
     await docClient.send(new DeleteCommand({
       TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      Key: { connectionId: event.requestContext.connectionId },
+      Key: { connectionId },
     }));
+
+    // 参加者一覧（issue #545）: 切断は参加者一覧からも即座に消す。残りの接続へ
+    // 更新後の一覧をブロードキャストする（削除済みなので自分自身は含まれない）
+    if (connection.Item?.roomId) {
+      const { roomId } = connection.Item;
+      const connections = await docClient.send(new QueryCommand({
+        TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+        IndexName: "roomId-index",
+        KeyConditionExpression: "roomId = :roomId",
+        ExpressionAttributeValues: { ":roomId": roomId },
+      }));
+      const remaining = connections.Items || [];
+      const participantNames = remaining
+        .filter((conn) => conn.role === "participant" && conn.name)
+        .map((conn) => conn.name);
+      const managementApi = buildManagementApiClient(event);
+      await Promise.allSettled(
+        remaining.map((conn) => postToConnection(managementApi, conn.connectionId, {
+          type: "participants",
+          names: participantNames,
+        }))
+      );
+    }
+
     return { statusCode: 200, body: "Disconnected" };
   } catch (error) {
     console.error(error);
@@ -254,6 +283,21 @@ exports.syncQuizRoom = async (event) => {
         points: room.Item.points,
       });
     }
+
+    // 参加者一覧（issue #545）: 再接続・遅れて参加した端末にも現在の参加者一覧を伝える
+    const roomConnections = await docClient.send(new QueryCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      IndexName: "roomId-index",
+      KeyConditionExpression: "roomId = :roomId",
+      ExpressionAttributeValues: { ":roomId": connection.Item.roomId },
+    }));
+    const participantNames = (roomConnections.Items || [])
+      .filter((conn) => conn.role === "participant" && conn.name)
+      .map((conn) => conn.name);
+    await postToConnection(managementApi, connectionId, {
+      type: "participants",
+      names: participantNames,
+    });
 
     return { statusCode: 200, body: "" };
   } catch (error) {
@@ -467,6 +511,21 @@ exports.setQuizRoomName = async (event) => {
       ExpressionAttributeValues: { ":name": name },
       ConditionExpression: "attribute_exists(connectionId)",
     }));
+
+    // 参加者一覧（issue #545）: 名前が確定したら、ルーム内の全接続（管理者含む）へ
+    // 更新後の参加者一覧をブロードキャストする。connections.Itemsは名前確定前に
+    // 取得したものなので、呼び出し元自身の分だけ新しい名前で上書きする
+    const managementApi = buildManagementApiClient(event);
+    const participantNames = (connections.Items || [])
+      .filter((conn) => conn.role === "participant")
+      .map((conn) => (conn.connectionId === connectionId ? name : conn.name))
+      .filter(Boolean);
+    await Promise.allSettled(
+      (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
+        type: "participants",
+        names: participantNames,
+      }))
+    );
 
     return { statusCode: 200, body: "" };
   } catch (error) {

--- a/backend/quizRoomHandler.test.js
+++ b/backend/quizRoomHandler.test.js
@@ -32,6 +32,9 @@ beforeEach(() => {
   ddbMock.reset();
   managementApiMock.reset();
   vi.spyOn(console, 'error').mockImplementation(() => {});
+  // 参加者一覧（issue #545）: syncQuizRoom等は無条件でQueryCommandを叩くようになったため、
+  // 個々のテストで参加者一覧の内容を検証しない限りは空配列を既定値としておく
+  ddbMock.on(QueryCommand).resolves({ Items: [] });
 });
 
 describe('createQuizRoom', () => {
@@ -209,14 +212,44 @@ describe('connectQuizRoom', () => {
 
 describe('disconnectQuizRoom', () => {
   it('deletes the connection record', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
     ddbMock.on(DeleteCommand).resolves({});
     const response = await disconnectQuizRoom(wsEvent({ connectionId: 'conn-1' }));
     expect(response.statusCode).toBe(200);
     expect(ddbMock.commandCalls(DeleteCommand)[0].args[0].input.Key).toEqual({ connectionId: 'conn-1' });
   });
 
+  it('does not broadcast when the disconnected connection had no room (e.g. already gone)', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+    ddbMock.on(DeleteCommand).resolves({});
+    await disconnectQuizRoom(wsEvent({ connectionId: 'conn-1' }));
+    expect(managementApiMock.commandCalls(PostToConnectionCommand)).toHaveLength(0);
+  });
+
+  it('broadcasts the updated participant list (excluding the departed participant) to the remaining connections (issue #545)', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant', name: 'たろう' } });
+    ddbMock.on(DeleteCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+        { connectionId: 'conn-2', roomId: 'ROOM01', role: 'participant', name: 'はなこ' },
+      ],
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    const response = await disconnectQuizRoom(wsEvent({ connectionId: 'conn-1' }));
+
+    expect(response.statusCode).toBe(200);
+    const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
+    expect(postCalls).toHaveLength(2);
+    const targets = postCalls.map((call) => call.args[0].input.ConnectionId).sort();
+    expect(targets).toEqual(['conn-2', 'conn-admin']);
+    const payload = JSON.parse(Buffer.from(postCalls[0].args[0].input.Data).toString('utf-8'));
+    expect(payload).toEqual({ type: 'participants', names: ['はなこ'] });
+  });
+
   it('handles errors', async () => {
-    ddbMock.on(DeleteCommand).rejects(new Error('DynamoDB error'));
+    ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
     const response = await disconnectQuizRoom(wsEvent());
     expect(response.statusCode).toBe(500);
   });
@@ -265,7 +298,7 @@ describe('syncQuizRoom', () => {
 
     expect(response.statusCode).toBe(200);
     const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
-    expect(postCalls).toHaveLength(2);
+    expect(postCalls).toHaveLength(3);
     const buzzPayload = JSON.parse(Buffer.from(postCalls[1].args[0].input.Data).toString('utf-8'));
     expect(buzzPayload).toEqual({ type: 'buzz', name: 'たろう', connectionId: 'conn-2' });
   });
@@ -281,7 +314,7 @@ describe('syncQuizRoom', () => {
 
     await syncQuizRoom(wsEvent({ connectionId: 'conn-1' }));
 
-    expect(managementApiMock.commandCalls(PostToConnectionCommand)).toHaveLength(1);
+    expect(managementApiMock.commandCalls(PostToConnectionCommand)).toHaveLength(2);
   });
 
   it('also sends the current point standings to a reconnecting/late-joining participant (issue #519)', async () => {
@@ -296,7 +329,7 @@ describe('syncQuizRoom', () => {
     await syncQuizRoom(wsEvent({ connectionId: 'conn-1' }));
 
     const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
-    expect(postCalls).toHaveLength(2);
+    expect(postCalls).toHaveLength(3);
     const pointsPayload = JSON.parse(Buffer.from(postCalls[1].args[0].input.Data).toString('utf-8'));
     expect(pointsPayload).toEqual({ type: 'points', points: { たろう: 2, はなこ: 1 } });
   });
@@ -312,7 +345,33 @@ describe('syncQuizRoom', () => {
 
     await syncQuizRoom(wsEvent({ connectionId: 'conn-1' }));
 
-    expect(managementApiMock.commandCalls(PostToConnectionCommand)).toHaveLength(1);
+    expect(managementApiMock.commandCalls(PostToConnectionCommand)).toHaveLength(2);
+  });
+
+  it('sends the current participant list to a reconnecting/late-joining connection (issue #545)', async () => {
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
+      Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' },
+    });
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({
+      Item: { roomId: 'ROOM01', state: { type: 'phrase', content: { id: 'p1' } } },
+    });
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+        { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant', name: 'たろう' },
+        { connectionId: 'conn-2', roomId: 'ROOM01', role: 'participant', name: 'はなこ' },
+        { connectionId: 'conn-3', roomId: 'ROOM01', role: 'participant' },
+      ],
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    await syncQuizRoom(wsEvent({ connectionId: 'conn-1' }));
+
+    const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
+    const participantsPayload = JSON.parse(
+      Buffer.from(postCalls[postCalls.length - 1].args[0].input.Data).toString('utf-8')
+    );
+    expect(participantsPayload).toEqual({ type: 'participants', names: ['たろう', 'はなこ'] });
   });
 
   it('handles errors', async () => {
@@ -509,8 +568,9 @@ describe('updateQuizRoomState', () => {
 describe('setQuizRoomName', () => {
   it('saves a trimmed name on the connection record', async () => {
     ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' } });
-    ddbMock.on(QueryCommand).resolves({ Items: [{ connectionId: 'conn-1', roomId: 'ROOM01' }] });
+    ddbMock.on(QueryCommand).resolves({ Items: [{ connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' }] });
     ddbMock.on(UpdateCommand).resolves({});
+    managementApiMock.on(PostToConnectionCommand).resolves({});
 
     const response = await setQuizRoomName(wsEvent({ connectionId: 'conn-1', body: { name: '  たろう  ' } }));
 
@@ -522,13 +582,37 @@ describe('setQuizRoomName', () => {
 
   it('truncates names longer than the configured limit', async () => {
     ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' } });
-    ddbMock.on(QueryCommand).resolves({ Items: [{ connectionId: 'conn-1', roomId: 'ROOM01' }] });
+    ddbMock.on(QueryCommand).resolves({ Items: [{ connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' }] });
     ddbMock.on(UpdateCommand).resolves({});
+    managementApiMock.on(PostToConnectionCommand).resolves({});
 
     await setQuizRoomName(wsEvent({ body: { name: 'x'.repeat(50) } }));
 
     const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
     expect(updateCall.ExpressionAttributeValues[':name']).toHaveLength(20);
+  });
+
+  it('broadcasts the updated participant list (including the newly-named connection) to every connection in the room (issue #545)', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' } });
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+        { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' },
+        { connectionId: 'conn-2', roomId: 'ROOM01', role: 'participant', name: 'はなこ' },
+      ],
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    const response = await setQuizRoomName(wsEvent({ connectionId: 'conn-1', body: { name: 'たろう' } }));
+
+    expect(response.statusCode).toBe(200);
+    const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
+    expect(postCalls).toHaveLength(3);
+    const targets = postCalls.map((call) => call.args[0].input.ConnectionId).sort();
+    expect(targets).toEqual(['conn-1', 'conn-2', 'conn-admin']);
+    const payload = JSON.parse(Buffer.from(postCalls[0].args[0].input.Data).toString('utf-8'));
+    expect(payload).toEqual({ type: 'participants', names: ['たろう', 'はなこ'] });
   });
 
   it('rejects an empty (or whitespace-only) name', async () => {
@@ -569,9 +653,10 @@ describe('setQuizRoomName', () => {
   it('allows re-saving the same name for the same connection (not a duplicate of itself)', async () => {
     ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant', name: 'たろう' } });
     ddbMock.on(QueryCommand).resolves({
-      Items: [{ connectionId: 'conn-1', roomId: 'ROOM01', name: 'たろう' }],
+      Items: [{ connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant', name: 'たろう' }],
     });
     ddbMock.on(UpdateCommand).resolves({});
+    managementApiMock.on(PostToConnectionCommand).resolves({});
 
     const response = await setQuizRoomName(wsEvent({ connectionId: 'conn-1', body: { name: 'たろう' } }));
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import { useSessionStorageState } from "./hooks/useSessionStorageState";
 import { useUrlQuerySync, parseCategoriesParam } from "./hooks/useUrlQuerySync";
 import { useWakeLock } from "./hooks/useWakeLock";
 import { useQuizRoomSync } from "./hooks/useQuizRoomSync";
+import { mergeParticipantsWithPoints } from "./utils/quizRoomParticipants";
 import DetailView from "./views/DetailView";
 import PrintEfudaView from "./views/PrintEfudaView";
 import AllPhrasesView from "./views/AllPhrasesView";
@@ -130,6 +131,9 @@ function App() {
   // ポイント制（issue #519）: 名前→累計ポイントのマップ。管理者には参加者ごとの
   // ポイントを一覧表示する
   const [quizRoomPoints, setQuizRoomPoints] = useState({});
+  // 参加者一覧（issue #545）: 名前確定済みの参加者名一覧。ポイントと統合して
+  // 「参加者名（0pt含む全員）」の1つのリストとして表示する
+  const [quizRoomParticipants, setQuizRoomParticipants] = useState([]);
 
   // コメント投稿用の状態
   const [commentText, setCommentText] = useState("");
@@ -910,6 +914,7 @@ function App() {
     onState: noop,
     onBuzz: setQuizRoomBuzzedBy,
     onPoints: setQuizRoomPoints,
+    onParticipants: setQuizRoomParticipants,
   });
 
   // 早押し正誤判定（issue #546）: 「正解」「不正解」を選んだら判定結果をサーバーへ
@@ -1722,20 +1727,23 @@ function App() {
               </div>
             </div>
           )}
-          {Object.keys(quizRoomPoints).length > 0 && (
-            <div className="mx-auto mt-3 text-start" style={{ maxWidth: "320px" }}>
-              <p className="text-muted small mb-2">参加者ごとのポイント</p>
-              <div className="d-flex flex-wrap gap-2 justify-content-center">
-                {Object.entries(quizRoomPoints)
-                  .sort((a, b) => b[1] - a[1])
-                  .map(([name, point]) => (
+          {(() => {
+            // 参加者一覧（issue #545）: まだ得点していない参加者も0ptとして含めた
+            // 1つのリストに統合して表示する
+            const participantList = mergeParticipantsWithPoints(quizRoomParticipants, quizRoomPoints);
+            return participantList.length > 0 && (
+              <div className="mx-auto mt-3 text-start" style={{ maxWidth: "320px" }}>
+                <p className="text-muted small mb-2">参加者一覧</p>
+                <div className="d-flex flex-wrap gap-2 justify-content-center">
+                  {participantList.map(({ name, points }) => (
                     <div key={name} className="bg-white rounded-3 shadow-sm px-3 py-2">
-                      <span className="fw-bold notranslate">{name}</span>: {point}pt
+                      <span className="fw-bold notranslate">{name}</span>: {points}pt
                     </div>
                   ))}
+                </div>
               </div>
-            </div>
-          )}
+            );
+          })()}
         </div>
       ) : (
         <div className="mb-4">

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2721,10 +2721,67 @@ describe('App', () => {
       ws.onmessage?.({ data: JSON.stringify({ type: 'points', points: { はなこ: 1, たろう: 3 } }) });
     });
 
-    expect(screen.getByText('参加者ごとのポイント')).toBeInTheDocument();
+    expect(screen.getByText('参加者一覧')).toBeInTheDocument();
     const points = screen.getAllByText(/pt$/).map((el) => el.textContent);
     // たろう(3pt)がはなこ(1pt)より先（降順）に表示される
     expect(points).toEqual(['たろう: 3pt', 'はなこ: 1pt']);
+  }, 40000);
+
+  it('shows participants who have not scored yet as 0pt in the same list once a "participants" message arrives (issue #545)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      if (url.includes('/get-phrase?')) {
+        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', audioData: 'dummy' }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    const ws = MockWebSocket.instances[0];
+    act(() => {
+      ws.readyState = MockWebSocket.OPEN;
+      ws.onopen?.();
+    });
+
+    act(() => {
+      ws.onmessage?.({ data: JSON.stringify({ type: 'participants', names: ['たろう', 'はなこ', 'じろう'] }) });
+      ws.onmessage?.({ data: JSON.stringify({ type: 'points', points: { たろう: 3 } }) });
+    });
+
+    expect(screen.getByText('参加者一覧')).toBeInTheDocument();
+    const points = screen.getAllByText(/pt$/).map((el) => el.textContent);
+    // たろう(3pt)がまだ得点していないじろう・はなこ(0pt)より先（降順、同点は名前昇順）
+    expect(points).toEqual(['たろう: 3pt', 'じろう: 0pt', 'はなこ: 0pt']);
   }, 40000);
 
   it('broadcasts the settings actually used to fetch the admin\'s own audio, even if the admin changes the voice while that card is still being read out (issue #498)', async () => {

--- a/frontend/src/hooks/useQuizRoomSync.js
+++ b/frontend/src/hooks/useQuizRoomSync.js
@@ -17,7 +17,9 @@ const SYNC_POLL_INTERVAL_MS = 5000;
 // {type:"nameError", message}が返るのでonNameErrorを呼ぶ
 // 早押し正誤判定（issue #546）: 管理者はjudgeBuzzで正誤を送信できる。不正解と判定
 // されたときはサーバーから{type:"roundReset", excludedName}が返るのでonRoundResetを呼ぶ
-export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz, onPoints, onNameError, onRoundReset }) {
+// 参加者一覧（issue #545）: サーバーから{type:"participants", names}（名前確定済みの
+// 参加者名一覧）を受け取るたびonParticipantsを呼ぶ
+export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz, onPoints, onNameError, onRoundReset, onParticipants }) {
   const [internalStatus, setInternalStatus] = useState("idle"); // connecting|connected|error（idleはwsBaseUrl/roomId未設定時に導出する）
   const connectionStatus = (!wsBaseUrl || !roomId) ? "idle" : internalStatus;
   const wsRef = useRef(null);
@@ -26,6 +28,7 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
   const onPointsRef = useRef(onPoints);
   const onNameErrorRef = useRef(onNameError);
   const onRoundResetRef = useRef(onRoundReset);
+  const onParticipantsRef = useRef(onParticipants);
   const reconnectAttemptsRef = useRef(0);
   const reconnectTimeoutRef = useRef(null);
   const closedByCleanupRef = useRef(false);
@@ -57,6 +60,10 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
   useEffect(() => {
     onRoundResetRef.current = onRoundReset;
   }, [onRoundReset]);
+
+  useEffect(() => {
+    onParticipantsRef.current = onParticipants;
+  }, [onParticipants]);
 
   useEffect(() => {
     if (!wsBaseUrl || !roomId) {
@@ -110,6 +117,8 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
             onNameErrorRef.current?.(data.message);
           } else if (data?.type === "roundReset") {
             onRoundResetRef.current?.({ excludedName: data.excludedName });
+          } else if (data?.type === "participants") {
+            onParticipantsRef.current?.(data.names);
           }
         } catch (error) {
           console.error("Failed to parse quiz room message:", error);

--- a/frontend/src/hooks/useQuizRoomSync.test.js
+++ b/frontend/src/hooks/useQuizRoomSync.test.js
@@ -165,6 +165,18 @@ describe('useQuizRoomSync', () => {
     expect(onRoundReset).toHaveBeenCalledWith({ excludedName: 'たろう' });
   });
 
+  it('calls onParticipants when a participants message is received (issue #545)', () => {
+    const onParticipants = vi.fn();
+    renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn(), onParticipants }));
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+      MockWebSocket.instances[0].triggerMessage({ type: 'participants', names: ['たろう', 'はなこ'] });
+    });
+
+    expect(onParticipants).toHaveBeenCalledWith(['たろう', 'はなこ']);
+  });
+
   it('judgeBuzz sends judgeBuzz with the correct flag only while the connection is open', () => {
     const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
 

--- a/frontend/src/utils/quizRoomParticipants.js
+++ b/frontend/src/utils/quizRoomParticipants.js
@@ -1,0 +1,10 @@
+// クイズ大会モード（issue #545）: 参加者一覧とポイント集計（issue #519）を1つのリストへ
+// 統合する。まだ得点していない参加者も0ptとして含め、管理者・参加者どちらの画面でも
+// 同じ並び順（ポイント降順、同点は名前の昇順）で表示できるようにする
+export function mergeParticipantsWithPoints(participantNames, points) {
+  const names = new Set(participantNames);
+  Object.keys(points).forEach((name) => names.add(name));
+  return Array.from(names)
+    .map((name) => ({ name, points: points[name] || 0 }))
+    .sort((a, b) => b.points - a.points || a.name.localeCompare(b.name));
+}

--- a/frontend/src/utils/quizRoomParticipants.test.js
+++ b/frontend/src/utils/quizRoomParticipants.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { mergeParticipantsWithPoints } from './quizRoomParticipants';
+
+describe('mergeParticipantsWithPoints', () => {
+  it('includes participants who have not scored yet as 0pt', () => {
+    const result = mergeParticipantsWithPoints(['たろう', 'はなこ'], { たろう: 2 });
+    expect(result).toEqual([
+      { name: 'たろう', points: 2 },
+      { name: 'はなこ', points: 0 },
+    ]);
+  });
+
+  it('includes a scorer even if they are missing from the participant list (e.g. late-arriving broadcast)', () => {
+    const result = mergeParticipantsWithPoints(['たろう'], { たろう: 1, じろう: 3 });
+    expect(result).toEqual([
+      { name: 'じろう', points: 3 },
+      { name: 'たろう', points: 1 },
+    ]);
+  });
+
+  it('sorts by points descending, breaking ties by name ascending', () => {
+    const result = mergeParticipantsWithPoints(['はなこ', 'たろう', 'じろう'], {});
+    expect(result).toEqual([
+      { name: 'じろう', points: 0 },
+      { name: 'たろう', points: 0 },
+      { name: 'はなこ', points: 0 },
+    ]);
+  });
+
+  it('returns an empty list when there are no participants and no scorers', () => {
+    expect(mergeParticipantsWithPoints([], {})).toEqual([]);
+  });
+});

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuizRoomSync } from "../hooks/useQuizRoomSync";
 import { API_BASE_URL } from "../config";
 import { unlockAudioPlayback, playSharedAudio } from "../utils/audioUnlock";
+import { mergeParticipantsWithPoints } from "../utils/quizRoomParticipants";
 
 // クイズ大会モード（issue #470）の参加者用入口（閲覧専用）。
 // ルームコードの直接入力、または招待URL（?roomId=...）からの参加に対応する。
@@ -76,6 +77,9 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   // ポイント制（issue #519）: 名前→累計ポイントのマップ。集計単位はconnectionIdではなく
   // name（早押し機能の実装参照）なので、自分のポイントはpoints[confirmedName]で引く
   const [points, setPoints] = useState({});
+  // 参加者一覧（issue #545）: 名前確定済みの参加者名一覧。管理者側と同様、ポイントと
+  // 統合した1つのリストとして表示する
+  const [participants, setParticipants] = useState([]);
 
   // ポイント制（issue #519）: サーバーは同一ルーム内での名前重複を拒否する。拒否された
   // 場合は名前入力画面に戻し、別の名前を選び直してもらう
@@ -117,6 +121,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     onPoints: setPoints,
     onNameError: handleNameError,
     onRoundReset: handleRoundReset,
+    onParticipants: setParticipants,
   });
 
   // 早押し結果表示のリセット判定（issue #510）。ラウンドを表す値（buzzRoundKey）を
@@ -278,6 +283,23 @@ function QuizRoomView({ setView, wsBaseUrl }) {
         <p className="text-muted small mb-3">接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}</p>
         <p className="fw-bold text-dark">獲得ポイント: {points[confirmedName] || 0}</p>
         {renderParticipantContent(roomState)}
+        {(() => {
+          // 参加者一覧（issue #545）: まだ得点していない参加者も0ptとして含めた
+          // 1つのリストに統合して表示する（管理者画面と同じ並び順）
+          const participantList = mergeParticipantsWithPoints(participants, points);
+          return participantList.length > 0 && (
+            <div className="mx-auto mt-4 text-start" style={{ maxWidth: "320px" }}>
+              <p className="text-muted small mb-2">参加者一覧</p>
+              <div className="d-flex flex-wrap gap-2 justify-content-center">
+                {participantList.map(({ name, points: pt }) => (
+                  <div key={name} className="bg-white rounded-3 shadow-sm px-3 py-2">
+                    <span className={`notranslate ${name === confirmedName ? "fw-bold" : ""}`}>{name}</span>: {pt}pt
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })()}
         {buzzedBy ? (
           <p className="fw-bold text-dark mt-4">🔔 {buzzedBy.name} さんが回答しました</p>
         ) : roomState?.type === "phrase" && !excludedThisRound && (

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -8,17 +8,19 @@ const onBuzzCallbacks = [];
 const onPointsCallbacks = [];
 const onNameErrorCallbacks = [];
 const onRoundResetCallbacks = [];
+const onParticipantsCallbacks = [];
 let mockConnectionStatus = 'connected';
 const setParticipantNameMock = vi.fn();
 const buzzMock = vi.fn();
 
 vi.mock('../hooks/useQuizRoomSync', () => ({
-  useQuizRoomSync: ({ onState, onBuzz, onPoints, onNameError, onRoundReset }) => {
+  useQuizRoomSync: ({ onState, onBuzz, onPoints, onNameError, onRoundReset, onParticipants }) => {
     onStateCallbacks.push(onState);
     onBuzzCallbacks.push(onBuzz);
     onPointsCallbacks.push(onPoints);
     onNameErrorCallbacks.push(onNameError);
     onRoundResetCallbacks.push(onRoundReset);
+    onParticipantsCallbacks.push(onParticipants);
     return {
       connectionStatus: mockConnectionStatus,
       broadcastState: vi.fn(),
@@ -60,6 +62,12 @@ function emitRoundReset(payload) {
   });
 }
 
+function emitParticipants(names) {
+  act(() => {
+    onParticipantsCallbacks[onParticipantsCallbacks.length - 1]?.(names);
+  });
+}
+
 // 早押し機能（issue #510）: 参加者画面は名前入力を先に確定させないと通常画面へ進まないため、
 // 名前を関係しないテストではこのヘルパーで確定させておく
 function confirmName(name = 'たろう') {
@@ -86,6 +94,7 @@ beforeEach(() => {
   onPointsCallbacks.length = 0;
   onNameErrorCallbacks.length = 0;
   onRoundResetCallbacks.length = 0;
+  onParticipantsCallbacks.length = 0;
   mockConnectionStatus = 'connected';
   setParticipantNameMock.mockClear();
   buzzMock.mockClear();
@@ -301,6 +310,22 @@ describe('QuizRoomView', () => {
 
     emitPoints({ はなこ: 2, たろう: 5 });
     expect(screen.getByText('獲得ポイント: 2')).toBeInTheDocument();
+  });
+
+  it('shows a combined participant list (including 0pt participants), highlighting the confirmed participant\'s own name (issue #545)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName('はなこ');
+
+    emitParticipants(['はなこ', 'たろう', 'じろう']);
+    emitPoints({ たろう: 5 });
+
+    expect(screen.getByText('参加者一覧')).toBeInTheDocument();
+    const points = screen.getAllByText(/pt$/).map((el) => el.textContent);
+    expect(points).toEqual(['たろう: 5pt', 'じろう: 0pt', 'はなこ: 0pt']);
+
+    const ownEntry = screen.getByText('はなこ', { selector: 'span.fw-bold' });
+    expect(ownEntry).toBeInTheDocument();
   });
 
   it('sends the participant back to the name entry screen with an error when the server rejects a duplicate name (issue #519)', () => {


### PR DESCRIPTION
## 概要

クイズ大会モードで、現在参加している全員をリスト形式で管理者画面・参加者画面の両方に表示する（issue #545）。

## 対応内容

- 参加者が名前を確定（setName）した時点、接続の切断時（$disconnect）、再接続・遅れて参加した端末のsync要求時に、サーバーからルーム内の現在の参加者名一覧を`{type: "participants", names}`としてブロードキャストする
- 切断時は接続情報の削除後、即座に参加者一覧から消す
- 参加者一覧はポイント制（issue #519）の集計と統合し、まだ得点していない参加者も0ptとして同じ1つのリストに表示する
  - 管理者・参加者共通のマージ/ソートロジックは`frontend/src/utils/quizRoomParticipants.js`に切り出し、重複を避けている
  - 並び順はポイント降順、同点は名前昇順で管理者・参加者画面共通
  - 参加者画面では自分自身の名前だけ太字で強調する

## 設計判断（issue内で要確認だった2点、ユーザーに確認済み）

- 参加者が切断した場合、参加者一覧から即座に消す
- 参加者一覧の表示は既存のポイント表示と1つのリストに統合する

## Test plan

- [x] backend: `npm run lint` エラー0件
- [x] backend: `npm test -- --run` 1492/1492件成功
- [x] frontend: `npm run lint` エラー0件
- [x] frontend: `npm test -- --run` 163/163件成功

Closes #545


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_