### PR TITLE
fix(ci): CI実行一覧でPR時点とpush-to-main時点の実行を判別できるようにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
-run-name: CI ${{ github.event.head_commit.message || github.event.pull_request.title }}
+run-name: >-
+  CI (${{ github.event_name == 'pull_request' && 'PR' || 'push-to-main' }})
+  ${{ github.event.head_commit.message || github.event.pull_request.title }}
 
 on:
   push:


### PR DESCRIPTION
## 概要

issue #558対応。PR #556の事例をきっかけに、CI失敗後にマージされたように見える構造を調査した結果、実際には「マージ前のPRゲート」と「マージ後にmainへのpushで再度走るCI」が別物であるにもかかわらず、Actions実行一覧では見た目がほぼ同一の「CI ...」が2件並び、判別できないことが根本原因だった（マージ判断自体は既に全CI成功後のみに限定されていた）。

対になる `dev-standards` 側の変更（post-mergeの`commitlint`が存在する理由のドキュメント化）は [bamiyanapp/dev-standards#66](https://github.com/bamiyanapp/dev-standards/pull/66)。

## 対応内容

- `.github/workflows/ci.yml`の`run-name`に、`github.event_name`に応じたラベル（`PR` / `push-to-main`）を追加し、Actions実行一覧だけでどちらの実行か判別できるようにした

## 却下した案

- push側の`commitlint`チェック自体の削除: `reusable-cd.yml`の`release` jobがbase_branchのコミット履歴からConventional Commitsとしてバージョンを自動採番するため、Squash mergeで実際に生成された最終コミットメッセージの確認として必要と判断し、削除しなかった（詳細はdev-standards#66のドキュメント参照）
- `npm ci`の健全性を継続監視するスケジュール実行の追加: 既存の`infra_failure`分離（[dev-standards#60](``https://github.com/bamiyanapp/dev-standards/pull/60)）により、インフラ起因の失敗は他ジョブを巻き添えにせず'::warning::'として明示的に表示される仕組みが既にあるため、現状のシグナルで十分検知可能と判断し追加しなかった``

## Test plan

- [x] `frontend`: `npm run lint` / `npm test -- --run`（165/165 pass）
- [x] `backend`: `npm run lint` / `npm test -- --run`（1492/1492 pass）
- [x] `ci.yml`のYAML構文をpython3の`yaml.safe_load`で解析確認（karuta側ルートにはactionlint未導入のため、同一のrun-name記述をdev-standards側の`lint:workflows`（actionlint）で検証済み、問題なし）

Closes #558


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_