### PR TITLE
feat(quiz-room): これまでに読み上げた札一覧を開閉式にし、参加者画面にも表示する

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -109,6 +109,9 @@ function App() {
   // 「取った人を記録する」参加者登録は、カテゴリ確定時のモーダルではなく読み札画面の
   // ボタンから任意に開閉する（issue #518）
   const [showPlayerRegistration, setShowPlayerRegistration] = useState(false);
+  // 「これまでに読み上げた札」一覧は、件数が増えると画面が長くなるためデフォルト非表示にし、
+  // ボタンを押したときだけ開く（issue #548）
+  const [showHistory, setShowHistory] = useState(false);
   const [scoresByCategory, setScoresByCategory] = useSessionStorageState(SCORES_STORAGE_KEY, {});
   const [currentRoundTakenBy, setCurrentRoundTakenBy] = useState(null);
 
@@ -1573,22 +1576,33 @@ function App() {
       </main>
 
       {currentHistory.length > 0 && (
-        <section className="history mx-auto" style={{ maxWidth: "600px" }}>
-          <h2 className="h4 fw-bold mb-3 border-bottom pb-2 text-dark">これまでに読み上げた札</h2>
-          <div className="list-group shadow-sm rounded">
-            {currentHistory.map((p, index) => (
-              <button key={`${p.category}-${p.id}-${currentHistory.length - index}`} onClick={() => openDetail(p.id, p.category)} className="list-group-item list-group-item-action d-flex align-items-center justify-content-between">
-                <div className="d-flex align-items-center">
-                  {p.level !== "-" && <span className="badge bg-danger me-2">Lv.{p.level}</span>}
-                  <span className="text-dark">{p.phrase}</span>
-                </div>
-                <div className="d-flex align-items-center">
-                  {p.elapsedTime && <span className="text-muted small me-3">{p.elapsedTime}秒</span>}
-                  <span className="text-primary small">詳細・報告 →</span>
-                </div>
-              </button>
-            ))}
-          </div>
+        <section className="history mx-auto text-center" style={{ maxWidth: "600px" }}>
+          <button
+            type="button"
+            onClick={() => setShowHistory(prev => !prev)}
+            className="btn btn-sm btn-outline-secondary rounded-pill px-3 mb-3"
+          >
+            {showHistory ? "これまでに読み上げた札を閉じる" : `これまでに読み上げた札を表示する（${currentHistory.length}枚）`}
+          </button>
+          {showHistory && (
+            <div className="text-start">
+              <h2 className="h4 fw-bold mb-3 border-bottom pb-2 text-dark">これまでに読み上げた札</h2>
+              <div className="list-group shadow-sm rounded">
+                {currentHistory.map((p, index) => (
+                  <button key={`${p.category}-${p.id}-${currentHistory.length - index}`} onClick={() => openDetail(p.id, p.category)} className="list-group-item list-group-item-action d-flex align-items-center justify-content-between">
+                    <div className="d-flex align-items-center">
+                      {p.level !== "-" && <span className="badge bg-danger me-2">Lv.{p.level}</span>}
+                      <span className="text-dark">{p.phrase}</span>
+                    </div>
+                    <div className="d-flex align-items-center">
+                      {p.elapsedTime && <span className="text-muted small me-3">{p.elapsedTime}秒</span>}
+                      <span className="text-primary small">詳細・報告 →</span>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
         </section>
       )}
 

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -601,6 +601,8 @@ describe('App', () => {
     }, { timeout: 20000 });
 
     fetch.mockClear();
+    // 「これまでに読み上げた札」一覧はデフォルト非表示のため、まずトグルボタンで開く（issue #548）
+    fireEvent.click(await screen.findByText(/これまでに読み上げた札を表示する/));
     fireEvent.click(await screen.findByText('詳細・報告 →'));
 
     await waitFor(() => {
@@ -1314,6 +1316,9 @@ describe('App', () => {
       expect(screen.getByText('読み札1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
     }, { timeout: 20000 });
 
+    // 「これまでに読み上げた札」一覧はデフォルト非表示のため、まずトグルボタンで開く（issue #548）
+    fireEvent.click(await screen.findByText(/これまでに読み上げた札を表示する/));
+
     fireEvent.click(await screen.findByText('詳細・報告 →'));
 
     await waitFor(() => {
@@ -1324,6 +1329,42 @@ describe('App', () => {
     // バックエンドの上限(1000文字)と揃え、送信後に拒否される体験を防ぐ
     const commentTextarea = screen.getByPlaceholderText('例：かなが間違っている、フレーズが違うなど');
     expect(commentTextarea).toHaveAttribute('maxlength', '1000');
+
+    randomSpy.mockRestore();
+  }, 40000);
+
+  it('keeps the reading history collapsed by default and toggles it via a button (issue #548)', async () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) {
+        return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-' }] }) };
+      }
+      if (url.includes('get-phrase')) return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', phrase: '読み札1', audioData: 'dummy' }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    fireEvent.click(await screen.findByText('次の札'));
+
+    await waitFor(() => {
+      expect(screen.getByText('読み札1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+    }, { timeout: 20000 });
+
+    // デフォルトでは一覧が閉じている
+    expect(screen.queryByText('これまでに読み上げた札', { selector: 'h2' })).not.toBeInTheDocument();
+    const toggleButton = await screen.findByText('これまでに読み上げた札を表示する（1枚）');
+
+    fireEvent.click(toggleButton);
+    expect(await screen.findByText('これまでに読み上げた札', { selector: 'h2' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('これまでに読み上げた札を閉じる'));
+    expect(screen.queryByText('これまでに読み上げた札', { selector: 'h2' })).not.toBeInTheDocument();
 
     randomSpy.mockRestore();
   }, 40000);
@@ -2026,7 +2067,12 @@ describe('App', () => {
       // （＝停止ボタンがいずれ押せなくなる＝isReadingがfalseに戻る）ことを確認する。
       await waitFor(() => expect(screen.getByRole('button', { name: '停止' })).toBeDisabled(), { timeout: 20000 });
 
-      // カード2が実際に履歴へ記録され、次のカードへ進めることも確認する
+      // カード2が実際に履歴へ記録され、次のカードへ進めることも確認する。
+      // 「これまでに読み上げた札」一覧はデフォルト非表示のため、まずトグルボタンで開く（issue #548）
+      const historyToggle = screen.queryByText(/これまでに読み上げた札を表示する/);
+      if (historyToggle) {
+        fireEvent.click(historyToggle);
+      }
       expect(screen.getAllByText('読み札2').length).toBeGreaterThan(0);
     } finally {
       window.Audio = originalAudio;

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -63,6 +63,13 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   const [manualRoomId, setManualRoomId] = useState("");
 
   const [roomState, setRoomState] = useState(null);
+  // これまでに読み上げた札の履歴（issue #548）: サーバー側では履歴を保持・配信していない
+  // ため、参加者が受信したphrase状態を自分のローカルstateに積み上げて構築する。この方式は
+  // 途中から参加した参加者には接続後に読まれた分しか履歴に残らないが、サーバー側の変更
+  // （DynamoDBの状態サイズ上限・新規WebSocketメッセージ種別の追加）が不要でシンプルなため
+  // 採用した。デフォルト非表示にし、ボタンを押したときだけ開く（管理者側と同じ挙動）
+  const [phraseHistory, setPhraseHistory] = useState([]);
+  const [showHistory, setShowHistory] = useState(false);
 
   // 早押し機能（issue #510）: 参加者名は入室のたびに入力してもらう（永続化しない）。
   // confirmedNameが空の間は名前入力画面を表示し、決定後にのみ通常の参加者画面へ進む
@@ -142,6 +149,12 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     setLastBuzzRoundKey(currentBuzzRoundKey);
     setBuzzedBy(null);
     setExcludedThisRound(false);
+    // これまでに読み上げた札の履歴（issue #548）: 新しいラウンドの札が届いたタイミングで
+    // ローカル履歴に積み上げる（同じ札の再ブロードキャストでは currentBuzzRoundKey が
+    // 変わらないため重複追加されない）
+    if (roomState?.type === "phrase" && roomState.content) {
+      setPhraseHistory(prev => [roomState.content, ...prev]);
+    }
   }
 
   const handleConfirmName = () => {
@@ -307,6 +320,33 @@ function QuizRoomView({ setView, wsBaseUrl }) {
             <button onClick={buzz} className="btn btn-danger btn-lg rounded-pill px-5">
               回答する
             </button>
+          </div>
+        )}
+        {phraseHistory.length > 0 && (
+          <div className="mx-auto mt-4 text-center" style={{ maxWidth: "480px" }}>
+            <button
+              type="button"
+              onClick={() => setShowHistory(prev => !prev)}
+              className="btn btn-sm btn-outline-secondary rounded-pill px-3"
+            >
+              {showHistory ? "これまでに読み上げた札を閉じる" : `これまでに読み上げた札を表示する（${phraseHistory.length}枚）`}
+            </button>
+            {showHistory && (
+              // 管理者側の「詳細・報告 →」リンク（openDetail、DetailViewへの画面遷移を伴う指摘
+              // コメント投稿につながる）はここでは出さず、閲覧専用の簡易表示にとどめる（issue #548）。
+              // クイズ大会モードの参加者は端末を共有していない不特定多数のため、管理者専用機能への
+              // 導線をそのまま公開する必要はないと判断した
+              <div className="text-start mt-3">
+                <div className="list-group shadow-sm rounded">
+                  {phraseHistory.map((p, index) => (
+                    <div key={`${p.category}-${p.id}-${phraseHistory.length - index}`} className="list-group-item d-flex align-items-center">
+                      {p.level !== "-" && <span className="badge bg-danger me-2">Lv.{p.level}</span>}
+                      <span className="text-dark">{p.phrase}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         )}
         <div className="mt-5">

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -386,6 +386,33 @@ describe('QuizRoomView', () => {
     expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
   });
 
+  it('accumulates broadcast phrases into a collapsed-by-default local history, newest first, without duplicating a re-broadcast of the same phrase (issue #548)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+
+    // 履歴一覧はデフォルトで折りたたまれている
+    expect(screen.queryByText('読み札1', { selector: '.list-group-item .text-dark' })).not.toBeInTheDocument();
+    expect(screen.getByText('これまでに読み上げた札を表示する（1枚）')).toBeInTheDocument();
+
+    // 同じ札の再ブロードキャスト（設定変更等）では重複追加されない
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3', speechRate: '100%' } });
+    expect(screen.getByText('これまでに読み上げた札を表示する（1枚）')).toBeInTheDocument();
+
+    emitState({ type: 'result', content: { time: 1.2, answer: '答え1' } });
+    emitState({ type: 'phrase', content: { id: 'p2', category: 'Cat1', phrase: '読み札2', level: '3' } });
+
+    fireEvent.click(screen.getByText('これまでに読み上げた札を表示する（2枚）'));
+
+    const items = screen.getAllByText(/^読み札/, { selector: '.list-group-item .text-dark' });
+    expect(items.map((el) => el.textContent)).toEqual(['読み札2', '読み札1']);
+
+    fireEvent.click(screen.getByText('これまでに読み上げた札を閉じる'));
+    expect(screen.queryByText('読み札1', { selector: '.list-group-item .text-dark' })).not.toBeInTheDocument();
+  });
+
   it('fetches and plays audio for a broadcast phrase using the settings broadcast by the admin, not the participant\'s own local settings (issue #490, #498)', async () => {
     // 参加者自身のローカル設定は無視され、管理者からブロードキャストされた設定が使われることを
     // 確認するため、参加者側のlocalStorageにはあえて異なる値を入れておく


### PR DESCRIPTION
## 概要

issue #548対応。

- 「これまでに読み上げた札」一覧（`App.jsx`）は常時表示だったが、件数が増えると画面が長くなるため、デフォルト非表示・ボタンで開閉できるようにした
- クイズ大会モードの参加者画面（`QuizRoomView.jsx`）には既読札の履歴表示が一切なかったため、新たに追加した

## 対応内容

- 管理者側: issue #518の`showPlayerRegistration`と同じトグルボタンパターン（`show〇〇` state + `prev => !prev`）で、「これまでに読み上げた札」セクションを開閉式にした
- 参加者側: サーバー（`backend/quizRoomHandler.js`）はルーム状態を1枚分のみ保持・配信しており既読履歴を持たないため、参加者側でブロードキャスト済みの`phrase`状態をローカルに積み上げる方式で履歴を構築した。既存のラウンド判定ロジックに相乗りし、新しいラウンドの札が届いたときだけ積み上げることで、同じ札の再ブロードキャスト（設定変更等）による重複を防いでいる
- 参加者向け表示は、管理者専用機能（`openDetail`経由の指摘コメント投稿）への導線を含めない閲覧専用の簡易表示にした

## 却下した案（issueのTODOに対する判断）

- 参加者側履歴のサーバー側保持・ブロードキャスト: DynamoDBの状態サイズ上限（8000文字）への配慮や新規WebSocketメッセージ種別の追加が必要になり複雑化するため見送った。「途中参加者は接続後に読まれた分しか履歴に残らない」という制約はissue本文でも許容されている選択肢として、クライアント側積み上げ方式を採用した
- 参加者向け表示に「詳細・報告」リンクを含める案: クイズ大会モードの参加者は端末を共有していない不特定多数のため、管理者専用機能への導線をそのまま公開する必要はないと判断し、閲覧専用にとどめた

## Test plan

- [x] `frontend`: `npm run lint` / `npm test -- --run`（167/167 pass）
- [x] `backend`: `npm run lint` / `npm test -- --run`（1492/1492 pass、変更なし）
- [x] 新規テスト: 管理者側トグルの開閉（`App.test.jsx`）、参加者側の履歴積み上げ（重複防止・新しい順表示を含む）とトグルの開閉（`QuizRoomView.test.jsx`）
- [x] トグル追加により既存の2件のテスト（「詳細・報告 →」を直接クリックしていたもの）が影響を受けたため、先にトグルボタンを開くよう修正済み

Closes #548


---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_