### PR TITLE
test(e2e): 通常モードの読み上げフローと主要な参照画面のE2Eテストを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,11 @@
 ### 対象パッケージ（静的チェック関連）
 
 静的チェック（lint / test / build）の対象パッケージは `frontend` と `backend` の両方とする。両方でエラー0件を確認するまで、コミット作成や完了報告に進んではならない。
+
+### E2Eテスト追加時のスクリーンショット添付
+
+`frontend/e2e/*.spec.js` にテストを新規追加・変更する場合、そのテストで検証する主要な画面・状態変化の要所で `frontend/e2e/screenshot.js` の `captureScreenshot(page, testInfo, name, caption)` を呼び出すこと。これによりCI（`reusable-ci.yml`のE2Eスクリーンショット報告機能、`dev-standards/docs/cicd-pipeline-specification.md`「1. CIワークフロー」参照）がPRコメント・Job Summaryへ画像として表示し、スマホオンリーの開発環境でも実装した画面を目視確認できるようになる（「開発環境の制約（スマホオンリー）」参照）。`captureScreenshot`の呼び出しを忘れると、そのテストが検証した画面が人間から見えないまま埋もれる。
+
+- `name`はファイル名・URLの一部になるためASCII安全な識別子にする
+- `caption`には表示内容が分かる日本語の説明文を渡す（省略時は`name`がそのまま見出しに使われ英語的で分かりにくくなる）
+- 1テスト内で検証する画面ごとに1枚を目安とし、同一画面内の些末な状態変化まで乱発しない（スクリーンショットが多すぎるとPRが見にくくなる問題はissue #628で別途検討中）

--- a/frontend/e2e/app-flows.spec.js
+++ b/frontend/e2e/app-flows.spec.js
@@ -21,6 +21,21 @@ test('normal read-aloud flow (category select -> phrase -> result), then browses
     window.print = () => { window.__printCalled = true; };
   });
 
