### PR TITLE
feat(quiz-room): 参加者一覧をルーム情報画面の下部に表形式で表示する

### DIFF
--- a/frontend/e2e/quiz-room.spec.js
+++ b/frontend/e2e/quiz-room.spec.js
@@ -114,9 +114,12 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
     await otherPage.getByText('決定').click();
     await expect(otherPage.getByText('接続状態: 接続済み')).toBeVisible({ timeout: 15000 });
 
-    // 参加者一覧（issue #545）: 管理者画面に両参加者が反映される
-    await expect(adminPage.getByText('たろう: 0pt')).toBeVisible({ timeout: 15000 });
-    await expect(adminPage.getByText('はなこ: 0pt')).toBeVisible();
+    // 参加者一覧（issue #545）: 管理者側はルーム情報画面の下部に表形式で反映される（issue #587）
+    await roomInfoLink.click();
+    await expect(adminPage.getByRole('row').nth(1)).toHaveText('たろう0pt', { timeout: 15000 });
+    await expect(adminPage.getByRole('row').nth(2)).toHaveText('はなこ0pt');
+    await adminPage.getByText('← 戻る').click();
+    await expect(nextButton).toBeVisible();
 
     await nextButton.click();
     await expect(adminPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 30000 });
@@ -151,12 +154,14 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
 
     // 管理者が正解と判定する
     await adminPage.getByRole('button', { name: '正解', exact: true }).click();
-
-    // ポイントが参加者一覧に反映される（管理者・参加者双方、issue #519, #545）
-    await expect(adminPage.getByText('はなこ: 1pt')).toBeVisible({ timeout: 15000 });
-    await expect(adminPage.getByText('たろう: 0pt')).toBeVisible();
     await expect(otherPage.getByText('獲得ポイント: 1')).toBeVisible({ timeout: 15000 });
     await captureScreenshot(adminPage, testInfo, 'admin-after-correct-judgment');
