### PR TITLE
feat(quiz-room): 早押し正解時に即座に結果画面へ切り替え、参加者に紙吹雪演出を出す

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -616,68 +616,78 @@ function App() {
   };
 
 
-  const playKarutaInternal = async () => {
+  // 現在読み上げ中の札の結果（経過時間・難易度・答え）を確定し、フェードアウト
+  // 演出を経て結果画面へ切り替える。通常は「次の札」押下時（playKarutaInternal）に
+  // しか呼ばれないが、クイズ大会モードで早押しが正解と判定された時点（issue #600）
+  // にも即座に呼ばれる。これにより、経過時間は「正解が出るまで」で確定し、結果画面
+  // （答え表示）も「次の札」を待たずに即座に切り替わる。呼び出し後にstartTimeRef.current
+  // をnullへ戻すため、後から「次の札」が押されてplayKarutaInternalが実行されても
+  // この結果確定処理は再実行されない（二重計測・上書きの防止）
+  const revealCurrentResult = async (winner) => {
     const targetPhrase = currentPhrase;
+    if (!startTimeRef.current || !targetPhrase) return;
 
-    if (startTimeRef.current && targetPhrase) {
-      const elapsedTime = (Date.now() - startTimeRef.current) / 1000;
-      
-      setHistoryByCategory(prev => {
-        const newHistory = { ...prev };
-        if (newHistory[categoryKey] && newHistory[categoryKey].length > 0) {
-          const updatedCategoryHistory = [...newHistory[categoryKey]];
-          const lastReadPhrase = updatedCategoryHistory[0];
-          if (lastReadPhrase.id === targetPhrase.id && lastReadPhrase.category === targetPhrase.category) {
-            updatedCategoryHistory[0] = { ...lastReadPhrase, elapsedTime: elapsedTime.toFixed(2) };
-            newHistory[categoryKey] = updatedCategoryHistory;
-          }
+    const elapsedTime = (Date.now() - startTimeRef.current) / 1000;
+    startTimeRef.current = null;
+
+    setHistoryByCategory(prev => {
+      const newHistory = { ...prev };
+      if (newHistory[categoryKey] && newHistory[categoryKey].length > 0) {
+        const updatedCategoryHistory = [...newHistory[categoryKey]];
+        const lastReadPhrase = updatedCategoryHistory[0];
+        if (lastReadPhrase.id === targetPhrase.id && lastReadPhrase.category === targetPhrase.category) {
+          updatedCategoryHistory[0] = { ...lastReadPhrase, elapsedTime: elapsedTime.toFixed(2) };
+          newHistory[categoryKey] = updatedCategoryHistory;
         }
-        return newHistory;
-      });
-      
-      const totalCount = allPhrasesForCategory.filter(p => p.category === targetPhrase.category).length || 1;
-      const historyCount = currentHistory.filter(p => p.category === targetPhrase.category).length || 1;
-      const remainingCount = Math.max(1, totalCount - (historyCount - 1));
-      let difficulty = elapsedTime / remainingCount;
-
-      if (!isFinite(difficulty) || isNaN(difficulty)) {
-        difficulty = 0;
       }
+      return newHistory;
+    });
 
-      if (targetPhrase.id && targetPhrase.category && isFinite(elapsedTime) && !isNaN(elapsedTime)) {
-        const isFast = targetPhrase.averageTime > 0 && elapsedTime < targetPhrase.averageTime;
+    const totalCount = allPhrasesForCategory.filter(p => p.category === targetPhrase.category).length || 1;
+    const historyCount = currentHistory.filter(p => p.category === targetPhrase.category).length || 1;
+    const remainingCount = Math.max(1, totalCount - (historyCount - 1));
+    let difficulty = elapsedTime / remainingCount;
 
-        nextContentRef.current = {
-          type: "result",
-          content: { time: elapsedTime, difficulty, isFast, answer: targetPhrase.answer },
-        };
-
-        // 結果表示のフェード完了を待ってから次の札の取得・再生に進む。
-        // 待たずに次の札をすぐキューへ入れると、次の札側のフリップ完了待ち
-        // （animationResolveRef）をこの結果表示のフェード完了が誤って解決して
-        // しまい、次の札の表示が中断される不具合があったため、明示的に区切る。
-        const resultFadePromise = new Promise(resolve => {
-          animationResolveRef.current = resolve;
-        });
-        setIsFadingOut(true);
-
-        fetch(`${API_BASE_URL}/record-time`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            id: targetPhrase.id,
-            category: targetPhrase.category,
-            time: elapsedTime,
-            difficulty: difficulty,
-          }),
-        }).catch((error) => {
-          console.error("Error recording time:", error);
-        });
-
-        await resultFadePromise;
-      }
-      startTimeRef.current = null;
+    if (!isFinite(difficulty) || isNaN(difficulty)) {
+      difficulty = 0;
     }
+
+    if (targetPhrase.id && targetPhrase.category && isFinite(elapsedTime) && !isNaN(elapsedTime)) {
+      const isFast = targetPhrase.averageTime > 0 && elapsedTime < targetPhrase.averageTime;
+
+      nextContentRef.current = {
+        type: "result",
+        content: { time: elapsedTime, difficulty, isFast, answer: targetPhrase.answer, winner: winner ?? null },
+      };
+
+      // 結果表示のフェード完了を待ってから次の札の取得・再生に進む。
+      // 待たずに次の札をすぐキューへ入れると、次の札側のフリップ完了待ち
+      // （animationResolveRef）をこの結果表示のフェード完了が誤って解決して
+      // しまい、次の札の表示が中断される不具合があったため、明示的に区切る。
+      const resultFadePromise = new Promise(resolve => {
+        animationResolveRef.current = resolve;
+      });
+      setIsFadingOut(true);
+
+      fetch(`${API_BASE_URL}/record-time`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: targetPhrase.id,
+          category: targetPhrase.category,
+          time: elapsedTime,
+          difficulty: difficulty,
+        }),
+      }).catch((error) => {
+        console.error("Error recording time:", error);
+      });
+
+      await resultFadePromise;
+    }
+  };
+
+  const playKarutaInternal = async () => {
+    await revealCurrentResult();
 
     if (selectedCategories.length === 0 || allPhrasesForCategory.length === 0) return;
 
@@ -906,6 +916,7 @@ function App() {
     voiceId,
     isMultiCategorySelection,
     setView,
+    revealCurrentResult,
   });
 
   useEffect(() => {

--- a/frontend/src/hooks/useQuizRoomAdmin.js
+++ b/frontend/src/hooks/useQuizRoomAdmin.js
@@ -24,6 +24,7 @@ export function useQuizRoomAdmin({
   voiceId,
   isMultiCategorySelection,
   setView,
+  revealCurrentResult,
 }) {
   // 管理者としてルームを開設した場合のみ設定される
   const [quizRoom, setQuizRoom] = useState(null); // { roomId, adminToken } | null
@@ -80,10 +81,18 @@ export function useQuizRoomAdmin({
 
   // 早押し正誤判定（issue #546）: 「正解」「不正解」を選んだら判定結果をサーバーへ
   // 送信し、モーダルはローカルで即座に閉じる（roundResetのブロードキャストは
-  // 参加者側の早押しボタン復活・除外に使われる）
-  const judgeQuizRoomBuzz = (correct) => {
+  // 参加者側の早押しボタン復活・除外に使われる）。
+  // 正解の場合は、その場でrevealCurrentResult()を呼び、経過時間を「正解が出た
+  // タイミング」で確定させ、結果画面（答え表示）へ即座に切り替える（issue #600）。
+  // 誰も正解しなかった場合は何もせず、従来どおり「次の札」押下時
+  // （App.jsxのplayKarutaInternal）まで経過時間の確定・結果画面切り替えが持ち越される
+  const judgeQuizRoomBuzz = async (correct) => {
+    const winner = correct ? quizRoomBuzzedBy?.name ?? null : null;
     judgeBuzz(correct);
     setQuizRoomBuzzedBy(null);
+    if (correct) {
+      await revealCurrentResult(winner);
+    }
   };
 
   // 早押し機能（issue #510）: 新しい札が出題されたら、前のラウンドの回答者表示をリセット
@@ -135,7 +144,9 @@ export function useQuizRoomAdmin({
       const r = displayContent.content;
       broadcastQuizRoomState({
         type: "result",
-        content: { time: r.time, isFast: r.isFast, difficulty: r.difficulty, answer: r.answer },
+        // winner: 早押しが正解と判定された場合、その回答者名（issue #600）。
+        // 誰も正解しなかった場合（通常の「次の札」による結果表示）はnull
+        content: { time: r.time, isFast: r.isFast, difficulty: r.difficulty, answer: r.answer, winner: r.winner ?? null },
       });
     } else {
       broadcastQuizRoomState({ type: "initial" });

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -393,6 +393,81 @@ describe('useQuizRoomAdmin (via App)', () => {
     expect(screen.getByText('答え1')).toBeInTheDocument();
   }, 40000);
 
+  it('reveals the result screen (and stops the elapsed-time measurement) as soon as a buzz is judged correct, instead of waiting for the admin to click 次の札, and broadcasts the winner\'s name (issue #600)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      if (url.includes('/get-phrase?')) {
+        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: '答え1', audioData: 'dummy' }) };
+      }
+      if (url.includes('/record-time')) return { ok: true, json: async () => ({}) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    const ws = MockWebSocket.instances[0];
+    act(() => {
+      ws.readyState = MockWebSocket.OPEN;
+      ws.onopen?.();
+    });
+
+    fireEvent.click(screen.getByText('次の札'));
+    await waitFor(() => {
+      expect(ws.sent.find((msg) => msg.includes('"type":"phrase"'))).toBeDefined();
+    }, { timeout: 20000 });
+
+    act(() => {
+      ws.onmessage?.({ data: JSON.stringify({ type: 'buzz', name: 'はなこ', connectionId: 'conn-2' }) });
+    });
+
+    fireEvent.click(screen.getByText('正解'));
+
+    expect(ws.sent).toContainEqual(JSON.stringify({ action: 'judgeBuzz', correct: true }));
+
+    // 「次の札」を一切押していないのに、正解判定だけで管理者の画面も
+    // 結果画面（答え表示）へ切り替わる
+    await waitFor(() => {
+      expect(screen.getByText('所要時間')).toBeInTheDocument();
+      expect(screen.getByText('答え1')).toBeInTheDocument();
+    }, { timeout: 20000 });
+
+    // 参加者側へも、正解者名（winner）を含むresultが即座にブロードキャストされる
+    await waitFor(() => {
+      const resultMsg = ws.sent.find((msg) => msg.includes('"action":"updateState"') && msg.includes('"type":"result"'));
+      expect(resultMsg).toBeDefined();
+      expect(JSON.parse(resultMsg).state.content.winner).toBe('はなこ');
+    }, { timeout: 20000 });
+  }, 40000);
+
   it('does not clear the responder shown to the admin when the same card is re-broadcast (e.g. a settings change re-sends the same phrase), only when the round actually changes (issue #510)', async () => {
     class MockWebSocket {
       constructor(url) {

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -42,6 +42,11 @@ function renderParticipantContent(roomState) {
     return (
       <div className="yomifuda shadow-lg mx-auto">
         <div className="d-flex flex-column justify-content-center align-items-center h-100">
+          {/* 早押し正解時の表示（issue #600）: winnerは正解と判定された回答者名、
+              早押しが無かった／不正解のみで終わった場合はnull */}
+          {r.winner && (
+            <div className="h4 fw-bold text-dark mb-3 notranslate">🎉 {r.winner} さん正解！</div>
+          )}
           <div className="text-muted mb-2">所要時間</div>
           <div className="display-4 fw-bold text-dark mb-2">{r.time?.toFixed(2)}<span className="fs-4">秒</span></div>
           {r.answer && r.answer !== "-" && (
@@ -168,6 +173,29 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     setBuzzedBy({ name: confirmedName });
     buzz();
   };
+
+  // 早押し正解時の紙吹雪演出（issue #600）。App.jsxの読了時演出と同じ
+  // pseudoRandom(seed)パターンを流用し、useMemoファクトリ内でのMath.random()
+  // 呼び出し（react-hooks/purity）を避ける。showCelebrationはresult表示かつ
+  // winner（正解と判定された回答者名）がある間だけtrueになり、次のラウンドの
+  // 札が届く（roomState.typeが"phrase"に変わる）とfalseに戻るため、ラウンドが
+  // 変わるたびに演出が再生成される
+  const showCelebration = roomState?.type === "result" && !!roomState.content?.winner;
+  const confettiPieces = useMemo(() => {
+    if (!showCelebration) return [];
+    const emojis = ["🎉", "✨", "🎊", "⭐"];
+    const pseudoRandom = (seed) => {
+      const x = Math.sin(seed) * 10000;
+      return x - Math.floor(x);
+    };
+    return Array.from({ length: 24 }, (_, i) => ({
+      id: i,
+      emoji: emojis[i % emojis.length],
+      left: pseudoRandom(i) * 100,
+      delay: pseudoRandom(i + 100) * 0.6,
+      duration: 2.2 + pseudoRandom(i + 200) * 1.2,
+    }));
+  }, [showCelebration]);
 
   const handleConfirmName = () => {
     const trimmed = nameDraft.trim();
@@ -301,6 +329,19 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   if (joinRoomId) {
     return (
       <div className="container py-5 mx-auto text-center">
+        {showCelebration && (
+          <div className="confetti-container" aria-hidden="true">
+            {confettiPieces.map(c => (
+              <span
+                key={c.id}
+                className="confetti-piece"
+                style={{ left: `${c.left}%`, animationDelay: `${c.delay}s`, animationDuration: `${c.duration}s` }}
+              >
+                {c.emoji}
+              </span>
+            ))}
+          </div>
+        )}
         <header className="mb-4">
           <h1 className="h4 fw-bold">クイズ大会モード（参加者）</h1>
           <p className="text-muted small">ルーム: {joinRoomId}</p>

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -160,6 +160,27 @@ describe('QuizRoomView', () => {
     expect(screen.getByText('答え1')).toBeInTheDocument();
   });
 
+  it('shows a celebratory winner message and confetti when the result includes a winner (a buzz was judged correct), but not when there is no winner (issue #600)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
+
+    emitState({ type: 'phrase', content: { category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '3' } });
+
+    // 誰も正解しなかった場合（winnerなし）は、従来どおり所要時間・答えのみ表示する
+    emitState({ type: 'result', content: { time: 1.2, answer: '答え1', winner: null } });
+    expect(screen.getByText('答え1')).toBeInTheDocument();
+    expect(screen.queryByText(/さん正解！/)).not.toBeInTheDocument();
+    expect(document.querySelector('.confetti-container')).not.toBeInTheDocument();
+
+    // 早押しが正解と判定された場合（winnerあり）は、正解者名と紙吹雪演出を表示する
+    emitState({ type: 'phrase', content: { category: 'Cat1', kana: 'あ', phrase: '読み札2', level: '3' } });
+    emitState({ type: 'result', content: { time: 0.8, answer: '答え2', winner: 'たろう' } });
+    expect(screen.getByText('🎉 たろう さん正解！')).toBeInTheDocument();
+    expect(document.querySelector('.confetti-container')).toBeInTheDocument();
+  });
+
   it('treats an unrecognized or empty room state (e.g. right after room creation, before any card is shown) as "waiting" rather than a blank screen', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
 


### PR DESCRIPTION
## 概要

issue #600対応。早押しが「正解」と判定された時点で、管理者・参加者双方の画面を即座に結果画面（答え表示）へ切り替え、参加者側には紙吹雪演出と正解者名を表示する。あわせて経過時間の計測も「正解が出たタイミング」で確定させる。

## 対応内容

- `App.jsx`: 経過時間の確定・結果画面への切り替え処理を`playKarutaInternal`から`revealCurrentResult(winner)`として切り出した。従来は「次の札」押下時にしか呼ばれなかったが、`judgeQuizRoomBuzz`が正解と判定した時点でも即座に呼ぶようにした。呼び出し後`startTimeRef.current`をnullへ戻すため、後から「次の札」が押されても二重に計測・上書きされない。誰も正解しなかった場合は従来どおり「次の札」押下時点まで持ち越される。
- 結果ブロードキャストに、正解と判定された回答者名を示す`winner`フィールドを追加した（早押しが無かった・不正解のみで終わった場合はnull）。`backend/quizRoomHandler.js`側は状態を汎用的に中継するのみのため変更不要だった。
- `QuizRoomView.jsx`（参加者側）: `winner`がある場合、`App.jsx`の読了時演出と同じパターンで紙吹雪を表示し、「🎉 (winner) さん正解！」を表示するようにした。

## 却下した案

特になし。

## Test plan

- [x] `frontend`: `npm run lint` / `npm test -- --run`（174/174 pass）
  - 「次の札」を押さずに「正解」判定だけで管理者の画面が結果画面へ切り替わり、参加者へ`winner`を含む`result`が即座にブロードキャストされることを検証するテストを追加
  - `winner`ありの場合に正解者名・紙吹雪が表示され、`winner`なしの場合は表示されないことを検証するテストを追加
- [x] `backend`: `npm run lint` / `npm test -- --run`（1492/1492 pass、本変更の対象外）

Closes #600

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_