### PR TITLE
feat(quiz-room): 参加者登録ボタンをクイズ大会ボタンの隣に配置し開始後は非表示に

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1543,52 +1543,6 @@ function App() {
               {displayContent.type === 'initial' && renderInitial()}
             </div>
 
-            {division !== "kids" && (
-              <div className="mb-4">
-                <button
-                  type="button"
-                  onClick={() => setShowPlayerRegistration(prev => !prev)}
-                  className="btn btn-sm btn-outline-secondary rounded-pill px-3"
-                >
-                  {showPlayerRegistration ? "参加者登録を閉じる" : players.length > 0 ? "参加者を編集する" : "取った人を記録する参加者を登録する"}
-                </button>
-                {showPlayerRegistration && (
-                  <div className="mt-3 mx-auto text-start" style={{ maxWidth: "360px" }}>
-                    {players.length > 0 && (
-                      <div className="d-flex flex-wrap gap-2 mb-2">
-                        {players.map(name => (
-                          <span key={name} className="badge bg-secondary d-flex align-items-center gap-1 py-2 px-3 fs-6">
-                            {name}
-                            <button
-                              type="button"
-                              onClick={() => removePlayer(name)}
-                              className="btn-close btn-close-white"
-                              style={{ fontSize: "0.6rem" }}
-                              aria-label={`${name}を削除`}
-                            ></button>
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                    {players.length < MAX_PLAYERS && (
-                      <div className="d-flex gap-2">
-                        <input
-                          type="text"
-                          value={newPlayerName}
-                          onChange={(e) => setNewPlayerName(e.target.value)}
-                          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addPlayer(); } }}
-                          placeholder="名前を入力"
-                          className="form-control"
-                          maxLength={20}
-                        />
-                        <button type="button" onClick={addPlayer} disabled={!newPlayerName.trim()} className="btn btn-outline-primary">追加</button>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            )}
-
             {displayContent.type === 'phrase' && division !== "kids" && players.length > 0 && (
               <div className="mb-4">
                 <div className="text-muted small mb-2">取った人:</div>
@@ -1746,16 +1700,63 @@ function App() {
           })()}
         </div>
       ) : (
-        <div className="mb-4">
-          <button
-            type="button"
-            onClick={createQuizRoom}
-            disabled={creatingQuizRoom}
-            className="btn btn-outline-dark px-4 rounded-pill"
-          >
-            {creatingQuizRoom ? "作成中..." : "クイズ大会のルームを作成する"}
-          </button>
-          {quizRoomCreateError && <p className="text-danger small">{quizRoomCreateError}</p>}
+        <div className="mb-4 d-flex flex-wrap gap-3 justify-content-center align-items-start">
+          <div>
+            <button
+              type="button"
+              onClick={createQuizRoom}
+              disabled={creatingQuizRoom}
+              className="btn btn-outline-dark px-4 rounded-pill"
+            >
+              {creatingQuizRoom ? "作成中..." : "クイズ大会のルームを作成する"}
+            </button>
+            {quizRoomCreateError && <p className="text-danger small">{quizRoomCreateError}</p>}
+          </div>
+          {division !== "kids" && (
+            <div>
+              <button
+                type="button"
+                onClick={() => setShowPlayerRegistration(prev => !prev)}
+                className="btn btn-sm btn-outline-secondary rounded-pill px-3"
+              >
+                {showPlayerRegistration ? "参加者登録を閉じる" : players.length > 0 ? "参加者を編集する" : "取った人を記録する参加者を登録する"}
+              </button>
+              {showPlayerRegistration && (
+                <div className="mt-3 mx-auto text-start" style={{ maxWidth: "360px" }}>
+                  {players.length > 0 && (
+                    <div className="d-flex flex-wrap gap-2 mb-2">
+                      {players.map(name => (
+                        <span key={name} className="badge bg-secondary d-flex align-items-center gap-1 py-2 px-3 fs-6">
+                          {name}
+                          <button
+                            type="button"
+                            onClick={() => removePlayer(name)}
+                            className="btn-close btn-close-white"
+                            style={{ fontSize: "0.6rem" }}
+                            aria-label={`${name}を削除`}
+                          ></button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  {players.length < MAX_PLAYERS && (
+                    <div className="d-flex gap-2">
+                      <input
+                        type="text"
+                        value={newPlayerName}
+                        onChange={(e) => setNewPlayerName(e.target.value)}
+                        onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addPlayer(); } }}
+                        placeholder="名前を入力"
+                        className="form-control"
+                        maxLength={20}
+                      />
+                      <button type="button" onClick={addPlayer} disabled={!newPlayerName.trim()} className="btn btn-outline-primary">追加</button>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
     </footer>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2380,6 +2380,55 @@ describe('App', () => {
     expect(screen.getByText('参加者を編集する')).toBeInTheDocument();
   });
 
+  it('places the player-registration button next to the quiz-room button, and hides it once a quiz room has been created (issue #549)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1', phrase: '読み札1' }] }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('エンジニア向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    fireEvent.click(screen.getByText(/決定/));
+    await waitFor(() => screen.getByText(/「Cat1」をお手元に持っていますか？/));
+    fireEvent.click(screen.getByText('はい'));
+    await waitFor(() => screen.getByText('次の札'));
+
+    // クイズ大会ルーム作成前は、参加者登録ボタンがルーム作成ボタンと並んで表示される
+    expect(screen.getByText('取った人を記録する参加者を登録する')).toBeInTheDocument();
+    expect(screen.getByText('クイズ大会のルームを作成する')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    // ルーム作成後は参加者登録ボタン自体が非表示になる
+    expect(screen.queryByText('取った人を記録する参加者を登録する')).not.toBeInTheDocument();
+    expect(screen.queryByText('参加者を編集する')).not.toBeInTheDocument();
+  });
+
   it('does not show player registration or the taken-by buttons in kids mode even if players are already registered', async () => {
     sessionStorage.setItem('players', JSON.stringify(['たろう']));
 


### PR DESCRIPTION
## 概要

「取った人を記録する参加者を登録する」ボタンを、クイズ大会のルームを作成するボタンの隣に配置し、クイズ大会開始後は非表示にする（issue #549）。

## 対応内容

- 読み札表示エリア直後にあった参加者登録ボタン・パネルを、footer内の「クイズ大会のルームを作成する」ボタンと同じ行（flexboxで横並び）へ移動
- 移動先は`quizRoom`未作成時のみ描画される分岐内のため、ルーム作成後はボタン・パネルごと自動的に非表示になる
- 既存の「取った人:」記録UI（読み札エリアの早押し記録ボタン群）自体は変更していない（`players`state・`recordTaken`等のロジックは無変更）

## Test plan

- [x] backend: `npm run lint` エラー0件
- [x] backend: `npm test -- --run` 1492/1492件成功（変更なし）
- [x] frontend: `npm run lint` エラー0件
- [x] frontend: `npm test -- --run` 165/165件成功

Closes #549


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_