### PR TITLE
feat(e2e): E2Eスクリーンショットを専用ブランチへ公開し確認しやすくする

### DIFF
--- a/docs/cicd-pipeline-specification.md
+++ b/docs/cicd-pipeline-specification.md
@@ -32,6 +32,16 @@ karutaの`main`は「変更は必ずPR経由」のリポジトリルールで保
 
 E2Eテスト実行中に読み込まれたJS（フロントエンドのビルド成果物のみ、Chromiumの`page.coverage`APIで計測）のカバレッジを`monocart-reporter`（`frontend/playwright.config.js`のreporter設定、`frontend/e2e/coverage.js`のヘルパー経由で各テストが呼び出す）で収集し、`frontend/coverage/coverage-summary.json`へ`frontend-test`ジョブのユニットテストカバレッジと同じ形式で出力する。`frontend-e2e-test`ジョブ側で`check-coverage-threshold`複合アクション（dev-standards）をthreshold未指定（表示のみ）で再利用し、Job Summary・ログへ表示する。閾値によるゲートは現時点では行っていない（要否は別途検討）。カバレッジ算出には`vite.config.js`の`build.sourcemap: true`が必要（ビルド成果物を元のソースファイル単位へマッピングするため）。
 
+### スクリーンショットの公開（issue #568）
+
+`frontend/e2e/screenshot.js`の`captureScreenshot()`が、`testInfo.attach()`によるPlaywright HTMLレポートへの添付に加えて、`frontend/e2e-screenshots/`へPNGファイルとしても書き出す。GitHub Actionsのアーティファクト（zip）はダウンロード・展開が必要で特にスマホ版GitHubアプリからは閲覧が難しいため、`frontend-e2e-test`ジョブ側（dev-standardsの`reusable-ci.yml`）で以下を行い、画像を直接埋め込んだ形で確認できるようにしている。
+
+1. `peaceiris/actions-gh-pages`で`frontend/e2e-screenshots/`配下のPNGを専用ブランチ`e2e-screenshots`（`runs/<run_id>/`配下、過去の実行分は`keep_files: true`で保持）へ公開する
+2. `raw.githubusercontent.com`のURLとして、Job Summaryへ画像を埋め込む
+3. `pull_request`イベントの場合は、同じ内容をPRコメントとしても投稿する（GitHubのモバイルアプリでもネイティブに画像が表示される）
+
+これらはいずれも補助的な機能であり、失敗してもE2Eテスト自体の成功/失敗判定には影響しない（各ステップに`continue-on-error: true`を付けている）。`e2e-screenshots`ブランチは実行のたびに蓄積されるため、リポジトリ肥大化への対応（古い実行分の定期削除等）は必要になった時点で別途検討する。
+
 ## 有効化・無効化しているジョブ（`ci.yml` 固有、issue #461）
 
 `reusable-ci.yml`が提供する任意ジョブのうち、karutaでは以下のように設定している。

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -17,6 +17,11 @@ dist-ssr
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+# ユニットテスト（vitest）・E2E（Playwright/monocart-reporter）双方のカバレッジ出力先（issue #541）
+/coverage/
+# E2Eの要所スクリーンショット。CI側（reusable-ci.yml）が公開ブランチへコピーする
+# 前段の一時ファイルで、リポジトリ本体には含めない（issue #568）
+/e2e-screenshots/
 
 # Editor directories and files
 .vscode/*

--- a/frontend/e2e/quiz-room.spec.js
+++ b/frontend/e2e/quiz-room.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { startCoverage, stopCoverage, closeContext } from './coverage.js';
+import { captureScreenshot } from './screenshot.js';
 
 // クイズ大会モード（issue #470）の管理者→参加者リアルタイム同期を、実際にデプロイ済みの
 // バックエンド（REST API + WebSocket API）に対してブラウザ2つ（別コンテキスト＝別端末相当）で検証する。
@@ -63,8 +64,9 @@ test('admin creates a quiz room and a participant sees the same card update in r
 // issue #559: 管理者・回答者（早押しした本人）・未回答参加者（早押ししていない他の参加者）の
 // 3ロールを同時に登場させ、正誤判定（issue #546）後にロールごとに画面の見え方が異なることを
 // 確認する。あわせて参加者一覧（issue #545）が管理者・参加者双方に反映されることも検証する。
-// 要所ではtestInfo.attach()でスクリーンショットをHTMLレポートへ添付し、CIログだけで
-// 挙動確認が完結するようにする（打鍵による再現確認の負担を下げる）
+// 要所ではcaptureScreenshot()でスクリーンショットをHTMLレポートへ添付しつつ、
+// CI側（reusable-ci.yml）が公開できるファイルとしても書き出す（issue #568）。
+// これによりCIログだけで挙動確認が完結するようにする（打鍵による再現確認の負担を下げる）
 test('admin judges a buzz, and the responder vs. other participants end up in different states (issue #545, #546)', async ({ browser }, testInfo) => {
   const adminContext = await browser.newContext();
   const adminPage = await adminContext.newPage();
@@ -118,7 +120,7 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
 
     // 管理者に判定モーダルが自動表示される（issue #546）
     await expect(adminPage.getByText('🔔 たろう さんが回答しました')).toBeVisible({ timeout: 15000 });
-    await testInfo.attach('admin-judgment-modal', { body: await adminPage.screenshot({ fullPage: true }), contentType: 'image/png' });
+    await captureScreenshot(adminPage, testInfo, 'admin-judgment-modal');
 
     // 回答者本人・未回答参加者のどちらの画面にも回答者名が表示され、早押しボタンは無くなる
     await expect(responderPage.getByText('🔔 たろう さんが回答しました')).toBeVisible({ timeout: 15000 });
@@ -132,8 +134,8 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
     // このラウンド中は復活しない（issue #546）
     await expect(otherPage.getByRole('button', { name: '回答する' })).toBeVisible({ timeout: 15000 });
     await expect(responderPage.getByRole('button', { name: '回答する' })).not.toBeVisible();
-    await testInfo.attach('other-participant-can-rebuzz', { body: await otherPage.screenshot({ fullPage: true }), contentType: 'image/png' });
-    await testInfo.attach('responder-excluded-this-round', { body: await responderPage.screenshot({ fullPage: true }), contentType: 'image/png' });
+    await captureScreenshot(otherPage, testInfo, 'other-participant-can-rebuzz');
+    await captureScreenshot(responderPage, testInfo, 'responder-excluded-this-round');
 
     // 未回答参加者（はなこ）が早押しする
     await otherPage.getByRole('button', { name: '回答する' }).click();
@@ -146,7 +148,7 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
     await expect(adminPage.getByText('はなこ: 1pt')).toBeVisible({ timeout: 15000 });
     await expect(adminPage.getByText('たろう: 0pt')).toBeVisible();
     await expect(otherPage.getByText('獲得ポイント: 1')).toBeVisible({ timeout: 15000 });
-    await testInfo.attach('admin-after-correct-judgment', { body: await adminPage.screenshot({ fullPage: true }), contentType: 'image/png' });
+    await captureScreenshot(adminPage, testInfo, 'admin-after-correct-judgment');
   } finally {
     // カバレッジ計測（issue #541）: 失敗時も可能な範囲でカバレッジを収集するため、
     // コンテキストを閉じる前にtry節の成否に関わらず停止・収集する

--- a/frontend/e2e/screenshot.js
+++ b/frontend/e2e/screenshot.js
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// スクリーンショットの保存先（issue #568）。testInfo.attach()によるPlaywright
+// HTMLレポートへの添付だけでは、特にスマホ版GitHubアプリからアーティファクトzipを
+// ダウンロード・展開する手段が事実上無く閲覧しづらいため、CI側（reusable-ci.yml）が
+// このディレクトリのPNGを別ブランチへ公開し、Job Summary・PRコメントへ
+// raw.githubusercontent.comのURLとして埋め込めるようにする
+export const SCREENSHOT_DIR = path.resolve(__dirname, '..', 'e2e-screenshots');
+
+// ページのスクリーンショットを撮影し、(1) 既存のPlaywright HTMLレポートへの
+// 添付、(2) CI側が公開できるようSCREENSHOT_DIRへのファイル書き出し、の両方を行う
+export async function captureScreenshot(page, testInfo, name) {
+  const body = await page.screenshot({ fullPage: true });
+  await testInfo.attach(name, { body, contentType: 'image/png' });
+  fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
+  fs.writeFileSync(path.join(SCREENSHOT_DIR, `${name}.png`), body);
+}


### PR DESCRIPTION
## 概要

issue #559対応でE2Eテストのスクリーンショットがアーティファクトへ保存されるようになったが、特にスマホアプリ版GitHubからはアーティファクト（zip）の閲覧が難しく確認しにくいという課題があった。本PRでは、スクリーンショットをJob Summary・PRコメントへ画像として直接埋め込み、ダウンロードなしで確認できるようにする。

対になる `dev-standards` 側の変更は [bamiyanapp/dev-standards#64](https://github.com/bamiyanapp/dev-standards/pull/64)。

## 対応内容

- `frontend/e2e/screenshot.js` に `captureScreenshot()` を新設。既存の `testInfo.attach()` によるPlaywright HTMLレポートへの添付に加えて、`frontend/e2e-screenshots/` へPNGファイルとしても書き出す
- `quiz-room.spec.js` の4箇所のスクリーンショット撮影をこのヘルパー経由に統一
- `frontend/.gitignore` に `/e2e-screenshots/` を追加（前段の一時ファイルのためリポジトリには含めない）。あわせて、issue #541以降生成されるようになっていた `frontend/coverage/` が未gitignoreだったため、この機会にあわせて追加
- `docs/cicd-pipeline-specification.md` にCI側（`dev-standards` の `reusable-ci.yml`）の公開フローを追記

CI側（`dev-standards`）では `peaceiris/actions-gh-pages` で `frontend/e2e-screenshots/` を専用ブランチ `e2e-screenshots` へ公開し、`raw.githubusercontent.com` のURLとしてJob Summaryへ画像を埋め込む。`pull_request` イベントの場合は同じ内容をPRコメントとしても投稿する（GitHubのモバイルアプリでもネイティブに画像が表示される）。いずれも補助的な機能であり `continue-on-error: true` を付けているため、失敗してもE2Eテスト自体の成功/失敗判定には影響しない。

## 却下した案

- スクリーンショットの外部ホスティングサービスへのアップロード: GitHub外の依存を増やすため見送り、GitHub Pages相当の仕組み（専用ブランチ + raw.githubusercontent.com）で完結させた
- 新規composite actionとしてdev-standards側に実装: 同一コミットで新規追加したcomposite actionはタグ参照している他リポジトリから直後には参照できないため、既存の実績あるサードパーティアクション（`peaceiris/actions-gh-pages`）を利用した

## Test plan

- [x] `frontend`: `npm run lint` / `npm test -- --run`（165/165 pass）
- [x] `backend`: `npm run lint` / `npm test -- --run`（1492/1492 pass）
- [x] `captureScreenshot()` は一時的なスモークテストでローカル動作を確認済み（ローカルの `vite preview` に対してPNGが実際に書き出されることを確認、後で削除）
- [ ] 実際のE2E実行によるCI側の公開フロー（専用ブランチへの公開・Job Summary/PRコメントへの画像埋め込み）の確認は、このセッションからは実行できないため、マージ後のCI実行結果で確認する

Closes #568


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_