### PR TITLE
fix(quiz-room): 早押し判定の正解表示・回答ボタン非活性化・連打対策を修正する

### DIFF
--- a/frontend/e2e/quiz-room.spec.js
+++ b/frontend/e2e/quiz-room.spec.js
@@ -127,12 +127,12 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
     await responderPage.getByRole('button', { name: '回答する' }).click();
 
     // 管理者に判定モーダルが自動表示される（issue #546）
-    await expect(adminPage.getByText('🔔 たろう さんが回答しました')).toBeVisible({ timeout: 15000 });
+    await expect(adminPage.getByText('🔔 たろう さんが回答中')).toBeVisible({ timeout: 15000 });
     await captureScreenshot(adminPage, testInfo, 'admin-judgment-modal');
 
     // 回答者本人・未回答参加者のどちらの画面にも回答者名が表示され、早押しボタンは無くなる
-    await expect(responderPage.getByText('🔔 たろう さんが回答しました')).toBeVisible({ timeout: 15000 });
-    await expect(otherPage.getByText('🔔 たろう さんが回答しました')).toBeVisible({ timeout: 15000 });
+    await expect(responderPage.getByText('🔔 たろう さんが回答中')).toBeVisible({ timeout: 15000 });
+    await expect(otherPage.getByText('🔔 たろう さんが回答中')).toBeVisible({ timeout: 15000 });
     await expect(otherPage.getByRole('button', { name: '回答する' })).not.toBeVisible();
 
     // 管理者が不正解と判定する
@@ -147,7 +147,7 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
 
     // 未回答参加者（はなこ）が早押しする
     await otherPage.getByRole('button', { name: '回答する' }).click();
