### PR TITLE
feat(e2e): PlaywrightのJSカバレッジ算出結果をログへ出力する

### DIFF
--- a/docs/cicd-pipeline-specification.md
+++ b/docs/cicd-pipeline-specification.md
@@ -28,6 +28,10 @@ karutaの`main`は「変更は必ずPR経由」のリポジトリルールで保
 
 このリポジトリにはE2E専用のモックバックエンドが存在しないため、**E2Eテストは実際にデプロイ済みの本番相当AWS環境（`frontend/src/config.js`のAPI_BASE_URL/WS_BASE_URLが指すAPI Gateway・DynamoDB・WebSocket API）に対して実行する**。CI実行のたびに実際のクイズ大会モードのルームが作成されるが、ルームはDynamoDBのTTLにより24時間で自動失効するため、テスト実行のたびに残骸が蓄積し続けることはない。
 
+### JSカバレッジのログ出力（issue #541）
+
+E2Eテスト実行中に読み込まれたJS（フロントエンドのビルド成果物のみ、Chromiumの`page.coverage`APIで計測）のカバレッジを`monocart-reporter`（`frontend/playwright.config.js`のreporter設定、`frontend/e2e/coverage.js`のヘルパー経由で各テストが呼び出す）で収集し、`frontend/coverage/coverage-summary.json`へ`frontend-test`ジョブのユニットテストカバレッジと同じ形式で出力する。`frontend-e2e-test`ジョブ側で`check-coverage-threshold`複合アクション（dev-standards）をthreshold未指定（表示のみ）で再利用し、Job Summary・ログへ表示する。閾値によるゲートは現時点では行っていない（要否は別途検討）。カバレッジ算出には`vite.config.js`の`build.sourcemap: true`が必要（ビルド成果物を元のソースファイル単位へマッピングするため）。
+
 ## 有効化・無効化しているジョブ（`ci.yml` 固有、issue #461）
 
 `reusable-ci.yml`が提供する任意ジョブのうち、karutaでは以下のように設定している。

--- a/frontend/e2e/coverage.js
+++ b/frontend/e2e/coverage.js
@@ -1,0 +1,40 @@
+import { addCoverageReport } from 'monocart-reporter';
+
+// E2Eテスト実行中に読み込まれたJSのカバレッジ（issue #541）を計測するヘルパー。
+// page.coverage.*はChromium限定のCDP APIのため、このリポジトリのE2E設定
+// （Chromiumのみを対象、playwright.config.js参照）でのみ使う前提とする。
+// startCoverageはページ作成直後・最初のgoto()より前に呼び、resetOnNavigation: false
+// によりページ内遷移をまたいで蓄積する。stopCoverageで収集した結果は
+// monocart-reporter（playwright.config.jsのreporter設定）のグローバルカバレッジ
+// レポートへ集約され、frontend/coverage/coverage-summary.jsonへ出力される。
+export async function startCoverage(page) {
+  await page.coverage.startJSCoverage({ resetOnNavigation: false });
+}
+
+export async function stopCoverage(page, testInfo) {
+  // テストタイムアウト等でこの呼び出し前にPlaywrightがページ/コンテキストを
+  // 強制的に閉じることがある（実機検証で確認済み）。カバレッジ収集はあくまで
+  // 補助的な計測であり、その失敗が本来のテスト失敗原因を上書き・隠蔽して
+  // しまわないよう、ここでの例外は握りつぶしログのみ出す
+  if (page.isClosed()) {
+    return;
+  }
+  try {
+    const coverage = await page.coverage.stopJSCoverage();
+    await addCoverageReport(coverage, testInfo);
+  } catch (error) {
+    console.warn(`Failed to collect JS coverage: ${error.message}`);
+  }
+}
+
+// テストタイムアウト等でPlaywrightがコンテキストを既に強制的に閉じていることがあり、
+// そのままcontext.close()を呼ぶと「Target...has been closed」という無関係な二次エラーで
+// 本来のテスト失敗原因を上書きしてしまう（実機検証で確認済み）。finally節での後始末を
+// 安全に行うためのヘルパー
+export async function closeContext(context) {
+  try {
+    await context.close();
+  } catch (error) {
+    console.warn(`Failed to close browser context: ${error.message}`);
+  }
+}

