### PR TITLE
chore(release): v1.43.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.43.0](https://github.com/bamiyanapp/karuta/compare/v1.42.1...v1.43.0) (2026-07-17)
+
+
+### Features
+
+* **quiz-room:** 早押し正解時に即座に結果画面へ切り替え、参加者に紙吹雪演出を出す ([#625](https://github.com/bamiyanapp/karuta/issues/625)) ([04e7441](https://github.com/bamiyanapp/karuta/commit/04e74413331524c2d0e159e25d5a19b8ee8523b3)), closes [#600](https://github.com/bamiyanapp/karuta/issues/600)
+
 ## [1.42.1](https://github.com/bamiyanapp/karuta/compare/v1.42.0...v1.42.1) (2026-07-17)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.42.1",
+    "version": "1.43.0",
     "date": "2026/07/17",
+    "body": "### Features\n\n* **quiz-room:** 早押し正解時に即座に結果画面へ切り替え、参加者に紙吹雪演出を出す ([#625](https://github.com/bamiyanapp/karuta/issues/625)) ([04e7441](https://github.com/bamiyanapp/karuta/commit/04e74413331524c2d0e159e25d5a19b8ee8523b3)), closes [#600](https://github.com/bamiyanapp/karuta/issues/600)"
+  },
+  {
+    "version": "1.42.1",
+    "date": "2026/07/17 16:01",
     "body": "### Bug Fixes\n\n* **e2e:** スクリーンショットに日本語キャプションを付けられるようにする ([#603](https://github.com/bamiyanapp/karuta/issues/603)) ([e9c149d](https://github.com/bamiyanapp/karuta/commit/e9c149d1d18b9232f2169c18317e6186fa9cc201)), closes [#601](https://github.com/bamiyanapp/karuta/issues/601)"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.42.1",
+  "version": "1.43.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.42.1",
+      "version": "1.43.0",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.42.1"
+  "version": "1.43.0"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。