+
+    // ポイントが参加者一覧（管理者側、ルーム情報画面、issue #587）に反映される
+    // （参加者側は獲得ポイント表示で確認済み、issue #519, #545）
+    await roomInfoLink.click();
+    await expect(adminPage.getByRole('row').nth(1)).toHaveText('はなこ1pt', { timeout: 15000 });
+    await expect(adminPage.getByRole('row').nth(2)).toHaveText('たろう0pt');
   } finally {
     // カバレッジ計測（issue #541）: 失敗時も可能な範囲でカバレッジを収集するため、
     // コンテキストを閉じる前にtry節の成否に関わらず停止・収集する

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,7 +7,6 @@ import { useSessionStorageState } from "./hooks/useSessionStorageState";
 import { useUrlQuerySync, parseCategoriesParam } from "./hooks/useUrlQuerySync";
 import { useWakeLock } from "./hooks/useWakeLock";
 import { useQuizRoomSync } from "./hooks/useQuizRoomSync";
-import { mergeParticipantsWithPoints } from "./utils/quizRoomParticipants";
 import DetailView from "./views/DetailView";
 import PrintEfudaView from "./views/PrintEfudaView";
 import AllPhrasesView from "./views/AllPhrasesView";
@@ -1268,7 +1267,14 @@ function App() {
   // 未設定（ページリロード等でstateが失われ、URLにこのviewだけが残っている場合）は
   // 通常のゲーム画面へフォールスルーする
   if (view === "quiz-room-info" && quizRoom) {
-    return <QuizRoomInfoView setView={setView} roomId={quizRoom.roomId} />;
+    return (
+      <QuizRoomInfoView
+        setView={setView}
+        roomId={quizRoom.roomId}
+        quizRoomParticipants={quizRoomParticipants}
+        quizRoomPoints={quizRoomPoints}
+      />
+    );
   }
 
   if (selectedCategories.length === 0 && !division) {
@@ -1745,23 +1751,6 @@ function App() {
               </div>
             </div>
           )}
-          {(() => {
-            // 参加者一覧（issue #545）: まだ得点していない参加者も0ptとして含めた
-            // 1つのリストに統合して表示する
-            const participantList = mergeParticipantsWithPoints(quizRoomParticipants, quizRoomPoints);
-            return participantList.length > 0 && (
-              <div className="mx-auto mt-3 text-start" style={{ maxWidth: "320px" }}>
-                <p className="text-muted small mb-2">参加者一覧</p>
-                <div className="d-flex flex-wrap gap-2 justify-content-center">
-                  {participantList.map(({ name, points }) => (
-                    <div key={name} className="bg-white rounded-3 shadow-sm px-3 py-2">
-                      <span className="fw-bold notranslate">{name}</span>: {points}pt
-                    </div>
-                  ))}
-                </div>
-              </div>
-            );
-          })()}
         </div>
       ) : (
         <div className="mb-4 d-flex flex-wrap gap-3 justify-content-center align-items-start">

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2946,10 +2946,13 @@ describe('App', () => {
       ws.onmessage?.({ data: JSON.stringify({ type: 'points', points: { はなこ: 1, たろう: 3 } }) });
     });
 
+    // 参加者一覧はルーム情報画面（issue #547）の下部に表形式で表示される（issue #587）
+    fireEvent.click(screen.getByText('ルーム情報を表示（クイズ大会モード）'));
+
     expect(screen.getByText('参加者一覧')).toBeInTheDocument();
-    const points = screen.getAllByText(/pt$/).map((el) => el.textContent);
+    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
     // たろう(3pt)がはなこ(1pt)より先（降順）に表示される
-    expect(points).toEqual(['たろう: 3pt', 'はなこ: 1pt']);
+    expect(rows).toEqual(['たろう3pt', 'はなこ1pt']);
   }, 40000);
 
   it('shows participants who have not scored yet as 0pt in the same list once a "participants" message arrives (issue #545)', async () => {
@@ -3003,10 +3006,13 @@ describe('App', () => {
       ws.onmessage?.({ data: JSON.stringify({ type: 'points', points: { たろう: 3 } }) });
     });
 
+    // 参加者一覧はルーム情報画面（issue #547）の下部に表形式で表示される（issue #587）
+    fireEvent.click(screen.getByText('ルーム情報を表示（クイズ大会モード）'));
+
     expect(screen.getByText('参加者一覧')).toBeInTheDocument();
-    const points = screen.getAllByText(/pt$/).map((el) => el.textContent);
+    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
     // たろう(3pt)がまだ得点していないじろう・はなこ(0pt)より先（降順、同点は名前昇順）
-    expect(points).toEqual(['たろう: 3pt', 'じろう: 0pt', 'はなこ: 0pt']);
+    expect(rows).toEqual(['たろう3pt', 'じろう0pt', 'はなこ0pt']);
   }, 40000);
 
   it('broadcasts the settings actually used to fetch the admin\'s own audio, even if the admin changes the voice while that card is still being read out (issue #498)', async () => {

--- a/frontend/src/views/QuizRoomInfoView.jsx
+++ b/frontend/src/views/QuizRoomInfoView.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import QRCode from "qrcode";
+import { mergeParticipantsWithPoints } from "../utils/quizRoomParticipants";
 
 // クイズ大会モード（issue #470）の管理者向けルーム情報画面（issue #547）。
 // 以前は通常のゲーム画面にインラインで展開する折りたたみパネル
@@ -7,7 +8,7 @@ import QRCode from "qrcode";
 // useQuizRoomSync（WebSocket接続）はApp.jsx側のトップレベルで呼ばれており、
 // view遷移によってApp自体がアンマウントされることはないため、この画面への
 // 遷移中も読み上げ・早押し等のクイズ大会の進行状態は維持される
-function QuizRoomInfoView({ setView, roomId }) {
+function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoomPoints = {} }) {
   const [qrDataUrl, setQrDataUrl] = useState(null);
   const [copied, setCopied] = useState(false);
 
@@ -18,6 +19,11 @@ function QuizRoomInfoView({ setView, roomId }) {
       .then(setQrDataUrl)
       .catch((error) => console.error("Failed to generate QR code:", error));
   }, [inviteUrl]);
+
+  // 参加者一覧（issue #545）: まだ得点していない参加者も0ptとして含めた1つのリストに
+  // 統合して表示する。以前は通常のゲーム画面にインラインで表示していたが、ルーム情報
+  // 画面（この画面）の下部へ移動し、表形式に変更した（issue #587）
+  const participantList = mergeParticipantsWithPoints(quizRoomParticipants, quizRoomPoints);
 
   const copyUrl = async () => {
     try {
@@ -55,6 +61,27 @@ function QuizRoomInfoView({ setView, roomId }) {
           </button>
         </div>
       </div>
+      {participantList.length > 0 && (
+        <div className="mx-auto mt-5 text-start" style={{ maxWidth: "360px" }}>
+          <p className="text-muted small mb-2">参加者一覧</p>
+          <table className="table table-sm table-bordered bg-white mb-0">
+            <thead>
+              <tr>
+                <th scope="col">名前</th>
+                <th scope="col" className="text-end">得点</th>
+              </tr>
+            </thead>
+            <tbody>
+              {participantList.map(({ name, points }) => (
+                <tr key={name}>
+                  <td className="notranslate">{name}</td>
+                  <td className="text-end">{points}pt</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
       <div className="mt-5">
         <button onClick={() => setView("game")} className="btn btn-link text-muted text-decoration-none">← 戻る</button>
       </div>

--- a/frontend/src/views/QuizRoomInfoView.test.jsx
+++ b/frontend/src/views/QuizRoomInfoView.test.jsx
@@ -27,6 +27,27 @@ describe('QuizRoomInfoView', () => {
     expect(urlInput).toBeInTheDocument();
   });
 
+  it('shows the participant list as a table at the bottom of the screen, sorted by points descending (issue #587)', () => {
+    render(
+      <QuizRoomInfoView
+        setView={vi.fn()}
+        roomId="ABC123"
+        quizRoomParticipants={['たろう', 'はなこ', 'じろう']}
+        quizRoomPoints={{ たろう: 3 }}
+      />
+    );
+
+    expect(screen.getByText('参加者一覧')).toBeInTheDocument();
+    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
+    // たろう(3pt)がまだ得点していないじろう・はなこ(0pt)より先（降順、同点は名前昇順）
+    expect(rows).toEqual(['たろう3pt', 'じろう0pt', 'はなこ0pt']);
+  });
+
+  it('does not show the participant list section when there are no participants yet', () => {
+    render(<QuizRoomInfoView setView={vi.fn()} roomId="ABC123" />);
+    expect(screen.queryByText('参加者一覧')).not.toBeInTheDocument();
+  });
+
   it('lets the admin go back to the normal game screen', () => {
     const setView = vi.fn();
     render(<QuizRoomInfoView setView={setView} roomId="ABC123" />);


### PR DESCRIPTION
## 概要

issue #587対応。管理者側の参加者一覧を、通常のゲーム画面のインライン表示から、ルーム情報画面（`views/QuizRoomInfoView.jsx`、issue #547）の下部へ移動し、表示形式もバッジから表形式に変更する。

## 対応内容

- `App.jsx`のゲーム画面から参加者一覧のインライン表示（バッジの折り返し表示）を削除し、`quizRoomParticipants`/`quizRoomPoints`を`QuizRoomInfoView`へpropsとして渡すように変更した。
- `QuizRoomInfoView.jsx`の下部に、名前・得点を列にした`<table>`で参加者一覧を表示するようにした（`mergeParticipantsWithPoints`によるポイント統合・ソートは`QuizRoomView.jsx`（参加者側）と同じロジックを再利用）。
- 参加者側（`QuizRoomView.jsx`）の参加者一覧表示は変更していない（issueの要望が「管理者側」に限定されていたため）。

## 却下した案

- 参加者一覧をゲーム画面とルーム情報画面の両方に表示する案は採らなかった。issue #547でルーム情報表示を別画面へ切り出した経緯（ゲーム画面をシンプルに保つ）と同じ考え方で、完全に移動する形にした。

## Test plan

- [x] `frontend`: `npm run lint` / `npm test -- --run`（172/172 pass）
  - `QuizRoomInfoView.test.jsx`に、参加者一覧が表形式・ポイント降順で表示されるテストと、参加者がいない場合はセクション自体が表示されないテストを追加
  - `App.test.jsx`の既存2テストを、ルーム情報画面へ遷移してから参加者一覧を確認する内容に更新
- [x] `backend`: `npm run lint` / `npm test -- --run`（1492/1492 pass、本変更の対象外）
- [x] `frontend/e2e/quiz-room.spec.js`も、参加者一覧の確認箇所をルーム情報画面への遷移＋テーブル形式のアサーションに更新（実行自体は本PRのCI結果で確認）

Closes #587

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_