--- a/frontend/e2e/quiz-room.spec.js
+++ b/frontend/e2e/quiz-room.spec.js
@@ -1,50 +1,63 @@
 import { test, expect } from '@playwright/test';
+import { startCoverage, stopCoverage, closeContext } from './coverage.js';
 
 // クイズ大会モード（issue #470）の管理者→参加者リアルタイム同期を、実際にデプロイ済みの
 // バックエンド（REST API + WebSocket API）に対してブラウザ2つ（別コンテキスト＝別端末相当）で検証する。
 // このリポジトリにはE2E用のモックバックエンドが存在しないため、本番相当のAWS環境に
 // 実際にルームを作成する（TTLで24時間後に自動失効するため、テスト実行が残骸を蓄積し続けることはない）。
-test('admin creates a quiz room and a participant sees the same card update in real time', async ({ browser }) => {
+test('admin creates a quiz room and a participant sees the same card update in real time', async ({ browser }, testInfo) => {
   const adminContext = await browser.newContext();
   const adminPage = await adminContext.newPage();
-
-  await adminPage.goto('/');
-  await adminPage.getByText('こども向け').click();
-  await adminPage.getByRole('button', { name: /おばけかるた/ }).click();
-  const nextButton = adminPage.getByRole('button', { name: '次の札' });
-  await expect(nextButton).toBeVisible();
-
-  await adminPage.getByText('クイズ大会のルームを作成する').click();
-  const roomInfoLink = adminPage.getByText('ルーム情報を表示（クイズ大会モード）');
-  await expect(roomInfoLink).toBeVisible({ timeout: 15000 });
-  await roomInfoLink.click();
-
-  const roomCode = (await adminPage.locator('p.h3.fw-bold.notranslate').innerText()).trim();
-  expect(roomCode).toMatch(/^[A-Z2-9]{6}$/);
+  await startCoverage(adminPage);
 
   const participantContext = await browser.newContext();
-  const participantPage = await participantContext.newPage();
-  await participantPage.goto(`/?view=quiz-room&roomId=${roomCode}`);
+  let participantPage = null;
 
-  await expect(participantPage.getByText('クイズ大会モード（参加者）')).toBeVisible();
-  // 早押し機能（issue #510）: 参加者はまず名前を入力してから通常の参加者画面へ進む
-  await participantPage.getByPlaceholder('お名前').fill('たろう');
-  await participantPage.getByText('決定').click();
-  await expect(participantPage.getByText('接続状態: 接続済み')).toBeVisible({ timeout: 15000 });
-  await expect(participantPage.getByText('ホストの操作を待っています...')).toBeVisible();
+  try {
+    await adminPage.goto('/');
+    await adminPage.getByText('こども向け').click();
+    await adminPage.getByRole('button', { name: /おばけかるた/ }).click();
+    const nextButton = adminPage.getByRole('button', { name: '次の札' });
+    await expect(nextButton).toBeVisible();
 
-  await nextButton.click();
+    await adminPage.getByText('クイズ大会のルームを作成する').click();
+    const roomInfoLink = adminPage.getByText('ルーム情報を表示（クイズ大会モード）');
+    await expect(roomInfoLink).toBeVisible({ timeout: 15000 });
+    await roomInfoLink.click();
 
-  // /get-phraseはPolly音声合成（未キャッシュ時）を伴うため、Lambdaコールドスタートを
-  // 含めると数秒〜十数秒かかることがある
-  await expect(adminPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 30000 });
-  await expect(participantPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 15000 });
-  const adminPhraseText = await adminPage.locator('.yomifuda-phrase').innerText();
-  const participantPhraseText = await participantPage.locator('.yomifuda-phrase').innerText();
-  expect(participantPhraseText).toBe(adminPhraseText);
+    const roomCode = (await adminPage.locator('p.h3.fw-bold.notranslate').innerText()).trim();
+    expect(roomCode).toMatch(/^[A-Z2-9]{6}$/);
 
-  await adminContext.close();
-  await participantContext.close();
+    participantPage = await participantContext.newPage();
+    await startCoverage(participantPage);
+    await participantPage.goto(`/?view=quiz-room&roomId=${roomCode}`);
+
+    await expect(participantPage.getByText('クイズ大会モード（参加者）')).toBeVisible();
+    // 早押し機能（issue #510）: 参加者はまず名前を入力してから通常の参加者画面へ進む
+    await participantPage.getByPlaceholder('お名前').fill('たろう');
+    await participantPage.getByText('決定').click();
+    await expect(participantPage.getByText('接続状態: 接続済み')).toBeVisible({ timeout: 15000 });
+    await expect(participantPage.getByText('ホストの操作を待っています...')).toBeVisible();
+
+    await nextButton.click();
+
+    // /get-phraseはPolly音声合成（未キャッシュ時）を伴うため、Lambdaコールドスタートを
+    // 含めると数秒〜十数秒かかることがある
+    await expect(adminPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 30000 });
+    await expect(participantPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 15000 });
+    const adminPhraseText = await adminPage.locator('.yomifuda-phrase').innerText();
+    const participantPhraseText = await participantPage.locator('.yomifuda-phrase').innerText();
+    expect(participantPhraseText).toBe(adminPhraseText);
+  } finally {
+    // カバレッジ計測（issue #541）: 失敗時も可能な範囲でカバレッジを収集するため、
+    // コンテキストを閉じる前にtry節の成否に関わらず停止・収集する
+    await stopCoverage(adminPage, testInfo);
+    if (participantPage) {
+      await stopCoverage(participantPage, testInfo);
+    }
+    await closeContext(adminContext);
+    await closeContext(participantContext);
+  }
 });
 
 // issue #559: 管理者・回答者（早押しした本人）・未回答参加者（早押ししていない他の参加者）の
