### PR TITLE
fix(quiz-room): 画面ロック・バックグラウンド復帰後にWebSocketを再接続する

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import { useSessionStorageState } from "./hooks/useSessionStorageState";
 import { useUrlQuerySync, parseCategoriesParam } from "./hooks/useUrlQuerySync";
 import { useWakeLock } from "./hooks/useWakeLock";
 import { useQuizRoomAdmin } from "./hooks/useQuizRoomAdmin";
+import { CONNECTION_STATUS_LABEL } from "./hooks/useQuizRoomSync";
 import DetailView from "./views/DetailView";
 import PrintEfudaView from "./views/PrintEfudaView";
 import AllPhrasesView from "./views/AllPhrasesView";
@@ -903,6 +904,8 @@ function App() {
     quizRoomBuzzedBy,
     quizRoomPoints,
     quizRoomParticipants,
+    quizRoomConnectionStatus,
+    reconnectQuizRoom,
     createQuizRoom,
     joinQuizRoom,
     judgeQuizRoomBuzz,
@@ -1605,6 +1608,27 @@ function App() {
       </div>
       {quizRoom ? (
         <div className="mb-4">
+          {/* issue #614: 管理者側は従来connectionStatusを受け取ってすらおらず、
+              切断されたことが画面のどこにも表示されなかった（切断に気づかず
+              読み上げを進めると参加者に札が配信されない不具合があった）。
+              接続状態が悪い場合のみ警告として表示し、平常時は表示を増やさない */}
+          {quizRoomConnectionStatus !== "connected" && (
+            <p className="text-danger small mb-2">
+              <span>
+                クイズ大会の接続状態: {CONNECTION_STATUS_LABEL[quizRoomConnectionStatus] || quizRoomConnectionStatus}
+                （参加者に札が届いていない可能性があります）
+              </span>
+              {quizRoomConnectionStatus === "error" && (
+                <button
+                  type="button"
+                  onClick={reconnectQuizRoom}
+                  className="btn btn-sm btn-outline-danger rounded-pill ms-2"
+                >
+                  再接続
+                </button>
+              )}
+            </p>
+          )}
           <button
             type="button"
             onClick={() => setView("quiz-room-info")}

--- a/frontend/src/hooks/useQuizRoomAdmin.js
+++ b/frontend/src/hooks/useQuizRoomAdmin.js
@@ -69,7 +69,7 @@ export function useQuizRoomAdmin({
   }, [isOnTopPage]);
 
   // クイズ大会モード: quizRoomが設定されている（管理者としてルームを開設した）間だけ接続する
-  const { broadcastState: broadcastQuizRoomState, judgeBuzz } = useQuizRoomSync({
+  const { connectionStatus: quizRoomConnectionStatus, broadcastState: broadcastQuizRoomState, judgeBuzz, reconnect: reconnectQuizRoom } = useQuizRoomSync({
     wsBaseUrl: WS_BASE_URL,
     roomId: quizRoom?.roomId,
     adminToken: quizRoom?.adminToken,
@@ -192,6 +192,8 @@ export function useQuizRoomAdmin({
     quizRoomBuzzedBy,
     quizRoomPoints,
     quizRoomParticipants,
+    quizRoomConnectionStatus,
+    reconnectQuizRoom,
     createQuizRoom,
     joinQuizRoom,
     judgeQuizRoomBuzz,

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -215,8 +215,6 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('shows the admin a connection warning once the connection is lost, and a reconnect button once retries are exhausted (issue #614)', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-
     class MockWebSocket {
       constructor(url) {
         this.url = url;
@@ -262,6 +260,12 @@ describe('useQuizRoomAdmin (via App)', () => {
     // 促す必要が無いため）
     expect(screen.getByText(/クイズ大会の接続状態: 接続中/)).toBeInTheDocument();
     expect(screen.queryByText('再接続')).not.toBeInTheDocument();
+
+    // 再接続の待ち時間（3秒間隔）を手動で進めるため、ここでフェイクタイマーへ
+    // 切り替える（ここまでのAppの初期表示・ルーム作成は実タイマーのまま行う。
+    // shouldAdvanceTime: trueは実時間の経過とfireTimersByTimeの呼び出しが
+    // 競合しMockWebSocket.instancesの数え上げがずれることがあったため使わない）
+    vi.useFakeTimers();
 
     // 再接続の上限（5回）まで切断を繰り返し、"error"状態に到達させる
     for (let attempt = 0; attempt < 6; attempt += 1) {

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -214,6 +214,81 @@ describe('useQuizRoomAdmin (via App)', () => {
     });
   }, 40000);
 
+  it('shows the admin a connection warning once the connection is lost, and a reconnect button once retries are exhausted (issue #614)', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        this.onopen = null;
+        this.onclose = null;
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {
+        this.readyState = 3;
+      }
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    // ハンドシェイク中（まだonopenが呼ばれていない）は「接続中...」の警告が
+    // 出るが、再接続ボタンはまだ出さない（一時的な状態であり、ユーザー操作を
+    // 促す必要が無いため）
+    expect(screen.getByText(/クイズ大会の接続状態: 接続中/)).toBeInTheDocument();
+    expect(screen.queryByText('再接続')).not.toBeInTheDocument();
+
+    // 再接続の上限（5回）まで切断を繰り返し、"error"状態に到達させる
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      const instance = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+      act(() => {
+        instance.readyState = 3;
+        instance.onclose?.();
+      });
+      if (attempt < 5) {
+        act(() => {
+          vi.advanceTimersByTime(3000);
+        });
+      }
+    }
+
+    expect(screen.getByText(/クイズ大会の接続状態: 接続できませんでした/)).toBeInTheDocument();
+    const reconnectButton = screen.getByText('再接続');
+    const countBeforeReconnect = MockWebSocket.instances.length;
+
+    fireEvent.click(reconnectButton);
+
+    expect(MockWebSocket.instances).toHaveLength(countBeforeReconnect + 1);
+    expect(screen.getByText(/クイズ大会の接続状態: 接続中/)).toBeInTheDocument();
+
+    vi.useRealTimers();
+  }, 20000);
+
   it('shows the responder\'s name to the admin when a participant buzzes in, and resets it once the next card is shown (issue #510)', async () => {
     class MockWebSocket {
       constructor(url) {

--- a/frontend/src/hooks/useQuizRoomSync.js
+++ b/frontend/src/hooks/useQuizRoomSync.js
@@ -2,10 +2,24 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 const RECONNECT_DELAY_MS = 3000;
 const MAX_RECONNECT_ATTEMPTS = 5; // 際限ない再接続ループを防ぐための上限
+// issue #614: 通常の再接続上限（5回・3秒間隔、約15秒）を使い切って"error"状態に
+// 達した後も、画面がフォアグラウンド（visible）である間は完全には諦めず、この
+// 緩い間隔で再試行を続ける。バックグラウンド中の無駄な再試行はせず、フォアグラウンド
+// 復帰時（下記のvisibilitychangeハンドラ）に即座に再接続を試みる方に任せる
+const ERROR_RETRY_INTERVAL_MS = 15000;
 // プッシュ通知（updateStateのブロードキャスト）が何らかの理由で届かなかった場合に備え、
 // 一定間隔でsyncを再要求し自己修復させる保険（本来はプッシュのみで完結するはずだが、
 // 個別のブロードキャスト送信が届かないケースを完全には排除できないため）
 const SYNC_POLL_INTERVAL_MS = 5000;
+
+// connectionStatusの値ごとの表示ラベル。参加者画面（QuizRoomView.jsx）・
+// 管理者画面（App.jsx、issue #614で追加）の両方で同じ表記を使うため共有する
+export const CONNECTION_STATUS_LABEL = {
+  idle: "未接続",
+  connecting: "接続中...",
+  connected: "接続済み",
+  error: "接続できませんでした",
+};
 
 // クイズ大会モード（issue #470）のWebSocket接続を管理する。adminTokenを渡すと管理者として、
 // 渡さなければ参加者（閲覧専用）として接続する。サーバーから状態（{type:"state", state, role}）を
@@ -33,6 +47,10 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
   const reconnectTimeoutRef = useRef(null);
   const closedByCleanupRef = useRef(false);
   const pollTimerRef = useRef(null);
+  // issue #614: connect自体はwsBaseUrl/roomId/adminTokenが変わるたびに再生成される
+  // 別のuseEffect内で定義されるため、フォアグラウンド復帰・手動再接続（下記の
+  // forceReconnect）から常に最新のconnectを呼べるようrefに保持する
+  const connectRef = useRef(() => {});
   // broadcastStateに渡された直近の状態。接続確立前（初回接続のLambdaコールド
   // スタート・WSハンドシェイク中）やその後の再接続中にbroadcastStateが呼ばれると、
   // それまではreadyState !== OPENのため送信が黙って失われ、参加者側の画面が
@@ -139,6 +157,10 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
         }
         if (reconnectAttemptsRef.current >= MAX_RECONNECT_ATTEMPTS) {
           setInternalStatus("error");
+          // issue #614: フォアグラウンドである間は、緩い間隔で再試行を続ける
+          if (typeof document !== "undefined" && document.visibilityState === "visible") {
+            reconnectTimeoutRef.current = setTimeout(connect, ERROR_RETRY_INTERVAL_MS);
+          }
           return;
         }
         reconnectAttemptsRef.current += 1;
@@ -147,6 +169,7 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
       };
     };
 
+    connectRef.current = connect;
     connect();
 
     return () => {
@@ -160,6 +183,49 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
       wsRef.current?.close();
     };
   }, [wsBaseUrl, roomId, adminToken]);
+
+  // issue #614: スマホの画面ロック・バックグラウンド復帰後、WebSocketが切断された
+  // ままになり自動再接続されないことがある（バックグラウンド中はブラウザが
+  // タイマーをスロットリングするため、復帰前に再接続試行の上限を使い切って
+  // しまうケースがある）。現在の接続が生きていなければ（readyState !== OPEN）、
+  // 試行回数をリセットして即座に再接続する。フォアグラウンド復帰
+  // （visibilitychange）・オンライン復帰（online）、および手動再接続ボタン
+  // （戻り値のreconnect）の両方から使う共通の関数
+  const forceReconnect = useCallback(() => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      return;
+    }
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+    if (wsRef.current) {
+      // 古い接続のonclose/onerrorが、これから行う再接続と二重に反応しないよう、
+      // 明示的に閉じる前にハンドラを外す
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.close();
+    }
+    reconnectAttemptsRef.current = 0;
+    connectRef.current();
+  }, []);
+
+  useEffect(() => {
+    if (!wsBaseUrl || !roomId) {
+      return undefined;
+    }
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        forceReconnect();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("online", forceReconnect);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("online", forceReconnect);
+    };
+  }, [wsBaseUrl, roomId, forceReconnect]);
 
   const broadcastState = useCallback((state) => {
     pendingStateRef.current = state;
@@ -190,5 +256,5 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
     }
   }, []);
 
-  return { connectionStatus, broadcastState, setParticipantName, buzz, judgeBuzz };
+  return { connectionStatus, broadcastState, setParticipantName, buzz, judgeBuzz, reconnect: forceReconnect };
 }

--- a/frontend/src/hooks/useQuizRoomSync.test.js
+++ b/frontend/src/hooks/useQuizRoomSync.test.js
@@ -367,6 +367,142 @@ describe('useQuizRoomSync', () => {
     expect(result.current.connectionStatus).toBe('error');
   });
 
+  // issue #614: スマホの画面ロック・バックグラウンド復帰後、WebSocketが切断された
+  // ままになり自動再接続されないことがある不具合の対応
+  describe('reconnecting on foreground/online recovery (issue #614)', () => {
+    const setVisibilityState = (state) => {
+      Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+    };
+
+    afterEach(() => {
+      setVisibilityState('visible');
+    });
+
+    it('immediately reconnects when the tab becomes visible again, even after the retry limit was exhausted', () => {
+      vi.useFakeTimers();
+      const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        const instance = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+        act(() => {
+          instance.triggerClose();
+          vi.advanceTimersByTime(3000);
+        });
+      }
+      act(() => {
+        MockWebSocket.instances[MockWebSocket.instances.length - 1].triggerClose();
+      });
+      expect(result.current.connectionStatus).toBe('error');
+      const countBeforeVisible = MockWebSocket.instances.length;
+
+      setVisibilityState('visible');
+      act(() => {
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      // 試行回数を使い切った後でも、フォアグラウンド復帰で即座に新しい接続が張られる
+      expect(MockWebSocket.instances).toHaveLength(countBeforeVisible + 1);
+      expect(result.current.connectionStatus).toBe('connecting');
+    });
+
+    it('does not reconnect when visibilitychange fires while the tab is still hidden', () => {
+      vi.useFakeTimers();
+      renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+      const countBefore = MockWebSocket.instances.length;
+
+      setVisibilityState('hidden');
+      act(() => {
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      expect(MockWebSocket.instances).toHaveLength(countBefore);
+    });
+
+    it('does not open a redundant connection when visibilitychange fires while already connected', () => {
+      vi.useFakeTimers();
+      const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+      act(() => {
+        MockWebSocket.instances[0].triggerOpen();
+      });
+      expect(result.current.connectionStatus).toBe('connected');
+
+      act(() => {
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+
+    it('reconnects immediately when the browser reports it is back online', () => {
+      vi.useFakeTimers();
+      const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+      act(() => {
+        MockWebSocket.instances[0].triggerClose();
+      });
+      expect(result.current.connectionStatus).toBe('connecting');
+
+      act(() => {
+        window.dispatchEvent(new Event('online'));
+      });
+
+      // オンライン復帰で、3秒の再接続待ちを待たずに即座に新しい接続が張られる
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+
+    it('lets the caller trigger a manual reconnect via the returned reconnect() function', () => {
+      vi.useFakeTimers();
+      const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        const instance = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+        act(() => {
+          instance.triggerClose();
+          vi.advanceTimersByTime(3000);
+        });
+      }
+      act(() => {
+        MockWebSocket.instances[MockWebSocket.instances.length - 1].triggerClose();
+      });
+      expect(result.current.connectionStatus).toBe('error');
+
+      act(() => {
+        result.current.reconnect();
+      });
+
+      expect(result.current.connectionStatus).toBe('connecting');
+      act(() => {
+        MockWebSocket.instances[MockWebSocket.instances.length - 1].triggerOpen();
+      });
+      expect(result.current.connectionStatus).toBe('connected');
+    });
+
+    it('keeps retrying at a slower interval past the retry limit while the tab stays visible, instead of giving up permanently', () => {
+      vi.useFakeTimers();
+      const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        const instance = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+        act(() => {
+          instance.triggerClose();
+          vi.advanceTimersByTime(3000);
+        });
+      }
+      act(() => {
+        MockWebSocket.instances[MockWebSocket.instances.length - 1].triggerClose();
+      });
+      expect(result.current.connectionStatus).toBe('error');
+      const countAtError = MockWebSocket.instances.length;
+
+      act(() => {
+        vi.advanceTimersByTime(15000);
+      });
+
+      expect(MockWebSocket.instances).toHaveLength(countAtError + 1);
+    });
+  });
+
   it('does not reconnect after the hook unmounts (cleanup closes the connection)', () => {
     vi.useFakeTimers();
     const { unmount } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useQuizRoomSync } from "../hooks/useQuizRoomSync";
+import { useQuizRoomSync, CONNECTION_STATUS_LABEL } from "../hooks/useQuizRoomSync";
 import { API_BASE_URL } from "../config";
 import { unlockAudioPlayback, playSharedAudio } from "../utils/audioUnlock";
 import { mergeParticipantsWithPoints } from "../utils/quizRoomParticipants";
@@ -8,13 +8,6 @@ import { mergeParticipantsWithPoints } from "../utils/quizRoomParticipants";
 // ルームコードの直接入力、または招待URL（?roomId=...）からの参加に対応する。
 // ルーム作成（管理者側の導線）はここではなく、通常のかるた読み上げ画面の
 // フッターのボタン→QuizRoomInfoView（issue #547）経由で行う（App.jsx参照）
-
-const CONNECTION_STATUS_LABEL = {
-  idle: "未接続",
-  connecting: "接続中...",
-  connected: "接続済み",
-  error: "接続できませんでした",
-};
 
 const MAX_NAME_LENGTH = 20; // backend/quizRoomHandler.jsのMAX_NAME_LENGTHと合わせる（早押し機能、issue #510）
 
@@ -125,7 +118,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     }
   };
 
-  const { connectionStatus, setParticipantName, buzz } = useQuizRoomSync({
+  const { connectionStatus, setParticipantName, buzz, reconnect } = useQuizRoomSync({
     wsBaseUrl,
     roomId: joinRoomId,
     onState: setRoomState,
@@ -346,7 +339,21 @@ function QuizRoomView({ setView, wsBaseUrl }) {
           <h1 className="h4 fw-bold">クイズ大会モード（参加者）</h1>
           <p className="text-muted small">ルーム: {joinRoomId}</p>
         </header>
-        <p className="text-muted small mb-3">接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}</p>
+        <p className="text-muted small mb-3">
+          <span>接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}</span>
+          {/* issue #614: 再接続の上限に達した場合、フォアグラウンド復帰・オンライン復帰では
+              自動的に再接続を試みるが、それでも復帰しない場合に手動でやり直せる導線が
+              無かったため追加する */}
+          {connectionStatus === "error" && (
+            <button
+              type="button"
+              onClick={reconnect}
+              className="btn btn-sm btn-outline-danger rounded-pill ms-2"
+            >
+              再接続
+            </button>
+          )}
+        </p>
         <p className="fw-bold text-dark">獲得ポイント: {points[confirmedName] || 0}</p>
         {renderParticipantContent(roomState)}
         {buzzedBy ? (

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -12,6 +12,7 @@ const onParticipantsCallbacks = [];
 let mockConnectionStatus = 'connected';
 const setParticipantNameMock = vi.fn();
 const buzzMock = vi.fn();
+const reconnectMock = vi.fn();
 
 vi.mock('../hooks/useQuizRoomSync', () => ({
   useQuizRoomSync: ({ onState, onBuzz, onPoints, onNameError, onRoundReset, onParticipants }) => {
@@ -26,7 +27,14 @@ vi.mock('../hooks/useQuizRoomSync', () => ({
       broadcastState: vi.fn(),
       setParticipantName: setParticipantNameMock,
       buzz: buzzMock,
+      reconnect: reconnectMock,
     };
+  },
+  CONNECTION_STATUS_LABEL: {
+    idle: '未接続',
+    connecting: '接続中...',
+    connected: '接続済み',
+    error: '接続できませんでした',
   },
 }));
 
@@ -98,6 +106,7 @@ beforeEach(() => {
   mockConnectionStatus = 'connected';
   setParticipantNameMock.mockClear();
   buzzMock.mockClear();
+  reconnectMock.mockClear();
   fetch.mockReset();
   // 個別のテストが/get-phrase等を明示的にモックしなかった場合のデフォルト応答。
   // 未設定のままだとfetch()がundefinedを返し、レスポンスのプロパティアクセスで
@@ -200,6 +209,22 @@ describe('QuizRoomView', () => {
     confirmName();
 
     expect(screen.getByText('接続状態: 接続できませんでした')).toBeInTheDocument();
+  });
+
+  it('shows a manual reconnect button only when the connection has failed, and calls reconnect() when clicked (issue #614)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    mockConnectionStatus = 'connected';
+
+    const { rerender } = render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
+
+    expect(screen.queryByText('再接続')).not.toBeInTheDocument();
+
+    mockConnectionStatus = 'error';
+    rerender(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+
+    fireEvent.click(screen.getByText('再接続'));
+    expect(reconnectMock).toHaveBeenCalled();
   });
 
   it('lets a participant leave the room and go back to the normal game view', () => {


### PR DESCRIPTION
## Summary

issue #614対応。クイズ大会の参加者・管理者がスマホの画面をロックしたりブラウザをバックグラウンドに回したりするとWebSocketが切断され、以下の理由で復帰できないままになることがあった。

- 再接続はMAX_RECONNECT_ATTEMPTS=5回・RECONNECT_DELAY_MS=3000msの固定で、約15秒で使い切ると以後自動再接続しない
- バックグラウンド中はブラウザがタイマーをスロットリングするため、フォアグラウンド復帰前に試行を消費・失敗しているケースがある
- "error"状態からの手動再接続の導線（再接続ボタン）が無かった
- 管理者側（App.jsx）はconnectionStatusを受け取ってすらおらず、切断されたことが画面のどこにも表示されなかった

## 対応内容（issueの4項目）

1. `useQuizRoomSync.js`に`visibilitychange`（フォアグラウンド復帰）・`online`（オンライン復帰）イベントのハンドラを追加し、現在の接続が生きていなければ試行回数をリセットして即座に再接続する
2. 参加者画面（QuizRoomView.jsx）・管理者画面（App.jsx）双方に、接続失敗時のみ「再接続」ボタンを表示
3. 管理者側にも接続状態を表示し、"connected"以外の間は警告文を表示するようにした
4. 再接続上限到達後も、フォアグラウンドである間は緩い間隔（15秒）で再試行を続けるようにした

参加者・管理者画面で重複していた接続状態ラベル定義は`useQuizRoomSync.js`からの共有exportに一本化した。

## 影響

クイズ大会モードのWebSocket再接続ロジックとUI表示のみ。バックエンド（`backend/quizRoomHandler.js`）への変更はなし。

## Test plan

- [x] frontend: `npm run lint` → 0 problems
- [x] frontend: `npm test -- --run` → 185 passed (185)
  - `visibilitychange`・`online`復帰での即時再接続、既に接続済みなら再接続しないこと、バックグラウンド中は反応しないこと、手動`reconnect()`、上限到達後もフォアグラウンドなら緩い間隔で再試行を続けることを検証
  - 再接続ボタンがerror状態でのみ表示されクリックで`reconnect()`が呼ばれることを検証（参加者・管理者双方）
- [x] backend: `npm run lint` → 0 problems / `npm test -- --run` → 1492 passed (1492)（本変更の対象外）

Closes #614

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_