### PR TITLE
chore(release): v1.41.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.41.0](https://github.com/bamiyanapp/karuta/compare/v1.40.0...v1.41.0) (2026-07-17)
+
+
+### Features
+
+* **quiz-room:** 管理者のルーム情報表示をインラインパネルから別画面への遷移に変更する ([#580](https://github.com/bamiyanapp/karuta/issues/580)) ([53b8ee0](https://github.com/bamiyanapp/karuta/commit/53b8ee0e855d46f37179b4880fcb5173e8594e49)), closes [#547](https://github.com/bamiyanapp/karuta/issues/547) [#558](https://github.com/bamiyanapp/karuta/issues/558)
+
 # [1.40.0](https://github.com/bamiyanapp/karuta/compare/v1.39.1...v1.40.0) (2026-07-17)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.40.0",
+    "version": "1.41.0",
     "date": "2026/07/17",
+    "body": "### Features\n\n* **quiz-room:** 管理者のルーム情報表示をインラインパネルから別画面への遷移に変更する ([#580](https://github.com/bamiyanapp/karuta/issues/580)) ([53b8ee0](https://github.com/bamiyanapp/karuta/commit/53b8ee0e855d46f37179b4880fcb5173e8594e49)), closes [#547](https://github.com/bamiyanapp/karuta/issues/547) [#558](https://github.com/bamiyanapp/karuta/issues/558)"
+  },
+  {
+    "version": "1.40.0",
+    "date": "2026/07/17 11:24",
     "body": "### Features\n\n* **quiz-room:** これまでに読み上げた札一覧を開閉式にし、参加者画面にも表示する ([#578](https://github.com/bamiyanapp/karuta/issues/578)) ([908de83](https://github.com/bamiyanapp/karuta/commit/908de838ab7e6918fd5f2f157e3225c65ee0491a)), closes [#state](https://github.com/bamiyanapp/karuta/issues/state) [#548](https://github.com/bamiyanapp/karuta/issues/548)"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.40.0",
+      "version": "1.41.0",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.40.0"
+  "version": "1.41.0"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。