@@ -55,80 +68,97 @@ test('admin creates a quiz room and a participant sees the same card update in r
 test('admin judges a buzz, and the responder vs. other participants end up in different states (issue #545, #546)', async ({ browser }, testInfo) => {
   const adminContext = await browser.newContext();
   const adminPage = await adminContext.newPage();
+  await startCoverage(adminPage);
 
-  await adminPage.goto('/');
-  await adminPage.getByText('こども向け').click();
-  await adminPage.getByRole('button', { name: /おばけかるた/ }).click();
-  const nextButton = adminPage.getByRole('button', { name: '次の札' });
-  await expect(nextButton).toBeVisible();
-
-  await adminPage.getByText('クイズ大会のルームを作成する').click();
-  const roomInfoLink = adminPage.getByText('ルーム情報を表示（クイズ大会モード）');
-  await expect(roomInfoLink).toBeVisible({ timeout: 15000 });
-  await roomInfoLink.click();
-  const roomCode = (await adminPage.locator('p.h3.fw-bold.notranslate').innerText()).trim();
-
-  // 回答者役（このラウンドで実際に早押しする本人）
   const responderContext = await browser.newContext();
-  const responderPage = await responderContext.newPage();
-  await responderPage.goto(`/?view=quiz-room&roomId=${roomCode}`);
-  await responderPage.getByPlaceholder('お名前').fill('たろう');
-  await responderPage.getByText('決定').click();
-  await expect(responderPage.getByText('接続状態: 接続済み')).toBeVisible({ timeout: 15000 });
-
-  // 未回答参加者役（早押しせず様子を見る側）
   const otherContext = await browser.newContext();
-  const otherPage = await otherContext.newPage();
-  await otherPage.goto(`/?view=quiz-room&roomId=${roomCode}`);
-  await otherPage.getByPlaceholder('お名前').fill('はなこ');
-  await otherPage.getByText('決定').click();
-  await expect(otherPage.getByText('接続状態: 接続済み')).toBeVisible({ timeout: 15000 });
+  let responderPage = null;
+  let otherPage = null;
 
-  // 参加者一覧（issue #545）: 管理者画面に両参加者が反映される
-  await expect(adminPage.getByText('たろう: 0pt')).toBeVisible({ timeout: 15000 });
-  await expect(adminPage.getByText('はなこ: 0pt')).toBeVisible();
+  try {
+    await adminPage.goto('/');
+    await adminPage.getByText('こども向け').click();
+    await adminPage.getByRole('button', { name: /おばけかるた/ }).click();
+    const nextButton = adminPage.getByRole('button', { name: '次の札' });
+    await expect(nextButton).toBeVisible();
 
-  await nextButton.click();
-  await expect(adminPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 30000 });
-  await expect(responderPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 15000 });
-  await expect(otherPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 15000 });
+    await adminPage.getByText('クイズ大会のルームを作成する').click();
+    const roomInfoLink = adminPage.getByText('ルーム情報を表示（クイズ大会モード）');
+    await expect(roomInfoLink).toBeVisible({ timeout: 15000 });
+    await roomInfoLink.click();
+    const roomCode = (await adminPage.locator('p.h3.fw-bold.notranslate').innerText()).trim();
 
-  // 回答者が早押しする
-  await responderPage.getByRole('button', { name: '回答する' }).click();
+    // 回答者役（このラウンドで実際に早押しする本人）
+    responderPage = await responderContext.newPage();
+    await startCoverage(responderPage);
+    await responderPage.goto(`/?view=quiz-room&roomId=${roomCode}`);
+    await responderPage.getByPlaceholder('お名前').fill('たろう');
+    await responderPage.getByText('決定').click();
+    await expect(responderPage.getByText('接続状態: 接続済み')).toBeVisible({ timeout: 15000 });
 
-  // 管理者に判定モーダルが自動表示される（issue #546）
-  await expect(adminPage.getByText('🔔 たろう さんが回答しました')).toBeVisible({ timeout: 15000 });
-  await testInfo.attach('admin-judgment-modal', { body: await adminPage.screenshot({ fullPage: true }), contentType: 'image/png' });
+    // 未回答参加者役（早押しせず様子を見る側）
+    otherPage = await otherContext.newPage();
+    await startCoverage(otherPage);
+    await otherPage.goto(`/?view=quiz-room&roomId=${roomCode}`);
+    await otherPage.getByPlaceholder('お名前').fill('はなこ');
+    await otherPage.getByText('決定').click();
+    await expect(otherPage.getByText('接続状態: 接続済み')).toBeVisible({ timeout: 15000 });
 
-  // 回答者本人・未回答参加者のどちらの画面にも回答者名が表示され、早押しボタンは無くなる
-  await expect(responderPage.getByText('🔔 たろう さんが回答しました')).toBeVisible({ timeout: 15000 });
-  await expect(otherPage.getByText('🔔 たろう さんが回答しました')).toBeVisible({ timeout: 15000 });
-  await expect(otherPage.getByRole('button', { name: '回答する' })).not.toBeVisible();
+    // 参加者一覧（issue #545）: 管理者画面に両参加者が反映される
+    await expect(adminPage.getByText('たろう: 0pt')).toBeVisible({ timeout: 15000 });
+    await expect(adminPage.getByText('はなこ: 0pt')).toBeVisible();
 
-  // 管理者が不正解と判定する
-  await adminPage.getByRole('button', { name: '不正解', exact: true }).click();
+    await nextButton.click();
+    await expect(adminPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 30000 });
+    await expect(responderPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 15000 });
+    await expect(otherPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 15000 });
 
