### PR TITLE
fix(deps): ルート直下のpackage-lock.json同期 + E2Eテストのロール別拡充

### DIFF
--- a/frontend/e2e/quiz-room.spec.js
+++ b/frontend/e2e/quiz-room.spec.js
@@ -46,3 +46,89 @@ test('admin creates a quiz room and a participant sees the same card update in r
   await adminContext.close();
   await participantContext.close();
 });
+
+// issue #559: 管理者・回答者（早押しした本人）・未回答参加者（早押ししていない他の参加者）の
+// 3ロールを同時に登場させ、正誤判定（issue #546）後にロールごとに画面の見え方が異なることを
+// 確認する。あわせて参加者一覧（issue #545）が管理者・参加者双方に反映されることも検証する。
+// 要所ではtestInfo.attach()でスクリーンショットをHTMLレポートへ添付し、CIログだけで
+// 挙動確認が完結するようにする（打鍵による再現確認の負担を下げる）
+test('admin judges a buzz, and the responder vs. other participants end up in different states (issue #545, #546)', async ({ browser }, testInfo) => {
+  const adminContext = await browser.newContext();
+  const adminPage = await adminContext.newPage();
+
+  await adminPage.goto('/');
+  await adminPage.getByText('こども向け').click();
+  await adminPage.getByRole('button', { name: /おばけかるた/ }).click();
+  const nextButton = adminPage.getByRole('button', { name: '次の札' });
+  await expect(nextButton).toBeVisible();
+
+  await adminPage.getByText('クイズ大会のルームを作成する').click();
+  const roomInfoLink = adminPage.getByText('ルーム情報を表示（クイズ大会モード）');
+  await expect(roomInfoLink).toBeVisible({ timeout: 15000 });
+  await roomInfoLink.click();
+  const roomCode = (await adminPage.locator('p.h3.fw-bold.notranslate').innerText()).trim();
+
+  // 回答者役（このラウンドで実際に早押しする本人）
+  const responderContext = await browser.newContext();
+  const responderPage = await responderContext.newPage();
+  await responderPage.goto(`/?view=quiz-room&roomId=${roomCode}`);
+  await responderPage.getByPlaceholder('お名前').fill('たろう');
+  await responderPage.getByText('決定').click();
+  await expect(responderPage.getByText('接続状態: 接続済み')).toBeVisible({ timeout: 15000 });
+
+  // 未回答参加者役（早押しせず様子を見る側）
+  const otherContext = await browser.newContext();
+  const otherPage = await otherContext.newPage();
+  await otherPage.goto(`/?view=quiz-room&roomId=${roomCode}`);
+  await otherPage.getByPlaceholder('お名前').fill('はなこ');
+  await otherPage.getByText('決定').click();
+  await expect(otherPage.getByText('接続状態: 接続済み')).toBeVisible({ timeout: 15000 });
+
+  // 参加者一覧（issue #545）: 管理者画面に両参加者が反映される
+  await expect(adminPage.getByText('たろう: 0pt')).toBeVisible({ timeout: 15000 });
+  await expect(adminPage.getByText('はなこ: 0pt')).toBeVisible();
+
+  await nextButton.click();
+  await expect(adminPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 30000 });
+  await expect(responderPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 15000 });
+  await expect(otherPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 15000 });
+
+  // 回答者が早押しする
+  await responderPage.getByRole('button', { name: '回答する' }).click();
+
+  // 管理者に判定モーダルが自動表示される（issue #546）
+  await expect(adminPage.getByText('🔔 たろう さんが回答しました')).toBeVisible({ timeout: 15000 });
+  await testInfo.attach('admin-judgment-modal', { body: await adminPage.screenshot({ fullPage: true }), contentType: 'image/png' });
+
+  // 回答者本人・未回答参加者のどちらの画面にも回答者名が表示され、早押しボタンは無くなる
+  await expect(responderPage.getByText('🔔 たろう さんが回答しました')).toBeVisible({ timeout: 15000 });
+  await expect(otherPage.getByText('🔔 たろう さんが回答しました')).toBeVisible({ timeout: 15000 });
+  await expect(otherPage.getByRole('button', { name: '回答する' })).not.toBeVisible();
+
+  // 管理者が不正解と判定する
+  await adminPage.getByRole('button', { name: '不正解', exact: true }).click();
+
+  // 未回答参加者（はなこ）は早押しボタンが復活するが、誤答した本人（たろう）は
+  // このラウンド中は復活しない（issue #546）
+  await expect(otherPage.getByRole('button', { name: '回答する' })).toBeVisible({ timeout: 15000 });
+  await expect(responderPage.getByRole('button', { name: '回答する' })).not.toBeVisible();
+  await testInfo.attach('other-participant-can-rebuzz', { body: await otherPage.screenshot({ fullPage: true }), contentType: 'image/png' });
+  await testInfo.attach('responder-excluded-this-round', { body: await responderPage.screenshot({ fullPage: true }), contentType: 'image/png' });
+
+  // 未回答参加者（はなこ）が早押しする
+  await otherPage.getByRole('button', { name: '回答する' }).click();
+  await expect(adminPage.getByText('🔔 はなこ さんが回答しました')).toBeVisible({ timeout: 15000 });
+
+  // 管理者が正解と判定する
+  await adminPage.getByRole('button', { name: '正解', exact: true }).click();
+
+  // ポイントが参加者一覧に反映される（管理者・参加者双方、issue #519, #545）
+  await expect(adminPage.getByText('はなこ: 1pt')).toBeVisible({ timeout: 15000 });
+  await expect(adminPage.getByText('たろう: 0pt')).toBeVisible();
+  await expect(otherPage.getByText('獲得ポイント: 1')).toBeVisible({ timeout: 15000 });
+  await testInfo.attach('admin-after-correct-judgment', { body: await adminPage.screenshot({ fullPage: true }), contentType: 'image/png' });
+
+  await adminContext.close();
+  await responderContext.close();
+  await otherContext.close();
+});

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -19,6 +19,10 @@ export default defineConfig({
   use: {
     baseURL: 'http://localhost:4173',
     trace: 'on-first-retry',
+    // 失敗時のスクリーンショットをHTMLレポートに自動添付し、CIログだけで
+    // 状態確認できるようにする（issue #559）。成功時の要所のスクリーンショットは
+    // 各テスト内でtestInfo.attach()により明示的に添付する
+    screenshot: 'only-on-failure',
     // 環境に応じてPlaywrightバンドルのChromiumダウンロードを避け、
     // 事前インストール済みのバイナリを使う（このリポジトリのCI/開発環境の既定パス）
     launchOptions: process.env.PLAYWRIGHT_CHROMIUM_PATH

--- a/package-lock.json
+++ b/package-lock.json
@@ -372,6 +372,37 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-filter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.0.tgz",
+      "integrity": "sha512-DPp6hkUjvwIivxbkrTiLXeRswNv1A/4GFA2X6scXma0AMa9632V3TwxmrlkUIEtUktiM3Ln+RrSH2xlP3/jUTw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0",
+        "argue-cli": "^3.1.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@commitlint/resolve-extends": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",
@@ -1417,6 +1448,21 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/argue-cli": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.1.0.tgz",
+      "integrity": "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
     },
     "node_modules/argv-formatter": {
       "version": "1.0.0",


### PR DESCRIPTION
## 概要

同一作業ブランチ（既存のオープンなPR）への追加コミットのため、このPRには2つの独立した変更が含まれています。

### 1. ルート直下のpackage-lock.jsonをpackage.jsonと同期させる

mainへのpush時にCIで走る`commitlint`ジョブ（`reusable-ci.yml`）が失敗していた件の調査・修正。

`commitlint`ジョブは実際のcommitlint検証より前に、リポジトリルート直下で`npm ci`により依存関係をインストールする構成になっている。ルート直下の`package-lock.json`が`package.json`の依存範囲と同期しておらず、`npm ci`が

```
npm error Missing: conventional-commits-filter@6.0.1 from lock file
npm error Missing: conventional-commits-parser@7.1.0 from lock file
npm error Missing: argue-cli@3.1.0 from lock file
```

で失敗していた。直前のコミットメッセージの体裁とは無関係な原因。ルートで`npm install`を実行し、`package-lock.json`のみを再生成して同期させた（`package.json`自体の変更はなし）。

### 2. E2Eテストのロール別拡充とスクリーンショット添付（issue #559）

クイズ大会モードの直近の機能追加（早押し・正誤判定・参加者一覧・ポイント制）に対し、ロール別（管理者・回答者・未回答参加者）の実挙動をE2Eで確認できていなかった問題に対応。

- 管理者・回答者（早押しした本人）・未回答参加者（早押ししない他の参加者）の3ブラウザコンテキストを同時に登場させるシナリオを追加
- 早押し→管理者への判定モーダル自動表示→不正解判定（誤答者は再早押し不可、他の参加者は早押しボタン復活）→正解判定（参加者一覧・ポイントへの反映）までを検証
- `playwright.config.js`に`screenshot: 'only-on-failure'`を設定し、要所では`testInfo.attach()`で成功パスのスクリーンショットもHTMLレポートへ添付（打鍵確認の負担軽減）

## Test plan

- [x] `npm ci --dry-run`が成功することを確認（package-lock.json同期）
- [x] `npx commitlint --from HEAD~1 --to HEAD --verbose`が0件の問題で成功することを確認
- [x] `npx playwright test --list`で新規シナリオが構文的に正しく認識されることを確認
- [x] frontend: `npm run lint` エラー0件 / `npm test -- --run` 165/165件成功
- [x] backend: `npm run lint` エラー0件 / `npm test -- --run` 1492/1492件成功（変更なし）
- [ ] E2E（`frontend-e2e-test`ジョブ）が実際にデプロイ済みのAWS環境に対してグリーンになることは、このPRのCI実行結果で確認する（このセッションからは実行不可）

Closes #559
