### PR TITLE
test(quiz-room): 切断後も得点済み参加者が一覧に残ることを明示的に検証

### DIFF
--- a/frontend/src/utils/quizRoomParticipants.test.js
+++ b/frontend/src/utils/quizRoomParticipants.test.js
@@ -18,6 +18,22 @@ describe('mergeParticipantsWithPoints', () => {
     ]);
   });
 
+  it('keeps a participant visible with their earned points after they disconnect (points are never cleared by a participant-list update, issue #545)', () => {
+    // 切断イベント（disconnectQuizRoom）はparticipants一覧からのみ名前を外し、
+    // ポイント（points）はjudgeQuizRoomBuzzでの加点時にしか変わらない。
+    // そのため切断後のparticipants一覧に名前が無くても、pointsに記録が
+    // 残っている限りは一覧に表示され続けるべきである
+    const beforeDisconnect = mergeParticipantsWithPoints(['たろう', 'はなこ'], { たろう: 2 });
+    expect(beforeDisconnect.map((p) => p.name)).toContain('たろう');
+
+    // たろうが切断し、participants一覧からは消えたが、pointsはそのまま
+    const afterDisconnect = mergeParticipantsWithPoints(['はなこ'], { たろう: 2 });
+    expect(afterDisconnect).toEqual([
+      { name: 'たろう', points: 2 },
+      { name: 'はなこ', points: 0 },
+    ]);
+  });
+
   it('sorts by points descending, breaking ties by name ascending', () => {
     const result = mergeParticipantsWithPoints(['はなこ', 'たろう', 'じろう'], {});
     expect(result).toEqual([


### PR DESCRIPTION
## 概要

issue #545の参加者一覧機能について、「セッションが切れて一覧から消えても、点数のあるユーザーは残して表示したい」という懸念に対する回帰テストを追加する。

## 対応内容

- 参加者一覧（`participants`メッセージ）とポイント集計（`points`メッセージ）は独立したサーバーメッセージであり、切断は`participants`一覧からのみ名前を外す。ポイントは`judgeQuizRoomBuzz`での加点時にしか変わらないため、既存の`mergeParticipantsWithPoints`（名前の和集合を取るロジック）により、得点済みの参加者は切断後もポイントが残っている限り一覧に表示され続ける仕様に**既になっていた**
- この挙動を明示的な回帰テストとして固定する（実装自体の変更はなし、テストのみ追加）

## Test plan

- [x] backend: `npm run lint` エラー0件
- [x] backend: `npm test -- --run` 1492/1492件成功（変更なし）
- [x] frontend: `npm run lint` エラー0件
- [x] frontend: `npm test -- --run` 164/164件成功


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_