-  // 未回答参加者（はなこ）は早押しボタンが復活するが、誤答した本人（たろう）は
-  // このラウンド中は復活しない（issue #546）
-  await expect(otherPage.getByRole('button', { name: '回答する' })).toBeVisible({ timeout: 15000 });
-  await expect(responderPage.getByRole('button', { name: '回答する' })).not.toBeVisible();
-  await testInfo.attach('other-participant-can-rebuzz', { body: await otherPage.screenshot({ fullPage: true }), contentType: 'image/png' });
-  await testInfo.attach('responder-excluded-this-round', { body: await responderPage.screenshot({ fullPage: true }), contentType: 'image/png' });
+    // 回答者が早押しする
+    await responderPage.getByRole('button', { name: '回答する' }).click();
 
-  // 未回答参加者（はなこ）が早押しする
-  await otherPage.getByRole('button', { name: '回答する' }).click();
-  await expect(adminPage.getByText('🔔 はなこ さんが回答しました')).toBeVisible({ timeout: 15000 });
+    // 管理者に判定モーダルが自動表示される（issue #546）
+    await expect(adminPage.getByText('🔔 たろう さんが回答しました')).toBeVisible({ timeout: 15000 });
+    await testInfo.attach('admin-judgment-modal', { body: await adminPage.screenshot({ fullPage: true }), contentType: 'image/png' });
 
