### PR TITLE
feat(quiz-room): 管理者がポイントを明示的にリセットできるようにする

### DIFF
--- a/backend/quizRoomHandler.js
+++ b/backend/quizRoomHandler.js
@@ -462,6 +462,50 @@ exports.judgeQuizRoomBuzz = async (event) => {
   }
 };
 
+// WebSocketカスタムルート"resetPoints"（issue #615）。管理者のみがポイント集計を
+// 初期化できる。同じルームで2ゲーム目を始める際、前のゲームのポイントを引き継がずに
+// 再スタートしたい場合に使う。ゲームリセット（"initial"へ戻る）のたびに自動では
+// リセットしない。カテゴリを切り替えても通算得点で戦い続けたいユースケースもあり、
+// 自動リセットにするとそれを一律に壊してしまうため、管理者の明示操作のみで行う
+exports.resetQuizRoomPoints = async (event) => {
+  try {
+    const connectionId = event.requestContext.connectionId;
+    const connection = await docClient.send(new GetCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      Key: { connectionId },
+    }));
+    if (!connection.Item || connection.Item.role !== "admin") {
+      return { statusCode: 403, body: "Forbidden" };
+    }
+
+    const { roomId } = connection.Item;
+    await docClient.send(new UpdateCommand({
+      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+      Key: { roomId },
+      UpdateExpression: "REMOVE points",
+    }));
+
+    const connections = await docClient.send(new QueryCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      IndexName: "roomId-index",
+      KeyConditionExpression: "roomId = :roomId",
+      ExpressionAttributeValues: { ":roomId": roomId },
+    }));
+    const managementApi = buildManagementApiClient(event);
+    await Promise.allSettled(
+      (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
+        type: "points",
+        points: {},
+      }))
+    );
+
+    return { statusCode: 200, body: "" };
+  } catch (error) {
+    console.error(error);
+    return { statusCode: 500, body: "Internal Server Error" };
+  }
+};
+
 // WebSocketカスタムルート"setName"（早押し機能、issue #510）。参加者（管理者含む、
 // ただし実際に使うのは参加者のみ）が自分の表示名を接続情報へ保存する
 exports.setQuizRoomName = async (event) => {

--- a/backend/quizRoomHandler.test.js
+++ b/backend/quizRoomHandler.test.js
@@ -13,6 +13,7 @@ import {
   setQuizRoomName,
   buzzQuizRoom,
   judgeQuizRoomBuzz,
+  resetQuizRoomPoints,
 } from './quizRoomHandler';
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
@@ -849,6 +850,52 @@ describe('judgeQuizRoomBuzz', () => {
   it('handles unexpected errors', async () => {
     ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
     const response = await judgeQuizRoomBuzz(wsEvent({ body: { correct: true } }));
+    expect(response.statusCode).toBe(500);
+  });
+});
+
+describe('resetQuizRoomPoints', () => {
+  it('rejects when the caller is not an admin', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' } });
+    const response = await resetQuizRoomPoints(wsEvent({}));
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('rejects when the connection record is missing', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+    const response = await resetQuizRoomPoints(wsEvent({}));
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('removes the points attribute and broadcasts an empty points map to every connection (issue #615)', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+        { connectionId: 'conn-p', roomId: 'ROOM01', role: 'participant' },
+      ],
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    const response = await resetQuizRoomPoints(wsEvent({ connectionId: 'conn-admin' }));
+
+    expect(response.statusCode).toBe(200);
+    const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(updateCall.Key).toEqual({ roomId: 'ROOM01' });
+    expect(updateCall.UpdateExpression).toBe('REMOVE points');
+
+    const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
+    expect(postCalls).toHaveLength(2);
+    const payload = JSON.parse(Buffer.from(postCalls[0].args[0].input.Data).toString('utf-8'));
+    expect(payload).toEqual({ type: 'points', points: {} });
+  });
+
+  it('handles unexpected errors', async () => {
+    ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
+    const response = await resetQuizRoomPoints(wsEvent({}));
     expect(response.statusCode).toBe(500);
   });
 });

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -233,6 +233,11 @@ functions:
     events:
       - websocket:
           route: judgeBuzz
+  resetQuizRoomPoints: # 追加（issue #615）。管理者のみポイント集計を初期化でき、ルーム内全接続へブロードキャストする
+    handler: quizRoomHandler.resetQuizRoomPoints
+    events:
+      - websocket:
+          route: resetPoints
 
 resources:
   Resources:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -906,6 +906,7 @@ function App() {
     quizRoomParticipants,
     quizRoomConnectionStatus,
     reconnectQuizRoom,
+    resetQuizRoomPoints,
     createQuizRoom,
     joinQuizRoom,
     judgeQuizRoomBuzz,
@@ -1158,6 +1159,7 @@ function App() {
         roomId={quizRoom.roomId}
         quizRoomParticipants={quizRoomParticipants}
         quizRoomPoints={quizRoomPoints}
+        resetQuizRoomPoints={resetQuizRoomPoints}
       />
     );
   }

--- a/frontend/src/hooks/useQuizRoomAdmin.js
+++ b/frontend/src/hooks/useQuizRoomAdmin.js
@@ -69,7 +69,13 @@ export function useQuizRoomAdmin({
   }, [isOnTopPage]);
 
   // クイズ大会モード: quizRoomが設定されている（管理者としてルームを開設した）間だけ接続する
-  const { connectionStatus: quizRoomConnectionStatus, broadcastState: broadcastQuizRoomState, judgeBuzz, reconnect: reconnectQuizRoom } = useQuizRoomSync({
+  const {
+    connectionStatus: quizRoomConnectionStatus,
+    broadcastState: broadcastQuizRoomState,
+    judgeBuzz,
+    resetPoints: resetQuizRoomPoints,
+    reconnect: reconnectQuizRoom,
+  } = useQuizRoomSync({
     wsBaseUrl: WS_BASE_URL,
     roomId: quizRoom?.roomId,
     adminToken: quizRoom?.adminToken,
@@ -194,6 +200,7 @@ export function useQuizRoomAdmin({
     quizRoomParticipants,
     quizRoomConnectionStatus,
     reconnectQuizRoom,
+    resetQuizRoomPoints,
     createQuizRoom,
     joinQuizRoom,
     judgeQuizRoomBuzz,

--- a/frontend/src/hooks/useQuizRoomSync.js
+++ b/frontend/src/hooks/useQuizRoomSync.js
@@ -256,5 +256,13 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
     }
   }, []);
 
-  return { connectionStatus, broadcastState, setParticipantName, buzz, judgeBuzz, reconnect: forceReconnect };
+  // ポイントリセット（issue #615）: 管理者が同じルームで2ゲーム目を始める際、
+  // 前のゲームのポイントを引き継がずに再スタートしたい場合に送信する
+  const resetPoints = useCallback(() => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ action: "resetPoints" }));
+    }
+  }, []);
+
+  return { connectionStatus, broadcastState, setParticipantName, buzz, judgeBuzz, resetPoints, reconnect: forceReconnect };
 }

