### PR TITLE
feat(e2e): PRの変更と無関係なE2Eスクリーンショットを折りたたむ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ci:
-    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.2.4
+    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.3.0
     with:
       frontend_dir: frontend
       backend_dir: backend

--- a/frontend/e2e/screenshot.js
+++ b/frontend/e2e/screenshot.js
@@ -24,4 +24,10 @@ export async function captureScreenshot(page, testInfo, name, caption) {
   if (caption) {
     fs.writeFileSync(path.join(SCREENSHOT_DIR, `${name}.caption.txt`), caption, 'utf-8');
   }
+  // issue #628: PRの変更と無関係なスクリーンショットをCI側（reusable-ci.yml）で
+  // 折りたたむため、どのスペックファイルが撮影したかを記録する。testInfo.fileは
+  // Playwrightが自動的に持つ絶対パスなのでスペック側の追加対応は不要。CI側は
+  // これとspec-source-map.jsonの宣言、PRの変更ファイル一覧を突き合わせて
+  // 関連の有無を判定する
+  fs.writeFileSync(path.join(SCREENSHOT_DIR, `${name}.spec.txt`), path.basename(testInfo.file), 'utf-8');
 }

--- a/frontend/e2e/spec-source-map.json
+++ b/frontend/e2e/spec-source-map.json
@@ -1,0 +1,19 @@
+{
+  "quiz-room.spec.js": [
+    "frontend/src/App.jsx",
+    "frontend/src/views/QuizRoomView.jsx",
+    "frontend/src/views/QuizRoomInfoView.jsx",
+    "frontend/src/hooks/useQuizRoomAdmin.js",
+    "frontend/src/utils/quizRoomParticipants.js",
+    "backend/quizRoomHandler.js"
+  ],
+  "app-flows.spec.js": [
+    "frontend/src/App.jsx",
+    "frontend/src/PwaUpdatePrompt.jsx",
+    "frontend/src/views/AllPhrasesView.jsx",
+    "frontend/src/views/DetailView.jsx",
+    "frontend/src/views/ChangelogView.jsx",
+    "frontend/src/views/CommentsView.jsx",
+    "frontend/src/views/PrintEfudaView.jsx"
+  ]
+}


### PR DESCRIPTION
## Summary

issue #628対応（案A: 宣言的な対応関係）。dev-standards側（PR #81、v1.3.0）で追加されたE2Eスクリーンショットの折りたたみ機能に対応する。

- 新規`frontend/e2e/spec-source-map.json`。各E2Eスペックファイル（`quiz-room.spec.js`・`app-flows.spec.js`）が検証対象とするソースパスを宣言した。CI側がPRの変更ファイル一覧と突き合わせ、重なりが無ければそのスペックのスクリーンショット群を折りたたむ。
- `frontend/e2e/screenshot.js`の`captureScreenshot()`に、撮影したスペックファイル名（Playwrightの`testInfo.file`から自動取得）を`<name>.spec.txt`として書き出す処理を追加した。
- `.github/workflows/ci.yml`のreusable-ci.yml参照タグをv1.2.4からv1.3.0（この機能を含むリリース）へ引き上げた。

## 影響

E2Eスクリーンショットの折りたたみ判定に必要な宣言・メタデータの追加のみ。既存のスクリーンショット撮影・キャプション表示のロジックは変更していない。

## Test plan

- [x] frontend: `npm run lint` → 0 problems
- [x] frontend: `npm test -- --run` → 177 passed (177)
- [x] backend: 本変更の対象外
- [x] `captureScreenshot()`が`.spec.txt`を正しく書き出すことを、モックの`testInfo`オブジェクトを使いローカルで手動確認済み
- [ ] 実際のCIでの折りたたみ動作は、本PRのCI実行結果（`frontend-e2e-test`ジョブのPRコメント）で確認する

Refs #628

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_