-  // 管理者が正解と判定する
-  await adminPage.getByRole('button', { name: '正解', exact: true }).click();
+    // 回答者本人・未回答参加者のどちらの画面にも回答者名が表示され、早押しボタンは無くなる
+    await expect(responderPage.getByText('🔔 たろう さんが回答しました')).toBeVisible({ timeout: 15000 });
+    await expect(otherPage.getByText('🔔 たろう さんが回答しました')).toBeVisible({ timeout: 15000 });
+    await expect(otherPage.getByRole('button', { name: '回答する' })).not.toBeVisible();
 
-  // ポイントが参加者一覧に反映される（管理者・参加者双方、issue #519, #545）
-  await expect(adminPage.getByText('はなこ: 1pt')).toBeVisible({ timeout: 15000 });
-  await expect(adminPage.getByText('たろう: 0pt')).toBeVisible();
-  await expect(otherPage.getByText('獲得ポイント: 1')).toBeVisible({ timeout: 15000 });
-  await testInfo.attach('admin-after-correct-judgment', { body: await adminPage.screenshot({ fullPage: true }), contentType: 'image/png' });
+    // 管理者が不正解と判定する
+    await adminPage.getByRole('button', { name: '不正解', exact: true }).click();
 
-  await adminContext.close();
-  await responderContext.close();
-  await otherContext.close();
+    // 未回答参加者（はなこ）は早押しボタンが復活するが、誤答した本人（たろう）は
+    // このラウンド中は復活しない（issue #546）
+    await expect(otherPage.getByRole('button', { name: '回答する' })).toBeVisible({ timeout: 15000 });
+    await expect(responderPage.getByRole('button', { name: '回答する' })).not.toBeVisible();
+    await testInfo.attach('other-participant-can-rebuzz', { body: await otherPage.screenshot({ fullPage: true }), contentType: 'image/png' });
+    await testInfo.attach('responder-excluded-this-round', { body: await responderPage.screenshot({ fullPage: true }), contentType: 'image/png' });
+
+    // 未回答参加者（はなこ）が早押しする
+    await otherPage.getByRole('button', { name: '回答する' }).click();
+    await expect(adminPage.getByText('🔔 はなこ さんが回答しました')).toBeVisible({ timeout: 15000 });
+
+    // 管理者が正解と判定する
+    await adminPage.getByRole('button', { name: '正解', exact: true }).click();
+
+    // ポイントが参加者一覧に反映される（管理者・参加者双方、issue #519, #545）
+    await expect(adminPage.getByText('はなこ: 1pt')).toBeVisible({ timeout: 15000 });
+    await expect(adminPage.getByText('たろう: 0pt')).toBeVisible();
+    await expect(otherPage.getByText('獲得ポイント: 1')).toBeVisible({ timeout: 15000 });
+    await testInfo.attach('admin-after-correct-judgment', { body: await adminPage.screenshot({ fullPage: true }), contentType: 'image/png' });
+  } finally {
+    // カバレッジ計測（issue #541）: 失敗時も可能な範囲でカバレッジを収集するため、
+    // コンテキストを閉じる前にtry節の成否に関わらず停止・収集する
+    await stopCoverage(adminPage, testInfo);
+    if (responderPage) {
+      await stopCoverage(responderPage, testInfo);
+    }
+    if (otherPage) {
+      await stopCoverage(otherPage, testInfo);
+    }
+    await closeContext(adminContext);
+    await closeContext(responderContext);
+    await closeContext(otherContext);
+  }
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "eslint-plugin-react-refresh": "^0.5.0",
         "globals": "^17.0.0",
         "jsdom": "^29.0.0",
