### PR TITLE
feat(quiz-room): 参加者画面の参加者一覧を表形式にし、接続ステータスを表示する

### DIFF
--- a/frontend/e2e/quiz-room.spec.js
+++ b/frontend/e2e/quiz-room.spec.js
@@ -116,8 +116,8 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
 
     // 参加者一覧（issue #545）: 管理者側はルーム情報画面の下部に表形式で反映される（issue #587）
     await roomInfoLink.click();
-    await expect(adminPage.getByRole('row').nth(1)).toHaveText('たろう0pt', { timeout: 15000 });
-    await expect(adminPage.getByRole('row').nth(2)).toHaveText('はなこ0pt');
+    await expect(adminPage.getByRole('row').nth(1)).toHaveText('たろう接続中0pt', { timeout: 15000 });
+    await expect(adminPage.getByRole('row').nth(2)).toHaveText('はなこ接続中0pt');
     await adminPage.getByText('← 戻る').click();
     await expect(nextButton).toBeVisible();
 
@@ -160,8 +160,8 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
     // ポイントが参加者一覧（管理者側、ルーム情報画面、issue #587）に反映される
     // （参加者側は獲得ポイント表示で確認済み、issue #519, #545）
     await roomInfoLink.click();
-    await expect(adminPage.getByRole('row').nth(1)).toHaveText('はなこ1pt', { timeout: 15000 });
-    await expect(adminPage.getByRole('row').nth(2)).toHaveText('たろう0pt');
+    await expect(adminPage.getByRole('row').nth(1)).toHaveText('はなこ接続中1pt', { timeout: 15000 });
+    await expect(adminPage.getByRole('row').nth(2)).toHaveText('たろう接続中0pt');
   } finally {
     // カバレッジ計測（issue #541）: 失敗時も可能な範囲でカバレッジを収集するため、
     // コンテキストを閉じる前にtry節の成否に関わらず停止・収集する

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -578,6 +578,7 @@ describe('useQuizRoomAdmin (via App)', () => {
     });
 
     act(() => {
+      ws.onmessage?.({ data: JSON.stringify({ type: 'participants', names: ['はなこ', 'たろう'] }) });
       ws.onmessage?.({ data: JSON.stringify({ type: 'points', points: { はなこ: 1, たろう: 3 } }) });
     });
 
@@ -587,7 +588,7 @@ describe('useQuizRoomAdmin (via App)', () => {
     expect(screen.getByText('参加者一覧')).toBeInTheDocument();
     const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
     // たろう(3pt)がはなこ(1pt)より先（降順）に表示される
-    expect(rows).toEqual(['たろう3pt', 'はなこ1pt']);
+    expect(rows).toEqual(['たろう接続中3pt', 'はなこ接続中1pt']);
   }, 40000);
 
   it('shows participants who have not scored yet as 0pt in the same list once a "participants" message arrives (issue #545)', async () => {
@@ -647,7 +648,7 @@ describe('useQuizRoomAdmin (via App)', () => {
     expect(screen.getByText('参加者一覧')).toBeInTheDocument();
     const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
     // たろう(3pt)がまだ得点していないじろう・はなこ(0pt)より先（降順、同点は名前昇順）
-    expect(rows).toEqual(['たろう3pt', 'じろう0pt', 'はなこ0pt']);
+    expect(rows).toEqual(['たろう接続中3pt', 'じろう接続中0pt', 'はなこ接続中0pt']);
   }, 40000);
 
   it('broadcasts the settings actually used to fetch the admin\'s own audio, even if the admin changes the voice while that card is still being read out (issue #498)', async () => {

--- a/frontend/src/utils/quizRoomParticipants.js
+++ b/frontend/src/utils/quizRoomParticipants.js
@@ -1,10 +1,16 @@
 // クイズ大会モード（issue #545）: 参加者一覧とポイント集計（issue #519）を1つのリストへ
 // 統合する。まだ得点していない参加者も0ptとして含め、管理者・参加者どちらの画面でも
-// 同じ並び順（ポイント降順、同点は名前の昇順）で表示できるようにする
+// 同じ並び順（ポイント降順、同点は名前の昇順）で表示できるようにする。
+// connected（issue #599/#602）: participantNamesは現在接続中の参加者名一覧
+// （backend/quizRoomHandler.jsのdisconnectQuizRoom等がブロードキャストする
+// "participants"メッセージ由来）なので、その一覧に含まれるかどうかで
+// 接続ステータスを判定できる。得点記録（points）は切断後も残り続けるため、
+// 切断済みでも一覧には引き続き表示されるが、connectedはfalseになる
 export function mergeParticipantsWithPoints(participantNames, points) {
+  const connectedNames = new Set(participantNames);
   const names = new Set(participantNames);
   Object.keys(points).forEach((name) => names.add(name));
   return Array.from(names)
-    .map((name) => ({ name, points: points[name] || 0 }))
+    .map((name) => ({ name, points: points[name] || 0, connected: connectedNames.has(name) }))
     .sort((a, b) => b.points - a.points || a.name.localeCompare(b.name));
 }

--- a/frontend/src/utils/quizRoomParticipants.test.js
+++ b/frontend/src/utils/quizRoomParticipants.test.js
@@ -5,20 +5,20 @@ describe('mergeParticipantsWithPoints', () => {
   it('includes participants who have not scored yet as 0pt', () => {
     const result = mergeParticipantsWithPoints(['たろう', 'はなこ'], { たろう: 2 });
     expect(result).toEqual([
-      { name: 'たろう', points: 2 },
-      { name: 'はなこ', points: 0 },
+      { name: 'たろう', points: 2, connected: true },
+      { name: 'はなこ', points: 0, connected: true },
     ]);
   });
 
   it('includes a scorer even if they are missing from the participant list (e.g. late-arriving broadcast)', () => {
     const result = mergeParticipantsWithPoints(['たろう'], { たろう: 1, じろう: 3 });
     expect(result).toEqual([
-      { name: 'じろう', points: 3 },
-      { name: 'たろう', points: 1 },
+      { name: 'じろう', points: 3, connected: false },
+      { name: 'たろう', points: 1, connected: true },
     ]);
   });
 
-  it('keeps a participant visible with their earned points after they disconnect (points are never cleared by a participant-list update, issue #545)', () => {
+  it('keeps a participant visible with their earned points after they disconnect (points are never cleared by a participant-list update, issue #545), and marks them as not connected (issue #599/#602)', () => {
     // 切断イベント（disconnectQuizRoom）はparticipants一覧からのみ名前を外し、
     // ポイント（points）はjudgeQuizRoomBuzzでの加点時にしか変わらない。
     // そのため切断後のparticipants一覧に名前が無くても、pointsに記録が
@@ -29,17 +29,17 @@ describe('mergeParticipantsWithPoints', () => {
     // たろうが切断し、participants一覧からは消えたが、pointsはそのまま
     const afterDisconnect = mergeParticipantsWithPoints(['はなこ'], { たろう: 2 });
     expect(afterDisconnect).toEqual([
-      { name: 'たろう', points: 2 },
-      { name: 'はなこ', points: 0 },
+      { name: 'たろう', points: 2, connected: false },
+      { name: 'はなこ', points: 0, connected: true },
     ]);
   });
 
   it('sorts by points descending, breaking ties by name ascending', () => {
     const result = mergeParticipantsWithPoints(['はなこ', 'たろう', 'じろう'], {});
     expect(result).toEqual([
-      { name: 'じろう', points: 0 },
-      { name: 'たろう', points: 0 },
-      { name: 'はなこ', points: 0 },
+      { name: 'じろう', points: 0, connected: true },
+      { name: 'たろう', points: 0, connected: true },
+      { name: 'はなこ', points: 0, connected: true },
     ]);
   });
 

--- a/frontend/src/views/QuizRoomInfoView.jsx
+++ b/frontend/src/views/QuizRoomInfoView.jsx
@@ -68,13 +68,17 @@ function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoom
             <thead>
               <tr>
                 <th scope="col">名前</th>
+                <th scope="col">接続</th>
                 <th scope="col" className="text-end">得点</th>
               </tr>
             </thead>
             <tbody>
-              {participantList.map(({ name, points }) => (
+              {participantList.map(({ name, points, connected }) => (
                 <tr key={name}>
                   <td className="notranslate">{name}</td>
+                  <td className={connected ? "text-success" : "text-muted"}>
+                    {connected ? "接続中" : "切断済み"}
+                  </td>
                   <td className="text-end">{points}pt</td>
                 </tr>
               ))}

--- a/frontend/src/views/QuizRoomInfoView.test.jsx
+++ b/frontend/src/views/QuizRoomInfoView.test.jsx
@@ -27,7 +27,7 @@ describe('QuizRoomInfoView', () => {
     expect(urlInput).toBeInTheDocument();
   });
 
-  it('shows the participant list as a table at the bottom of the screen, sorted by points descending (issue #587)', () => {
+  it('shows the participant list as a table at the bottom of the screen, sorted by points descending, with a connection status column (issue #587, #599)', () => {
     render(
       <QuizRoomInfoView
         setView={vi.fn()}
@@ -40,7 +40,21 @@ describe('QuizRoomInfoView', () => {
     expect(screen.getByText('参加者一覧')).toBeInTheDocument();
     const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
     // たろう(3pt)がまだ得点していないじろう・はなこ(0pt)より先（降順、同点は名前昇順）
-    expect(rows).toEqual(['たろう3pt', 'じろう0pt', 'はなこ0pt']);
+    expect(rows).toEqual(['たろう接続中3pt', 'じろう接続中0pt', 'はなこ接続中0pt']);
+  });
+
+  it('shows a participant as disconnected when they are no longer in the connected-participants list, while keeping their earned points visible (issue #599, #602)', () => {
+    render(
+      <QuizRoomInfoView
+        setView={vi.fn()}
+        roomId="ABC123"
+        quizRoomParticipants={['はなこ']}
+        quizRoomPoints={{ たろう: 2 }}
+      />
+    );
+
+    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
+    expect(rows).toEqual(['たろう切断済み2pt', 'はなこ接続中0pt']);
   });
 
   it('does not show the participant list section when there are no participants yet', () => {

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -349,23 +349,6 @@ function QuizRoomView({ setView, wsBaseUrl }) {
         <p className="text-muted small mb-3">接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}</p>
         <p className="fw-bold text-dark">獲得ポイント: {points[confirmedName] || 0}</p>
         {renderParticipantContent(roomState)}
-        {(() => {
-          // 参加者一覧（issue #545）: まだ得点していない参加者も0ptとして含めた
-          // 1つのリストに統合して表示する（管理者画面と同じ並び順）
-          const participantList = mergeParticipantsWithPoints(participants, points);
-          return participantList.length > 0 && (
-            <div className="mx-auto mt-4 text-start" style={{ maxWidth: "320px" }}>
-              <p className="text-muted small mb-2">参加者一覧</p>
-              <div className="d-flex flex-wrap gap-2 justify-content-center">
-                {participantList.map(({ name, points: pt }) => (
-                  <div key={name} className="bg-white rounded-3 shadow-sm px-3 py-2">
-                    <span className={`notranslate ${name === confirmedName ? "fw-bold" : ""}`}>{name}</span>: {pt}pt
-                  </div>
-                ))}
-              </div>
-            </div>
-          );
-        })()}
         {buzzedBy ? (
           <p className="fw-bold text-dark mt-4">🔔 {buzzedBy.name} さんが回答中</p>
         ) : roomState?.type === "phrase" && !excludedThisRound && (
@@ -375,6 +358,37 @@ function QuizRoomView({ setView, wsBaseUrl }) {
             </button>
           </div>
         )}
+        {(() => {
+          // 参加者一覧（issue #545）: まだ得点していない参加者も0ptとして含めた
+          // 1つのリストに統合して表示する（管理者画面と同じ並び順）。
+          // 表形式・接続ステータス表示、回答ボタンより下への配置はissue #599で対応
+          const participantList = mergeParticipantsWithPoints(participants, points);
+          return participantList.length > 0 && (
+            <div className="mx-auto mt-4 text-start" style={{ maxWidth: "360px" }}>
+              <p className="text-muted small mb-2">参加者一覧</p>
+              <table className="table table-sm table-bordered bg-white mb-0">
+                <thead>
+                  <tr>
+                    <th scope="col">名前</th>
+                    <th scope="col">接続</th>
+                    <th scope="col" className="text-end">得点</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {participantList.map(({ name, points: pt, connected }) => (
+                    <tr key={name}>
+                      <td className={`notranslate ${name === confirmedName ? "fw-bold" : ""}`}>{name}</td>
+                      <td className={connected ? "text-success" : "text-muted"}>
+                        {connected ? "接続中" : "切断済み"}
+                      </td>
+                      <td className="text-end">{pt}pt</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          );
+        })()}
         {phraseHistory.length > 0 && (
           <div className="mx-auto mt-4 text-center" style={{ maxWidth: "480px" }}>
             <button

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -276,6 +276,19 @@ describe('QuizRoomView', () => {
     expect(screen.queryByText('回答する')).not.toBeInTheDocument();
   });
 
+  it('places the participant list below the buzz button/responder display, not above it (issue #599)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    const { container } = render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName('はなこ');
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+    emitParticipants(['はなこ', 'たろう']);
+
+    const html = container.innerHTML;
+    expect(html.indexOf('回答する')).toBeGreaterThan(-1);
+    expect(html.indexOf('参加者一覧')).toBeGreaterThan(html.indexOf('回答する'));
+  });
+
   it('hides the buzz button immediately on click, before the server broadcast arrives, so it cannot be pressed again in the meantime (issue #588)', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
@@ -352,7 +365,7 @@ describe('QuizRoomView', () => {
     expect(screen.getByText('獲得ポイント: 2')).toBeInTheDocument();
   });
 
-  it('shows a combined participant list (including 0pt participants), highlighting the confirmed participant\'s own name (issue #545)', () => {
+  it('shows a combined participant list as a table (including 0pt participants), highlighting the confirmed participant\'s own name (issue #545, #599)', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
     confirmName('はなこ');
@@ -361,11 +374,26 @@ describe('QuizRoomView', () => {
     emitPoints({ たろう: 5 });
 
     expect(screen.getByText('参加者一覧')).toBeInTheDocument();
-    const points = screen.getAllByText(/pt$/).map((el) => el.textContent);
-    expect(points).toEqual(['たろう: 5pt', 'じろう: 0pt', 'はなこ: 0pt']);
+    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
+    expect(rows).toEqual(['たろう接続中5pt', 'じろう接続中0pt', 'はなこ接続中0pt']);
 
-    const ownEntry = screen.getByText('はなこ', { selector: 'span.fw-bold' });
+    const ownEntry = screen.getByText('はなこ', { selector: 'td.fw-bold' });
     expect(ownEntry).toBeInTheDocument();
+  });
+
+  it('shows a participant as disconnected once they leave, while keeping their earned points visible (issue #599, #602)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName('はなこ');
+
+    emitParticipants(['はなこ', 'たろう']);
+    emitPoints({ たろう: 2 });
+
+    // たろうが切断（participants一覧から名前が消える）。得点は残る
+    emitParticipants(['はなこ']);
+
+    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
+    expect(rows).toEqual(['たろう切断済み2pt', 'はなこ接続中0pt']);
   });
 
   it('sends the participant back to the name entry screen with an error when the server rejects a duplicate name (issue #519)', () => {


### PR DESCRIPTION
## 概要

issue #599対応（issue #602統合分を含む）。参加者画面の参加者一覧を管理者側と同じ表形式にし、回答ボタンより下へ配置を変更する。あわせて管理者・参加者双方の参加者一覧に接続ステータス（接続中／切断済み）を表示する。

## 対応内容

- `QuizRoomView.jsx`の参加者一覧を`<table>`ベースの表形式に変更し、描画順を回答ボタンより後ろへ移動した。
- `utils/quizRoomParticipants.js`の`mergeParticipantsWithPoints`に`connected`フィールドを追加した。既に持っている「現在接続中の参加者名一覧」との突き合わせのみで判定でき、サーバー側の変更は不要だった。
- 接続ステータス列（「接続中」/「切断済み」）を、管理者画面（`QuizRoomInfoView.jsx`）・参加者画面（`QuizRoomView.jsx`）双方の表に追加した。

## 却下した案

特になし。

## Test plan

- [x] `frontend`: `npm run lint` / `npm test -- --run`（177/177 pass）
  - `quizRoomParticipants.test.js`の既存テストを`connected`フィールド込みの期待値に更新
  - `QuizRoomView.test.jsx`: 表形式・接続ステータス表示、切断後も得点付きで表示され続けること、参加者一覧が回答ボタンより下に配置されることを検証するテストを追加・更新
  - `QuizRoomInfoView.test.jsx`: 接続ステータス列の表示を検証するテストを追加
  - `hooks/useQuizRoomAdmin.test.jsx`の既存2テストを接続ステータス列込みの期待値に更新
- [x] `backend`: `npm run lint` / `npm test -- --run`（1492/1492 pass、本変更の対象外）
- [x] `frontend/e2e/quiz-room.spec.js`の参加者一覧アサーションも接続ステータス列を含む内容に更新（実行自体は本PRのCI結果で確認）

Closes #599

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_