+  // PWAの「オフラインで利用可能になりました」トースト（PwaUpdatePrompt.jsx）は
+  // position: fixedで画面下部に表示され、5秒後に自動で消えるが、それまでの間は
+  // 同じ位置にあるトップ画面のフッターリンク（全札一覧を見る／更新履歴を見る／
+  // 指摘された内容を確認するなど）を覆いクリックをブロックすることがある
+  // （PwaUpdatePrompt.jsx自身のコメントに既知の不具合として記載あり）。
+  // このテストはそのフッターリンクを実際にクリックするため、都度出現していれば
+  // 明示的に閉じる
+  const dismissPwaToastIfPresent = async () => {
+    try {
+      await page.getByRole('button', { name: '閉じる' }).click({ timeout: 500 });
+    } catch {
+      // トーストが出ていなければ何もしない
+    }
+  };
+
   try {
     await page.goto('/');
 
@@ -29,6 +44,7 @@ test('normal read-aloud flow (category select -> phrase -> result), then browses
     // ボタンが無い。カテゴリ選択後のゲーム画面には存在しないため、division選択前に
     // 先に一通り確認しておく
     // 全札一覧画面: 検索・絞り込み・詳細画面への遷移
+    await dismissPwaToastIfPresent();
     await page.getByText('全札一覧を見る →').click();
     await expect(page.getByText('全札一覧')).toBeVisible();
     await page.getByPlaceholder('読み札・読み・答えで検索').fill('ふでこぞう');
@@ -52,6 +68,7 @@ test('normal read-aloud flow (category select -> phrase -> result), then browses
     await expect(page.getByText('こども向け')).toBeVisible();
 
     // 更新履歴画面（changelog.jsonをビルド時に同梱しているだけで通信は発生しない）
+    await dismissPwaToastIfPresent();
     await page.getByText('更新履歴を見る').click();
     await expect(page.getByText('更新履歴')).toBeVisible();
     await captureScreenshot(page, testInfo, 'changelog-view', '更新履歴画面');
@@ -59,12 +76,14 @@ test('normal read-aloud flow (category select -> phrase -> result), then browses
     await expect(page.getByText('こども向け')).toBeVisible();
 
     // 指摘一覧画面
+    await dismissPwaToastIfPresent();
     await page.getByText('指摘された内容を確認する').click();
     await expect(page.getByText('指摘された内容一覧')).toBeVisible();
     await captureScreenshot(page, testInfo, 'comments-view', '指摘された内容一覧画面');
 
     // ここから通常の読み上げフロー（カテゴリ選択→読み上げ→結果表示）
     await page.goto('/');
+    await dismissPwaToastIfPresent();
     await page.getByText('こども向け').click();
     // こども向けは1タップで即座に読み上げ画面へ遷移する（App.jsxのtoggleDraftCategory）
     await page.getByRole('button', { name: /おばけかるた/ }).click();

--- a/frontend/e2e/app-flows.spec.js
+++ b/frontend/e2e/app-flows.spec.js
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+import { startCoverage, stopCoverage, closeContext } from './coverage.js';
+
+// issue #576対応: E2EのJSカバレッジを引き上げるため、これまでquiz-room.spec.jsの
+// クイズ大会モードでしかカバーできていなかった通常モード（カテゴリ選択→読み上げ→
+// 結果表示）と、主要な参照画面（絵札印刷・全札一覧・詳細・更新履歴・指摘一覧）を
+// 一連の実操作で通しでカバーする。実際のデプロイ済みバックエンドに対して実行する
+// ため（quiz-room.spec.jsと同じ方針）、書き込みを伴う操作のうち本番データを恒久的に
+// 汚す可能性があるもの（かるたの誤り指摘の実送信、絵札PDFの実生成）は行わず、
+// フォームの表示確認や画面遷移・表示内容の確認にとどめる
+test('normal read-aloud flow (category select -> phrase -> result), then browses print/reference views (issue #576)', async ({ browser }, testInfo) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await startCoverage(page);
+
+  // print-efuda画面の「印刷する」ボタンでwindow.print()の実ダイアログを
+  // 開かせないよう、ナビゲーション前に上書きしておく
+  await page.addInitScript(() => {
+    window.__printCalled = false;
+    window.print = () => { window.__printCalled = true; };
+  });
+
+  try {
+    await page.goto('/');
+
+    // 参照系画面（全札一覧・更新履歴・指摘一覧）は、どなた向けかを選ぶ前の
+    // トップ画面（App.jsxの`selectedCategories.length === 0 && !division`）にしか
+    // ボタンが無い。カテゴリ選択後のゲーム画面には存在しないため、division選択前に
+    // 先に一通り確認しておく
+    // 全札一覧画面: 検索・絞り込み・詳細画面への遷移
+    await page.getByText('全札一覧を見る →').click();
+    await expect(page.getByText('全札一覧')).toBeVisible();
+    await page.getByPlaceholder('読み札・読み・答えで検索').fill('ふでこぞう');
+    const matchedRow = page.getByRole('row', { name: /ふでこぞう/ });
+    await expect(matchedRow).toBeVisible();
+    await matchedRow.click();
+
+    // 詳細画面（かるたの誤りを指摘するフォームは表示だけ確認し、実送信はしない
+    // ——本番データへ恒久的な指摘レコードが残ってしまうため）
+    await expect(page.getByRole('heading', { name: /の詳細$/ })).toBeVisible();
+    await expect(page.getByText('読み上げる')).toBeVisible();
+    await expect(page.getByText('かるたの誤りを指摘する')).toBeVisible();
+    await expect(page.getByPlaceholder('例：かなが間違っている、フレーズが違うなど')).toBeVisible();
+    await page.getByText('← 戻る').click();
+    await expect(page.getByText('全札一覧')).toBeVisible();
+
+    // 全札一覧から戻る（division未選択のままなのでトップ画面に戻る）
+    await page.getByText('← 戻る').click();
+    await expect(page.getByText('こども向け')).toBeVisible();
+
+    // 更新履歴画面（changelog.jsonをビルド時に同梱しているだけで通信は発生しない）
+    await page.getByText('更新履歴を見る').click();
+    await expect(page.getByText('更新履歴')).toBeVisible();
+    await page.getByText('← 戻る').click();
+    await expect(page.getByText('こども向け')).toBeVisible();
+
+    // 指摘一覧画面
+    await page.getByText('指摘された内容を確認する').click();
+    await expect(page.getByText('指摘された内容一覧')).toBeVisible();
+
+    // ここから通常の読み上げフロー（カテゴリ選択→読み上げ→結果表示）
+    await page.goto('/');
+    await page.getByText('こども向け').click();
+    // こども向けは1タップで即座に読み上げ画面へ遷移する（App.jsxのtoggleDraftCategory）
+    await page.getByRole('button', { name: /おばけかるた/ }).click();
+
+    const nextButton = page.getByRole('button', { name: '次の札' });
+    await expect(nextButton).toBeVisible();
+    await expect(page.getByText('読み上げ済み 0 / 全45枚')).toBeVisible();
+
+    await nextButton.click();
+    // /get-phraseはPolly合成（未キャッシュ時）・Lambdaコールドスタートを伴うことがある
+    await expect(page.locator('.yomifuda-phrase')).toBeVisible({ timeout: 30000 });
+
+    // もう一度「次の札」を押すと、直前の札の結果（所要時間・答え）が表示されてから
+    // 次の札の取得に進む
+    await nextButton.click();
+    await expect(page.getByText('所要時間')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('読み上げ済み 1 / 全45枚')).toBeVisible();
+    await expect(page.locator('.yomifuda-phrase')).toBeVisible({ timeout: 30000 });
+
+    // 絵札印刷画面
+    await page.getByText('絵札を印刷する').click();
+    await expect(page.getByText('おばけかるたの絵札印刷')).toBeVisible();
+    await expect(page.locator('.efuda-card-text').first()).toBeVisible();
+
+    // 裏面表示（種別・レベルのみ、読み札本文は出ない）に切り替える
+    await page.getByRole('button', { name: '裏面' }).click();
+    await expect(page.locator('.efuda-card-back-category').first()).toBeVisible();
+
+    // 印刷ダイアログは開かせず、window.print()が呼ばれたことだけ確認する
+    await page.getByText('印刷する', { exact: true }).click();
+    await expect.poll(() => page.evaluate(() => window.__printCalled)).toBe(true);
+
+    await page.getByText('← 戻る').click();
+    await expect(nextButton).toBeVisible();
+  } finally {
+    await stopCoverage(page, testInfo);
+    await closeContext(context);
+  }
+});

--- a/frontend/e2e/app-flows.spec.js
+++ b/frontend/e2e/app-flows.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { startCoverage, stopCoverage, closeContext } from './coverage.js';
+import { captureScreenshot } from './screenshot.js';
 
 // issue #576対応: E2EのJSカバレッジを引き上げるため、これまでquiz-room.spec.jsの
 // クイズ大会モードでしかカバーできていなかった通常モード（カテゴリ選択→読み上げ→
@@ -33,6 +34,7 @@ test('normal read-aloud flow (category select -> phrase -> result), then browses
     await page.getByPlaceholder('読み札・読み・答えで検索').fill('ふでこぞう');
     const matchedRow = page.getByRole('row', { name: /ふでこぞう/ });
     await expect(matchedRow).toBeVisible();
+    await captureScreenshot(page, testInfo, 'all-phrases-search-result', '全札一覧画面：検索結果が絞り込まれた状態');
     await matchedRow.click();
 
     // 詳細画面（かるたの誤りを指摘するフォームは表示だけ確認し、実送信はしない
@@ -41,6 +43,7 @@ test('normal read-aloud flow (category select -> phrase -> result), then browses
     await expect(page.getByText('読み上げる')).toBeVisible();
     await expect(page.getByText('かるたの誤りを指摘する')).toBeVisible();
     await expect(page.getByPlaceholder('例：かなが間違っている、フレーズが違うなど')).toBeVisible();
+    await captureScreenshot(page, testInfo, 'detail-view', '詳細画面：かるたの誤りを指摘するフォームが表示された状態');
     await page.getByText('← 戻る').click();
     await expect(page.getByText('全札一覧')).toBeVisible();
 
@@ -51,12 +54,14 @@ test('normal read-aloud flow (category select -> phrase -> result), then browses
     // 更新履歴画面（changelog.jsonをビルド時に同梱しているだけで通信は発生しない）
     await page.getByText('更新履歴を見る').click();
     await expect(page.getByText('更新履歴')).toBeVisible();
+    await captureScreenshot(page, testInfo, 'changelog-view', '更新履歴画面');
     await page.getByText('← 戻る').click();
     await expect(page.getByText('こども向け')).toBeVisible();
 
     // 指摘一覧画面
     await page.getByText('指摘された内容を確認する').click();
     await expect(page.getByText('指摘された内容一覧')).toBeVisible();
+    await captureScreenshot(page, testInfo, 'comments-view', '指摘された内容一覧画面');
 
     // ここから通常の読み上げフロー（カテゴリ選択→読み上げ→結果表示）
     await page.goto('/');
@@ -77,16 +82,19 @@ test('normal read-aloud flow (category select -> phrase -> result), then browses
     await nextButton.click();
     await expect(page.getByText('所要時間')).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('読み上げ済み 1 / 全45枚')).toBeVisible();
+    await captureScreenshot(page, testInfo, 'normal-mode-result', '通常モード：結果画面（所要時間・答え表示）');
     await expect(page.locator('.yomifuda-phrase')).toBeVisible({ timeout: 30000 });
 
     // 絵札印刷画面
     await page.getByText('絵札を印刷する').click();
     await expect(page.getByText('おばけかるたの絵札印刷')).toBeVisible();
     await expect(page.locator('.efuda-card-text').first()).toBeVisible();
+    await captureScreenshot(page, testInfo, 'print-efuda-front', '絵札印刷画面：表面表示');
 
     // 裏面表示（種別・レベルのみ、読み札本文は出ない）に切り替える
     await page.getByRole('button', { name: '裏面' }).click();
     await expect(page.locator('.efuda-card-back-category').first()).toBeVisible();
+    await captureScreenshot(page, testInfo, 'print-efuda-back', '絵札印刷画面：裏面表示');
 
     // 印刷ダイアログは開かせず、window.print()が呼ばれたことだけ確認する
     await page.getByText('印刷する', { exact: true }).click();

--- a/frontend/e2e/app-flows.spec.js
+++ b/frontend/e2e/app-flows.spec.js
@@ -46,7 +46,7 @@ test('normal read-aloud flow (category select -> phrase -> result), then browses
     // 全札一覧画面: 検索・絞り込み・詳細画面への遷移
     await dismissPwaToastIfPresent();
     await page.getByText('全札一覧を見る →').click();
-    await expect(page.getByText('全札一覧')).toBeVisible();
+    await expect(page.getByRole('heading', { name: '全札一覧' })).toBeVisible();
     await page.getByPlaceholder('読み札・読み・答えで検索').fill('ふでこぞう');
     const matchedRow = page.getByRole('row', { name: /ふでこぞう/ });
     await expect(matchedRow).toBeVisible();
@@ -61,7 +61,7 @@ test('normal read-aloud flow (category select -> phrase -> result), then browses
     await expect(page.getByPlaceholder('例：かなが間違っている、フレーズが違うなど')).toBeVisible();
     await captureScreenshot(page, testInfo, 'detail-view', '詳細画面：かるたの誤りを指摘するフォームが表示された状態');
     await page.getByText('← 戻る').click();
-    await expect(page.getByText('全札一覧')).toBeVisible();
+    await expect(page.getByRole('heading', { name: '全札一覧' })).toBeVisible();
 
     // 全札一覧から戻る（division未選択のままなのでトップ画面に戻る）
     await page.getByText('← 戻る').click();
@@ -70,7 +70,10 @@ test('normal read-aloud flow (category select -> phrase -> result), then browses
     // 更新履歴画面（changelog.jsonをビルド時に同梱しているだけで通信は発生しない）
     await dismissPwaToastIfPresent();
     await page.getByText('更新履歴を見る').click();
-    await expect(page.getByText('更新履歴')).toBeVisible();
+    // changelog.json本体の各エントリ文中にも「更新履歴」という語が複数回登場するため
+    // （例: 本機能自体の追加を記録したエントリ）、getByTextでは複数要素にマッチして
+    // strict mode violationになる。見出し要素に限定する
+    await expect(page.getByRole('heading', { name: '更新履歴' })).toBeVisible();
     await captureScreenshot(page, testInfo, 'changelog-view', '更新履歴画面');
     await page.getByText('← 戻る').click();
     await expect(page.getByText('こども向け')).toBeVisible();
@@ -78,7 +81,7 @@ test('normal read-aloud flow (category select -> phrase -> result), then browses
     // 指摘一覧画面
     await dismissPwaToastIfPresent();
     await page.getByText('指摘された内容を確認する').click();
-    await expect(page.getByText('指摘された内容一覧')).toBeVisible();
+    await expect(page.getByRole('heading', { name: '指摘された内容一覧' })).toBeVisible();
     await captureScreenshot(page, testInfo, 'comments-view', '指摘された内容一覧画面');
 
     // ここから通常の読み上げフロー（カテゴリ選択→読み上げ→結果表示）


### PR DESCRIPTION
## Summary

issue #576対応（E2EのJSカバレッジ引き上げ）。

- 新規`frontend/e2e/app-flows.spec.js`を追加。これまでE2Eはクイズ大会モード（`quiz-room.spec.js`）でしかApp.jsxの主要ロジックをカバーできておらず、通常モード（カテゴリ選択→読み上げ→結果表示）や絵札印刷・全札一覧・詳細・更新履歴・指摘一覧といった参照画面が未カバーだった。
- 参照系画面（全札一覧・更新履歴・指摘一覧）へのリンクは、どなた向けかを選ぶ前のトップ画面にしか存在せず、カテゴリ選択後のゲーム画面には無いため、division選択前に先にこれらを一通り確認してから通常の読み上げフローへ進む順序にした。
- 絵札印刷画面は実際にゲーム画面から遷移し、表面・裏面表示切り替えを確認する。「印刷する」ボタンは`window.print()`の実ダイアログを開かせないよう事前に上書きし、呼び出されたことのみ確認する。
- 詳細画面の「かるたの誤りを指摘する」フォームは表示のみ確認し、実送信は行わない（本番データへ恒久的な指摘レコードが残ってしまうため）。絵札PDFの実生成も、コスト・時間の観点から対象外とした。

## 影響

新規E2Eテストファイルの追加のみ。既存コードへの変更なし。

## Test plan

- [x] frontend: `npm run lint` → 0 problems
- [x] frontend: `npm test -- --run` → 177 passed (177)
- [x] backend: `npm run lint` → 0 problems（本変更の対象外）
- [x] backend: `npm test -- --run` → 1492 passed (1492)（本変更の対象外）
- [ ] 本PRのCI（`frontend-e2e-test`ジョブ）で、追加したE2Eテストが実際のデプロイ済みバックエンドに対して正しく動作し、JSカバレッジが向上することをPR画面から確認する（`test:e2e`自体は実際のAWS環境と通信する構成のため、開発セッションのサンドボックス環境からは実行できず、CIでの確認が必要）

Refs #576

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_