### PR TITLE
fix(e2e): スクリーンショットに日本語キャプションを付けられるようにする

### DIFF
--- a/frontend/e2e/quiz-room.spec.js
+++ b/frontend/e2e/quiz-room.spec.js
@@ -131,7 +131,7 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
 
     // 管理者に判定モーダルが自動表示される（issue #546）
     await expect(adminPage.getByText('🔔 たろう さんが回答中')).toBeVisible({ timeout: 15000 });
-    await captureScreenshot(adminPage, testInfo, 'admin-judgment-modal');
+    await captureScreenshot(adminPage, testInfo, 'admin-judgment-modal', '管理者：早押し判定モーダルが表示された状態');
 
     // 回答者本人・未回答参加者のどちらの画面にも回答者名が表示され、早押しボタンは無くなる
     await expect(responderPage.getByText('🔔 たろう さんが回答中')).toBeVisible({ timeout: 15000 });
@@ -145,8 +145,8 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
     // このラウンド中は復活しない（issue #546）
     await expect(otherPage.getByRole('button', { name: '回答する' })).toBeVisible({ timeout: 15000 });
     await expect(responderPage.getByRole('button', { name: '回答する' })).not.toBeVisible();
-    await captureScreenshot(otherPage, testInfo, 'other-participant-can-rebuzz');
-    await captureScreenshot(responderPage, testInfo, 'responder-excluded-this-round');
+    await captureScreenshot(otherPage, testInfo, 'other-participant-can-rebuzz', '未回答参加者（はなこ）：不正解判定後も回答ボタンが再表示された状態');
+    await captureScreenshot(responderPage, testInfo, 'responder-excluded-this-round', '誤答した本人（たろう）：このラウンド中は回答ボタンが再表示されない状態');
 
     // 未回答参加者（はなこ）が早押しする
     await otherPage.getByRole('button', { name: '回答する' }).click();
@@ -155,7 +155,7 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
     // 管理者が正解と判定する
     await adminPage.getByRole('button', { name: '正解', exact: true }).click();
     await expect(otherPage.getByText('獲得ポイント: 1')).toBeVisible({ timeout: 15000 });
-    await captureScreenshot(adminPage, testInfo, 'admin-after-correct-judgment');
+    await captureScreenshot(adminPage, testInfo, 'admin-after-correct-judgment', '管理者：正解判定後の状態');
 
     // ポイントが参加者一覧（管理者側、ルーム情報画面、issue #587）に反映される
     // （参加者側は獲得ポイント表示で確認済み、issue #519, #545）

--- a/frontend/e2e/screenshot.js
+++ b/frontend/e2e/screenshot.js
@@ -12,10 +12,16 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const SCREENSHOT_DIR = path.resolve(__dirname, '..', 'e2e-screenshots');
 
 // ページのスクリーンショットを撮影し、(1) 既存のPlaywright HTMLレポートへの
-// 添付、(2) CI側が公開できるようSCREENSHOT_DIRへのファイル書き出し、の両方を行う
-export async function captureScreenshot(page, testInfo, name) {
+// 添付、(2) CI側が公開できるようSCREENSHOT_DIRへのファイル書き出し、の両方を行う。
+// nameはファイル名（URLの一部になるため引き続きASCII安全な識別子を渡すこと）、
+// captionはPRコメント・Job Summaryの見出しに使われる日本語の説明文（issue #601）。
+// captionを省略した場合はCI側（dev-standards）がnameをそのまま見出しとして使う
+export async function captureScreenshot(page, testInfo, name, caption) {
   const body = await page.screenshot({ fullPage: true });
   await testInfo.attach(name, { body, contentType: 'image/png' });
   fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
   fs.writeFileSync(path.join(SCREENSHOT_DIR, `${name}.png`), body);
+  if (caption) {
+    fs.writeFileSync(path.join(SCREENSHOT_DIR, `${name}.caption.txt`), caption, 'utf-8');
+  }
 }


### PR DESCRIPTION
## 概要

issue #601対応。`frontend/e2e/screenshot.js`の`captureScreenshot()`に、PRコメント・Job Summaryの見出しに使う日本語キャプション（`caption`引数）を追加した。第4引数省略時は従来どおりファイル名（`name`）がそのまま見出しに使われる（CI側dev-standardsのフォールバック挙動、後方互換）。

## 対応内容

- `captureScreenshot(page, testInfo, name, caption)`: `caption`が指定された場合、`${name}.caption.txt`（UTF-8プレーンテキスト）を`e2e-screenshots/`へ書き出すようにした。ファイル名自体（URLの一部になる）は変更せず英語のまま維持し、表示用キャプションのみ分離している（dev-standards側でのURLエンコード問題を避けるため）。
- `frontend/e2e/quiz-room.spec.js`の既存4箇所の`captureScreenshot`呼び出しに、それぞれ日本語のキャプションを追加した。
- dev-standards側の対応（`caption.txt`を読み取って見出しに使う）は別PR（[bamiyanapp/dev-standards#73](https://github.com/bamiyanapp/dev-standards/pull/73)）で対応済み。

## 却下した案

特になし（dev-standards側PR #73と同じ設計方針: ファイル名は英語のまま、表示用キャプションのみ分離）。

## Test plan

- [x] `frontend`: `npm run lint` / `npm test -- --run`（172/172 pass）
- [x] `backend`: `npm run lint` / `npm test -- --run`（1492/1492 pass、本変更の対象外）
- [x] `captureScreenshot`自体をNodeで直接呼び出し、caption指定時は`.caption.txt`が正しい内容で書き出されること、未指定時は書き出されないことを確認した
- [ ] 日本語キャプションが実際にPRコメント・Job Summaryへ反映されるのは、dev-standards側PR #73がリリースされ、本リポジトリの`ci.yml`の参照バージョンを引き上げた後になる。現時点のdev-standards（v1.2.3）は`caption.txt`を無視してファイル名を見出しに使う従来動作のままだが、後方互換な変更のためこのPR自体のCIは問題なく通る想定

Refs #601

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_