-    await expect(adminPage.getByText('🔔 はなこ さんが回答しました')).toBeVisible({ timeout: 15000 });
+    await expect(adminPage.getByText('🔔 はなこ さんが回答中')).toBeVisible({ timeout: 15000 });
 
     // 管理者が正解と判定する
     await adminPage.getByRole('button', { name: '正解', exact: true }).click();

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -151,6 +151,10 @@ function App() {
   const stopRequestedRef = useRef(false);
   const prefetchedNextRef = useRef(null);
   const autoAdvanceTimeoutRef = useRef(null);
+  // 「次の札」連打対策（issue #590）: loadingは処理の後半（フェードアウト待ち完了後）に
+  // ならないとtrueにならず、押下直後の連打を防げないため、押下と同時に同期的に
+  // 立てられる再入防止用のrefを別途持つ
+  const playKarutaInFlightRef = useRef(false);
 
   const resolvedTheme = useMemo(() => {
     return themeSetting === "system" ? (systemPrefersDark ? "dark" : "light") : themeSetting;
@@ -663,9 +667,9 @@ function App() {
   };
 
 
-  const playKaruta = async () => {
+  const playKarutaInternal = async () => {
     const targetPhrase = currentPhrase;
-    
+
     if (startTimeRef.current && targetPhrase) {
       const elapsedTime = (Date.now() - startTimeRef.current) / 1000;
       
@@ -727,9 +731,7 @@ function App() {
     }
 
     if (selectedCategories.length === 0 || allPhrasesForCategory.length === 0) return;
-    
-    setLoading(true);
-    
+
     try {
       const readKeys = new Set(currentHistory.map(p => `${p.category}:${p.id}`));
       let unreadPhrases = allPhrasesForCategory.filter(p => !readKeys.has(`${p.category}:${p.id}`));
@@ -780,8 +782,19 @@ function App() {
     } catch (error) {
       console.error("Error fetching phrase:", error);
       alert("通信エラーが発生しました: " + error.message);
+    }
+  };
+
+  const playKaruta = async () => {
+    if (playKarutaInFlightRef.current) return;
+    playKarutaInFlightRef.current = true;
+    setLoading(true);
+
+    try {
+      await playKarutaInternal();
     } finally {
       setLoading(false);
+      playKarutaInFlightRef.current = false;
     }
   };
 
@@ -1716,7 +1729,13 @@ function App() {
               <div className="modal-dialog modal-dialog-centered">
                 <div className="modal-content rounded-4 border-0 shadow">
                   <div className="modal-body p-5 text-center">
-                    <h3 className="h5 mb-4 fw-bold">🔔 {quizRoomBuzzedBy.name} さんが回答しました</h3>
+                    <h3 className="h5 mb-4 fw-bold">🔔 {quizRoomBuzzedBy.name} さんが回答中</h3>
+                    {currentPhrase?.answer && currentPhrase.answer !== "-" && (
+                      <>
+                        <div className="text-muted mb-2">答え</div>
+                        <div className="h4 fw-bold text-dark mb-4">{currentPhrase.answer}</div>
+                      </>
+                    )}
                     <div className="d-flex gap-2 justify-content-center">
                       <button onClick={() => judgeQuizRoomBuzz(true)} className="btn btn-primary btn-lg px-4 rounded-pill shadow-sm fs-6">正解</button>
                       <button onClick={() => judgeQuizRoomBuzz(false)} className="btn btn-outline-secondary btn-lg px-4 rounded-pill fs-6">不正解</button>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -567,6 +567,67 @@ describe('App', () => {
     randomSpy.mockRestore();
   }, 40000);
 
+  it('ignores a second "次の札" click while the first is still advancing (e.g. during the fade-out animation), instead of flipping multiple cards at once (issue #590)', async () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    const getPhraseCallIds = [];
+    const phraseById = {
+      p1: { id: 'p1', category: 'Cat1', phrase: '読み札1' },
+      p2: { id: 'p2', category: 'Cat1', phrase: '読み札2' },
+      p3: { id: 'p3', category: 'Cat1', phrase: '読み札3' },
+    };
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }, { id: 'p2', category: 'Cat1' }, { id: 'p3', category: 'Cat1' }] }),
+        };
+      }
+      if (url.includes('/get-phrase?')) {
+        const id = new URL(url).searchParams.get('id');
+        getPhraseCallIds.push(id);
+        return { ok: true, json: async () => ({ ...phraseById[id], audioData: 'dummy' }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+    await waitFor(() => screen.getByText('次の札'));
+    fireEvent.click(screen.getByText('次の札'));
+
+    // p1の読み上げが完了し、次の札へ進める状態に戻るのを待つ
+    await waitFor(() => expect(screen.getByText('次の札')).not.toBeDisabled(), { timeout: 20000 });
+    await waitFor(() => expect(screen.getByText('読み上げ済み 1 / 全3枚')).toBeInTheDocument());
+
+    // ここで連打する。同じボタン要素を捕まえてから2回続けてクリックすることで、
+    // 1回目のクリックで非活性化される前に2回目が送られる状況を再現する
+    // （修正前はこの間ボタンが非活性化されておらず、2回目のクリックも処理されて
+    // しまい、p2だけでなくp3までまとめてめくれてしまっていた）
+    const nextButton = screen.getByText('次の札');
+    fireEvent.click(nextButton);
+    fireEvent.click(nextButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('読み上げ済み 2 / 全3枚')).toBeInTheDocument();
+    }, { timeout: 20000 });
+
+    // p2を読み上げている間にp3が裏でプリフェッチされること自体は既存の正常な挙動
+    // （'prefetches the next phrase...'テスト参照）なので、/get-phraseの呼び出し数
+    // ではなく「実際にキューへ積まれ読み上げ済みとしてカウントされた枚数」で判定する。
+    // 修正前は2回目のクリックも処理されてしまい、ここで3枚目まで自動的に
+    // 読み上げ済みになってしまっていた（もう一度「次の札」を押していないのに進む）
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    expect(screen.getByText('読み上げ済み 2 / 全3枚')).toBeInTheDocument();
+
+    randomSpy.mockRestore();
+  }, 40000);
+
   it('requests announceCategory=true for the detail-view replay when multiple categories are selected', async () => {
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     fetch.mockImplementation(async (url) => {
@@ -2643,12 +2704,12 @@ describe('App', () => {
       ws.onmessage?.({ data: JSON.stringify({ type: 'buzz', name: 'はなこ', connectionId: 'conn-2' }) });
     });
 
-    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+    expect(screen.getByText('🔔 はなこ さんが回答中')).toBeInTheDocument();
 
     fireEvent.click(screen.getByText('次の札'));
 
     await waitFor(() => {
-      expect(screen.queryByText('🔔 はなこ さんが回答しました')).not.toBeInTheDocument();
+      expect(screen.queryByText('🔔 はなこ さんが回答中')).not.toBeInTheDocument();
     }, { timeout: 20000 });
   }, 40000);
 
@@ -2702,14 +2763,74 @@ describe('App', () => {
       ws.onmessage?.({ data: JSON.stringify({ type: 'buzz', name: 'はなこ', connectionId: 'conn-2' }) });
     });
 
-    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+    expect(screen.getByText('🔔 はなこ さんが回答中')).toBeInTheDocument();
     expect(screen.getByText('正解')).toBeInTheDocument();
     expect(screen.getByText('不正解')).toBeInTheDocument();
 
     fireEvent.click(screen.getByText('不正解'));
 
     expect(ws.sent).toContainEqual(JSON.stringify({ action: 'judgeBuzz', correct: false }));
-    expect(screen.queryByText('🔔 はなこ さんが回答しました')).not.toBeInTheDocument();
+    expect(screen.queryByText('🔔 はなこ さんが回答中')).not.toBeInTheDocument();
+  }, 40000);
+
+  it('shows the current phrase\'s answer in the judgment modal, so the admin can tell whether the response was correct (issue #586)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      if (url.includes('/get-phrase?')) {
+        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: '答え1', audioData: 'dummy' }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    const ws = MockWebSocket.instances[0];
+    act(() => {
+      ws.readyState = MockWebSocket.OPEN;
+      ws.onopen?.();
+    });
+
+    // 実際に札を読み上げ、currentPhraseに答えがセットされた状態にしてから早押しを送る
+    fireEvent.click(screen.getByText('次の札'));
+    await waitFor(() => {
+      expect(ws.sent.find((msg) => msg.includes('"type":"phrase"'))).toBeDefined();
+    }, { timeout: 20000 });
+
+    act(() => {
+      ws.onmessage?.({ data: JSON.stringify({ type: 'buzz', name: 'はなこ', connectionId: 'conn-2' }) });
+    });
+
+    expect(screen.getByText('🔔 はなこ さんが回答中')).toBeInTheDocument();
+    expect(screen.getByText('答え1')).toBeInTheDocument();
   }, 40000);
 
   it('does not clear the responder shown to the admin when the same card is re-broadcast (e.g. a settings change re-sends the same phrase), only when the round actually changes (issue #510)', async () => {
@@ -2766,13 +2887,13 @@ describe('App', () => {
     act(() => {
       ws.onmessage?.({ data: JSON.stringify({ type: 'buzz', name: 'はなこ', connectionId: 'conn-2' }) });
     });
-    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+    expect(screen.getByText('🔔 はなこ さんが回答中')).toBeInTheDocument();
 
     // 同じ札を表示したまま設定を変える（再ブロードキャストが発生するが、ラウンドは
     // 変わっていないので回答者表示は消えてはならない）
     fireEvent.click(screen.getByText('はやい'));
 
-    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+    expect(screen.getByText('🔔 はなこ さんが回答中')).toBeInTheDocument();
   }, 40000);
 
   it('shows each participant\'s points to the admin as a "points" message arrives, sorted from highest to lowest (issue #519)', async () => {

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -157,6 +157,18 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     }
   }
 
+  // 早押しボタン押下時、サーバーからのbuzzブロードキャストが返ってくるまでの間
+  // ボタンが非活性化されず連打・二重押下できてしまう問題（issue #588）への対策。
+  // 押した瞬間にローカルで即座にbuzzedByを仮設定してボタンを非表示にする。
+  // サーバー側は早押しを1件だけ条件付き書き込みで確定させるため（backend/
+  // quizRoomHandler.js buzzQuizRoom）実際の勝者判定はサーバーに委ねられており、
+  // 後から届くbuzzブロードキャスト（自分の勝ち・他の参加者の勝ちいずれも）が
+  // この仮の値を正しい値で上書きする
+  const handleBuzz = () => {
+    setBuzzedBy({ name: confirmedName });
+    buzz();
+  };
+
   const handleConfirmName = () => {
     const trimmed = nameDraft.trim();
     if (!trimmed) {
@@ -314,10 +326,10 @@ function QuizRoomView({ setView, wsBaseUrl }) {
           );
         })()}
         {buzzedBy ? (
-          <p className="fw-bold text-dark mt-4">🔔 {buzzedBy.name} さんが回答しました</p>
+          <p className="fw-bold text-dark mt-4">🔔 {buzzedBy.name} さんが回答中</p>
         ) : roomState?.type === "phrase" && !excludedThisRound && (
           <div className="mt-4">
-            <button onClick={buzz} className="btn btn-danger btn-lg rounded-pill px-5">
+            <button onClick={handleBuzz} className="btn btn-danger btn-lg rounded-pill px-5">
               回答する
             </button>
           </div>

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -251,8 +251,27 @@ describe('QuizRoomView', () => {
     expect(buzzMock).toHaveBeenCalled();
 
     emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
-    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+    expect(screen.getByText('🔔 はなこ さんが回答中')).toBeInTheDocument();
     expect(screen.queryByText('回答する')).not.toBeInTheDocument();
+  });
+
+  it('hides the buzz button immediately on click, before the server broadcast arrives, so it cannot be pressed again in the meantime (issue #588)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName('たろう');
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+    fireEvent.click(screen.getByText('回答する'));
+
+    // サーバーからのbuzzブロードキャストがまだ届いていない時点でも、
+    // 自分自身の押下は即座に反映され、ボタンは既に非表示になっている
+    expect(screen.getByText('🔔 たろう さんが回答中')).toBeInTheDocument();
+    expect(screen.queryByText('回答する')).not.toBeInTheDocument();
+
+    // 後から届くブロードキャストが、実際の勝者（別の参加者だった場合を含む）で
+    // 正しく上書きする
+    emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
+    expect(screen.getByText('🔔 はなこ さんが回答中')).toBeInTheDocument();
   });
 
   it('lets other participants buzz in again after a roundReset (incorrect judgment), but not the participant who was judged incorrect (issue #546)', () => {
@@ -348,13 +367,13 @@ describe('QuizRoomView', () => {
 
     emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
     emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
-    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+    expect(screen.getByText('🔔 はなこ さんが回答中')).toBeInTheDocument();
 
     emitState({ type: 'result', content: { time: 1.2, answer: '答え1' } });
-    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+    expect(screen.getByText('🔔 はなこ さんが回答中')).toBeInTheDocument();
 
     emitState({ type: 'phrase', content: { id: 'p2', category: 'Cat1', phrase: '読み札2', level: '3' } });
-    expect(screen.queryByText('🔔 はなこ さんが回答しました')).not.toBeInTheDocument();
+    expect(screen.queryByText('🔔 はなこ さんが回答中')).not.toBeInTheDocument();
     expect(screen.getByText('回答する')).toBeInTheDocument();
   });
 
@@ -365,10 +384,10 @@ describe('QuizRoomView', () => {
 
     emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
     emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
-    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+    expect(screen.getByText('🔔 はなこ さんが回答中')).toBeInTheDocument();
 
     emitState({ type: 'initial' });
-    expect(screen.queryByText('🔔 はなこ さんが回答しました')).not.toBeInTheDocument();
+    expect(screen.queryByText('🔔 はなこ さんが回答中')).not.toBeInTheDocument();
   });
 
   it('does not clear an already-recorded responder when the same phrase is re-broadcast (e.g. the admin changed a setting mid-round)', () => {
@@ -378,12 +397,12 @@ describe('QuizRoomView', () => {
 
     emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3', speechRate: '80%' } });
     emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
-    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+    expect(screen.getByText('🔔 はなこ さんが回答中')).toBeInTheDocument();
 
     // 同じ札（id/categoryが同一）が設定変更等で再ブロードキャストされても、
     // 既に記録済みの回答者表示を誤って消してはならない
     emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3', speechRate: '100%' } });
-    expect(screen.getByText('🔔 はなこ さんが回答しました')).toBeInTheDocument();
+    expect(screen.getByText('🔔 はなこ さんが回答中')).toBeInTheDocument();
   });
 
   it('accumulates broadcast phrases into a collapsed-by-default local history, newest first, without duplicating a re-broadcast of the same phrase (issue #548)', () => {


### PR DESCRIPTION
## 概要

重要度「高」の3件のバグを修正する。

- issue #586: 早押し判定モーダルに正解が表示されず、管理者が正誤を判定できない
- issue #588: 早押し回答ボタンが即座に無効化されず、他の参加者も回答可能な時間帯が生じる
- issue #590:「次の札」ボタンを連打すると、複数枚まとめてめくれてしまう

対応の過程で、issue #589（早押し回答時の表示文言を「回答しました」→「回答中」に変更する）も同じ箇所の修正だったため、あわせて解消した。

## 対応内容

- **#586**: `App.jsx`の早押し判定モーダルに、結果画面（`renderResult`）と同じ体裁で`currentPhrase.answer`を表示するようにした。
- **#588**: `QuizRoomView.jsx`に、早押しボタン押下と同時にローカルで`buzzedBy`を仮設定する`handleBuzz`を追加した。サーバー側は早押しを1件だけ条件付き書き込みで確定させる（`backend/quizRoomHandler.js` `buzzQuizRoom`）ため、実際の勝者判定はサーバーに委ねたまま、後から届く正式なブロードキャストがこの仮の値を正しい値で上書きする。
- **#589**: 早押し回答時の表示文言を「〜さんが回答しました」から「〜さんが回答中」に変更した（`App.jsx`・`QuizRoomView.jsx`双方、正誤判定前であるため）。
- **#590**: `App.jsx`の`playKaruta`を、再入防止用のref（`playKarutaInFlightRef`）で押下と同時に同期的にガードする薄いラッパーに分離し、実処理は`playKarutaInternal`へ切り出した。従来は`loading`state（ボタンの非活性化に使用）が処理後半（結果表示のフェードアウト演出待ち完了後）にならないとtrueにならず、連打を防げていなかった。

## 却下した案

- #588について、参加者間の完全なリアルタイム同期（他の参加者の押下を即座に検知する）は、WebSocketのラウンドトリップが必ず発生する以上、クライアント側だけでは原理的に解消できない。今回は「自分自身の押下を即座に反映する」楽観的更新にとどめ、サーバー側の早押し確定ロジック（条件付き書き込み）による正しさの担保は変更していない。

## Test plan

- [x] `frontend`: `npm run lint` / `npm test -- --run`（170/170 pass）
  - #586: 判定モーダルに答えが表示されることを検証するテストを追加
  - #588: 押下直後（ブロードキャスト到達前）にボタンが非表示になることを検証するテストを追加
  - #590: 連打しても2回目は無視され、1枚しか進まないことを検証するテストを追加（プリフェッチによる裏側の先読みと、実際に読み上げ済みとしてカウントされる枚数を区別して検証）
  - 既存テストの「〜さんが回答しました」表記を「〜さんが回答中」に更新
- [x] `backend`: `npm run lint` / `npm test -- --run`（1492/1492 pass、本変更の対象外）

Closes #586
Closes #588
Closes #589
Closes #590

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_