### PR TITLE
chore(release): v1.42.1 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.42.1](https://github.com/bamiyanapp/karuta/compare/v1.42.0...v1.42.1) (2026-07-17)
+
+
+### Bug Fixes
+
+* **e2e:** スクリーンショットに日本語キャプションを付けられるようにする ([#603](https://github.com/bamiyanapp/karuta/issues/603)) ([e9c149d](https://github.com/bamiyanapp/karuta/commit/e9c149d1d18b9232f2169c18317e6186fa9cc201)), closes [#601](https://github.com/bamiyanapp/karuta/issues/601)
+
 # [1.42.0](https://github.com/bamiyanapp/karuta/compare/v1.41.2...v1.42.0) (2026-07-17)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.42.0",
+    "version": "1.42.1",
     "date": "2026/07/17",
+    "body": "### Bug Fixes\n\n* **e2e:** スクリーンショットに日本語キャプションを付けられるようにする ([#603](https://github.com/bamiyanapp/karuta/issues/603)) ([e9c149d](https://github.com/bamiyanapp/karuta/commit/e9c149d1d18b9232f2169c18317e6186fa9cc201)), closes [#601](https://github.com/bamiyanapp/karuta/issues/601)"
+  },
+  {
+    "version": "1.42.0",
+    "date": "2026/07/17 13:53",
     "body": "### Features\n\n* **quiz-room:** 参加者一覧をルーム情報画面の下部に表形式で表示する ([#597](https://github.com/bamiyanapp/karuta/issues/597)) ([89fc5e4](https://github.com/bamiyanapp/karuta/commit/89fc5e4d7d8cd56f9f180de20572f9d00ed7cf66)), closes [#587](https://github.com/bamiyanapp/karuta/issues/587)"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.42.0",
+      "version": "1.42.1",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.42.0"
+  "version": "1.42.1"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。