### PR TITLE
fix(ci): dev-standardsの参照バージョンをv1.2.3へ更新する

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   release:
-    uses: bamiyanapp/dev-standards/.github/workflows/reusable-cd.yml@v1.2.1
+    uses: bamiyanapp/dev-standards/.github/workflows/reusable-cd.yml@v1.2.3
     with:
       enable_release: true
       enable_changelog_json: true
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 0
       - name: 🚀 Deploy to GitHub Pages
         id: deploy
-        uses: bamiyanapp/dev-standards/.github/actions/deploy-github-pages@v1.2.1
+        uses: bamiyanapp/dev-standards/.github/actions/deploy-github-pages@v1.2.3
         with:
           working-directory: frontend
           node-version: 24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ci:
-    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.0.2
+    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.2.3
     with:
       frontend_dir: frontend
       backend_dir: backend


### PR DESCRIPTION
## 概要

issue #583（CIパイプライン全停止インシデント）の緊急ロールバックで`v1.0.2`に固定していた`ci.yml`のdev-standards参照を、根本修正版である`v1.2.3`へ更新する。あわせて`cd.yml`の`v1.2.1`参照（`reusable-cd.yml`・`deploy-github-pages`）も最新へ揃え、`dev-standards` submoduleの参照コミットも`v1.2.3`タグへ更新した。

## 背景

`v1.2.1`で発生したCI全停止（`uses:`がstepsコンテキストを参照できず0ジョブで失敗）を`v1.0.2`へのロールバックで応急処置した後、dev-standards側でPR #70→#71と2段階の修正を経て、`check-coverage-threshold`の参照方法を「動的なref解決」から「固定タグの直接指定」に変更した`v1.2.3`をリリース済みだった（詳細はdev-standards側`docs/cicd-pipeline-specification.md`参照）。この修正版への切り替えがkaruta側でまだ行われていなかったため対応した。

なお、このセッションの環境からは実際のGitHub Actions実行を直接トリガーできないため、この修正が本当にCI上で問題なく動作するかは、本PRのCI実行結果で確認する。

## 却下した案

特になし。

## Test plan

- [x] `frontend`: `npm run lint` / `npm test -- --run`（167/167 pass、ワークフローファイルのみの変更で影響なし）
- [x] `backend`: `npm run lint` / `npm test -- --run`（1492/1492 pass、同上）
- [ ] このPR自体のCI実行が正常に完走することを確認する（dev-standards v1.2.3の`check-coverage-threshold`参照修正が実際に機能するかの最終確認）

Refs #583

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_