+        "monocart-reporter": "^2.12.2",
         "vite": "^6.0.0",
         "vite-plugin-pwa": "^1.3.0",
         "vitest": "^4.0.0"
@@ -3317,10 +3318,47 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3338,6 +3376,32 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-loose": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
+      "integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -3870,12 +3934,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/console-grid": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/console-grid/-/console-grid-2.2.4.tgz",
+      "integrity": "sha512-OLjCRTiHhOpTRo9lQp/2FgJDyq5uQHwkEmVJulEnQ6JVf27oKKzXHZnNOv/e72V4++UdMZCrDWtvXW5sx4lyQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -4057,6 +4166,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4110,6 +4226,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -4117,6 +4250,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/devlop": {
@@ -4160,6 +4304,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eight-colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.3.tgz",
+      "integrity": "sha512-4B54S2Qi4pJjeHmCbDIsveQZWQ/TSSQng4ixYJ9/SYHHpeS5nYK0pzcHvWzWUfRsvJQjwoIENhAwqg59thQceg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -4188,6 +4346,16 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/entities": {
       "version": "8.0.0",
@@ -4418,6 +4586,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -4838,6 +5013,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -5250,6 +5435,78 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -5303,6 +5560,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -6179,6 +6443,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6188,6 +6465,50 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/koa": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.1.tgz",
+      "integrity": "sha512-e7IpWJrnanNUroVK2taAgMxoEZvHLXdQiNjeExSu/DEIWm83jaKGBgb7tLmu2rMYpA027qFB3iLR/k3AVpFRnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "content-disposition": "~1.0.1",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
+        "delegates": "^1.0.0",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/koa-static-resolver": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/koa-static-resolver/-/koa-static-resolver-1.0.6.tgz",
+      "integrity": "sha512-ZX5RshSzH8nFn05/vUNQzqw32nEigsPa67AVUr6ZuQxuGdnCcTLcdgr4C81+YbJjpgqKHfacMBd7NmJIbj7fXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -6279,6 +6600,13 @@
       "bin": {
         "lz-string": "bin/bin.js"
       }
+    },
+    "node_modules/lz-utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/lz-utils/-/lz-utils-2.1.1.tgz",
+      "integrity": "sha512-d3Thjos0PSJQAoyMj6vipSSrtrRHS7DImqUNR8x9NW3+zQIftPIbMJAWhi5nPdg5Q9zHz6lxtN8kp/VdMlhi/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -6500,6 +6828,16 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -6943,6 +7281,33 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -6976,6 +7341,82 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/monocart-coverage-reports": {
+      "version": "2.12.12",
+      "resolved": "https://registry.npmjs.org/monocart-coverage-reports/-/monocart-coverage-reports-2.12.12.tgz",
+      "integrity": "sha512-d9FdUr2dn58Crweon0IE0zVi8r/i4vLvfvb2G7eL5vL5LfrxCB2X6F6qzuiwV6RioA4zbAI//7CYi6LjCvN3zA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-loose": "^8.5.2",
+        "acorn-walk": "^8.3.5",
+        "commander": "^14.0.3",
+        "console-grid": "^2.2.4",
+        "eight-colors": "^1.3.3",
+        "foreground-child": "^4.0.3",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "lz-utils": "^2.1.1",
+        "monocart-locator": "^1.0.3"
+      },
+      "bin": {
+        "mcr": "lib/cli.js"
+      }
+    },
+    "node_modules/monocart-coverage-reports/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/monocart-coverage-reports/node_modules/foreground-child": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-4.0.3.tgz",
+      "integrity": "sha512-yeXZaNbCBGaT9giTpLPBdtedzjwhlJBUoL/R4BVQU5mn0TQXOHwVIl1Q2DMuBIdNno4ktA1abZ7dQFVxD6uHxw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/monocart-locator": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/monocart-locator/-/monocart-locator-1.0.3.tgz",
+      "integrity": "sha512-pe29W2XAoA1WQmZZqxXoP7s06ZEXUhcb81086v68cqjk1HnVL7Q/iU/WJnnetxjPcLqwb4qG8vaSGUOMQU602g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/monocart-reporter": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/monocart-reporter/-/monocart-reporter-2.12.2.tgz",
+      "integrity": "sha512-LkQQVeZvpYht4AmR76lBZj21pUxRKtTUmISktSbYQyDw09egqNJ3GJiM5d3QvtfobpogY8SdmEXml8wF9Rkrfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "console-grid": "^2.2.4",
+        "eight-colors": "^1.3.3",
+        "koa": "^3.2.1",
+        "koa-static-resolver": "^1.0.6",
+        "lz-utils": "^2.1.1",
+        "monocart-coverage-reports": "^2.12.12",
+        "monocart-locator": "^1.0.3"
+      },
+      "bin": {
+        "monocart": "lib/cli.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7007,6 +7448,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -7071,6 +7522,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/optionator": {
@@ -7206,6 +7670,16 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/path-exists": {
@@ -7906,6 +8380,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -8125,6 +8606,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.2.0",
@@ -8489,6 +8980,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
@@ -8535,6 +9036,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -8559,6 +9070,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -8872,6 +9416,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vfile": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-react-refresh": "^0.5.0",
     "globals": "^17.0.0",
     "jsdom": "^29.0.0",
+    "monocart-reporter": "^2.12.2",
     "vite": "^6.0.0",
     "vite-plugin-pwa": "^1.3.0",
     "vitest": "^4.0.0"

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -15,7 +15,29 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  reporter: process.env.CI ? [['html', { open: 'never' }]] : 'list',
+  reporter: [
+    process.env.CI ? ['html', { open: 'never' }] : ['list'],
+    // JSカバレッジ算出結果のログ出力（issue #541）。frontend/e2e/coverage.jsの
+    // startCoverage/stopCoverageで各ページのカバレッジを収集し、ここで登録した
+    // グローバルレポートへ集約する。console-summaryでコンソールへ要約を出力しつつ、
+    // json-summaryでfrontend/coverage/coverage-summary.jsonへも出力する
+    // （frontend-testジョブのユニットテストカバレッジと同じ形式・パスにすることで、
+    // dev-standardsのcheck-coverage-threshold複合アクションをそのまま再利用できる）
+    ['monocart-reporter', {
+      name: 'karuta E2E Coverage Report',
+      outputFile: './coverage/monocart-report/index.html',
+      coverage: {
+        outputDir: './coverage',
+        // vite buildの出力（バンドル・minify済み）のうち、node_modules等の
+        // ベンダーコードを除いた自アプリのソースだけをカバレッジ集計対象にする。
+        // sourcePathはsourcemap由来の正規化されたパスで、先頭が"src/..."のケースも
+        // あるため、区切り文字の有無に関わらず"src/"にマッチさせる（実機検証で、
+        // 先頭一致を考慮しないと全件除外されることを確認済み）
+        sourceFilter: (sourcePath) => /(^|[/\\])src[/\\]/.test(sourcePath),
+        reports: [['console-summary'], ['json-summary']],
+      },
+    }],
+  ],
   use: {
     baseURL: 'http://localhost:4173',
     trace: 'on-first-retry',

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -28,6 +28,11 @@ export default defineConfig({
     }),
   ],
   base: "./",
+  // E2EテストのJSカバレッジ算出（issue #541）でビルド成果物（バンドル・minify済み）を
+  // 元のソースファイル単位へマッピングするためにソースマップを出力する
+  build: {
+    sourcemap: true,
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## 概要

E2Eテスト実行中に読み込まれたフロントエンドのJSカバレッジを計測し、ユニットテスト側と同じ形式でログ・Job Summaryへ出力できるようにする（issue #541）。CI側のジョブ配線は[dev-standards PR #63](https://github.com/bamiyanapp/dev-standards/pull/63)で対応（`@v1.0.2`より新しいタグが必要）。

## 対応内容

- Chromiumの`page.coverage.startJSCoverage()`/`stopJSCoverage()`（CDP API）で各ページのJSカバレッジを収集し、`monocart-reporter`（`monocart-coverage-reports`をラップするPlaywright reporter）の`addCoverageReport()`でグローバルカバレッジレポートへ集約する方式を採用
- `frontend/e2e/coverage.js`に`startCoverage`/`stopCoverage`/`closeContext`の3ヘルパーを新設し、`quiz-room.spec.js`の各テストで作成した全ページ（管理者・参加者・回答者・未回答参加者）を計測対象にした
- `playwright.config.js`のreporter設定で`json-summary`レポートを`frontend/coverage/coverage-summary.json`へ出力（`@vitest/coverage-v8`と同一形式のため、dev-standardsの`check-coverage-threshold`複合アクションをE2E側でもそのまま再利用できる）
- `vite.config.js`に`build.sourcemap: true`を追加（ビルド成果物を元のソースファイル単位へマッピングするために必要）

## 却下した案

`v8-to-istanbul`＋`istanbul-lib-report`を自前で組み合わせて変換・集約・レポート生成する案は却下した。`monocart-reporter`が収集からIstanbul形式への変換、複数ページ・複数テストにまたがる集約、レポート生成までを一括して提供しており、自前実装より検証済みで保守コストが低いため。

## 実機検証で発見・修正した不具合

このセッションからは実AWS環境へのE2E実行はできないが、ローカルで`vite build`＋`vite preview`によるフロントエンドの静的配信のみで実際にChromiumを起動し、カバレッジ収集の実動作を確認した。この過程で2件の実装不備を発見・修正した。

1. `sourceFilter`の正規表現が`src/...`のような先頭一致（区切り文字なし）を考慮しておらず、全192ファイルが除外されていた
2. テストタイムアウト時にPlaywrightがページ/コンテキストを強制的に閉じることがあり、その状態で`stopJSCoverage()`や`context.close()`を呼ぶと無関係な二次エラーで本来の失敗原因を覆い隠していた（`coverage.js`側でクローズ済みチェック・例外の握り潰しを追加）

## Test plan

- [x] frontend: `npm run lint` エラー0件 / `npm test -- --run` 165/165件成功（変更なし）
- [x] backend: `npm run lint` エラー0件 / `npm test -- --run` 1492/1492件成功（変更なし）
- [x] ローカルで実際にChromiumを起動し、`coverage/coverage-summary.json`が正しい形式・実データで生成されることを確認済み
- [ ] 実際のAWS環境に対するE2E実行結果（クイズ大会モードの実シナリオ実行時のカバレッジ数値）はこのセッションからは確認できない

Closes #541


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_