--- a/frontend/src/hooks/useQuizRoomSync.test.js
+++ b/frontend/src/hooks/useQuizRoomSync.test.js
@@ -195,6 +195,22 @@ describe('useQuizRoomSync', () => {
     expect(MockWebSocket.instances[0].sent).toContainEqual(JSON.stringify({ action: 'judgeBuzz', correct: false }));
   });
 
+  it('resetPoints sends resetPoints only while the connection is open (issue #615)', () => {
+    const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+    act(() => {
+      result.current.resetPoints();
+    });
+    expect(MockWebSocket.instances[0].sent).toEqual([]);
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+      result.current.resetPoints();
+    });
+
+    expect(MockWebSocket.instances[0].sent).toContainEqual(JSON.stringify({ action: 'resetPoints' }));
+  });
+
   it('setParticipantName sends setName only while the connection is open, and resends it once the socket opens if called earlier', () => {
     const { result } = renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
 

--- a/frontend/src/views/QuizRoomInfoView.jsx
+++ b/frontend/src/views/QuizRoomInfoView.jsx
@@ -8,7 +8,7 @@ import { mergeParticipantsWithPoints } from "../utils/quizRoomParticipants";
 // useQuizRoomSync（WebSocket接続）はApp.jsx側のトップレベルで呼ばれており、
 // view遷移によってApp自体がアンマウントされることはないため、この画面への
 // 遷移中も読み上げ・早押し等のクイズ大会の進行状態は維持される
-function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoomPoints = {} }) {
+function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoomPoints = {}, resetQuizRoomPoints }) {
   const [qrDataUrl, setQrDataUrl] = useState(null);
   const [copied, setCopied] = useState(false);
 
@@ -24,6 +24,16 @@ function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoom
   // 統合して表示する。以前は通常のゲーム画面にインラインで表示していたが、ルーム情報
   // 画面（この画面）の下部へ移動し、表形式に変更した（issue #587）
   const participantList = mergeParticipantsWithPoints(quizRoomParticipants, quizRoomPoints);
+
+  // ポイントリセット（issue #615）: 同じルームで2ゲーム目を始める際、前のゲームの
+  // ポイントを引き継がずに再スタートしたい場合に管理者が明示的に実行する。取り消せない
+  // 操作のため確認ダイアログを挟む（ゲームリセット等での自動リセットは行わない。
+  // カテゴリを切り替えても通算得点で戦い続けたいユースケースを壊さないため）
+  const handleResetPoints = () => {
+    if (window.confirm("参加者全員のポイントをリセットします。よろしいですか？")) {
+      resetQuizRoomPoints?.();
+    }
+  };
 
   const copyUrl = async () => {
     try {
@@ -84,6 +94,11 @@ function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoom
               ))}
             </tbody>
           </table>
