### PR TITLE
chore(release): v1.36.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.36.0](https://github.com/bamiyanapp/karuta/compare/v1.35.0...v1.36.0) (2026-07-16)
+
+
+### Features
+
+* **quiz-room:** add real-time participant roster for admin and participant screens ([#553](https://github.com/bamiyanapp/karuta/issues/553)) ([2fca8e1](https://github.com/bamiyanapp/karuta/commit/2fca8e1ccd211199731f7029947d416173a86765)), closes [#545](https://github.com/bamiyanapp/karuta/issues/545)
+
 # [1.35.0](https://github.com/bamiyanapp/karuta/compare/v1.34.5...v1.35.0) (2026-07-16)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.35.0",
+    "version": "1.36.0",
     "date": "2026/07/16",
+    "body": "### Features\n\n* **quiz-room:** add real-time participant roster for admin and participant screens ([#553](https://github.com/bamiyanapp/karuta/issues/553)) ([2fca8e1](https://github.com/bamiyanapp/karuta/commit/2fca8e1ccd211199731f7029947d416173a86765)), closes [#545](https://github.com/bamiyanapp/karuta/issues/545)"
+  },
+  {
+    "version": "1.35.0",
+    "date": "2026/07/16 21:51",
     "body": "### Features\n\n* **quiz-room:** add admin buzz judgment modal with point award and retry exclusion ([#550](https://github.com/bamiyanapp/karuta/issues/550)) ([81dc809](https://github.com/bamiyanapp/karuta/commit/81dc8098d3d40bf23a0ae5bbe285f6f80f32bcb2)), closes [#546](https://github.com/bamiyanapp/karuta/issues/546)"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.35.0",
+      "version": "1.36.0",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.35.0"
+  "version": "1.36.0"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。