+          <div className="text-end mt-2">
+            <button type="button" onClick={handleResetPoints} className="btn btn-sm btn-outline-danger">
+              ポイントをリセット
+            </button>
+          </div>
         </div>
       )}
       <div className="mt-5">

--- a/frontend/src/views/QuizRoomInfoView.test.jsx
+++ b/frontend/src/views/QuizRoomInfoView.test.jsx
@@ -60,6 +60,28 @@ describe('QuizRoomInfoView', () => {
   it('does not show the participant list section when there are no participants yet', () => {
     render(<QuizRoomInfoView setView={vi.fn()} roomId="ABC123" />);
     expect(screen.queryByText('参加者一覧')).not.toBeInTheDocument();
+    expect(screen.queryByText('ポイントをリセット')).not.toBeInTheDocument();
+  });
+
+  it('calls resetQuizRoomPoints only after the admin confirms the reset (issue #615)', () => {
+    const resetQuizRoomPoints = vi.fn();
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(
+      <QuizRoomInfoView
+        setView={vi.fn()}
+        roomId="ABC123"
+        quizRoomParticipants={['たろう']}
+        quizRoomPoints={{ たろう: 3 }}
+        resetQuizRoomPoints={resetQuizRoomPoints}
+      />
+    );
+
+    fireEvent.click(screen.getByText('ポイントをリセット'));
+    expect(resetQuizRoomPoints).not.toHaveBeenCalled();
+
+    window.confirm.mockReturnValue(true);
+    fireEvent.click(screen.getByText('ポイントをリセット'));
+    expect(resetQuizRoomPoints).toHaveBeenCalled();
   });
 
   it('lets the admin go back to the normal game screen', () => {


### PR DESCRIPTION
## Summary

issue #615対応。同じルームで2ゲーム目を開始しても前のゲームのポイントが残り続け、リセットする手段が存在しなかった。

対応方針は「ゲームリセット時に自動リセット」と「管理者が明示的にボタンを押した時だけリセット」の2案があり、ユーザーに確認の上、後者を採用した。自動リセットにすると、カテゴリを切り替えても通算得点で戦い続けたいユースケースを一律に壊してしまうため。

## 対応内容

- `backend/quizRoomHandler.js`: 新規WebSocketカスタムルート`resetPoints`を追加。管理者のみ実行でき、ルームのpoints属性を削除し全接続へ`{type: "points", points: {}}`をブロードキャストする（既存の`judgeQuizRoomBuzz`と同じパターン）
- `backend/serverless.yml`: 上記のWebSocketルート定義を追加（IAM権限は既存の共有ロールでカバー済みのため追加不要）
- `frontend/src/hooks/useQuizRoomSync.js`・`useQuizRoomAdmin.js`: `resetPoints()`を追加し呼び出し側へ公開
- `frontend/src/views/QuizRoomInfoView.jsx`: 参加者一覧テーブルの下に「ポイントをリセット」ボタンを追加。取り消せない操作のため`window.confirm`による確認を挟む

## 影響

クイズ大会モードにポイントリセット機能を追加するのみ。既存のポイント集計・ブロードキャストロジックへの変更はなし。

## Test plan

- [x] backend: `npm run lint` → 0 problems / `npm test -- --run` → 1496 passed (1496)
  - 権限チェック（管理者以外・接続情報無し）、points属性の削除とブロードキャスト内容、エラーハンドリングを検証
- [x] frontend: `npm run lint` → 0 problems / `npm test -- --run` → 187 passed (187)
  - `resetPoints()`が接続OPEN時のみ送信されること、確認ダイアログでキャンセルした場合は実行されないことを検証

Closes #615

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V

---
_Generated by [Claude Code](https://claude.ai/code/session_014z4cmmiSNxF5fZJUsDjW7V)_