### PR TITLE
chore(release): v1.46.1 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.46.1](https://github.com/bamiyanapp/karuta/compare/v1.46.0...v1.46.1) (2026-07-18)
+
+
+### Bug Fixes
+
+* **quiz-room:** ルーム情報画面でも早押し判定モーダルを表示し、効果音を追加する ([#647](https://github.com/bamiyanapp/karuta/issues/647)) ([9cc178d](https://github.com/bamiyanapp/karuta/commit/9cc178d440a4f1aefd348f65fe5627d7ccefbc28)), closes [#613](https://github.com/bamiyanapp/karuta/issues/613)
+
 # [1.46.0](https://github.com/bamiyanapp/karuta/compare/v1.45.0...v1.46.0) (2026-07-18)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.46.0",
+    "version": "1.46.1",
     "date": "2026/07/18",
+    "body": "### Bug Fixes\n\n* **quiz-room:** ルーム情報画面でも早押し判定モーダルを表示し、効果音を追加する ([#647](https://github.com/bamiyanapp/karuta/issues/647)) ([9cc178d](https://github.com/bamiyanapp/karuta/commit/9cc178d440a4f1aefd348f65fe5627d7ccefbc28)), closes [#613](https://github.com/bamiyanapp/karuta/issues/613)"
+  },
+  {
+    "version": "1.46.0",
+    "date": "2026/07/18 02:48",
     "body": "### Bug Fixes\n\n* **deps:** ルート直下のpackage-lock.jsonの不整合を解消する ([#645](https://github.com/bamiyanapp/karuta/issues/645)) ([618a425](https://github.com/bamiyanapp/karuta/commit/618a425c8b326f38574095fa608aadaa99ee42a8)), closes [#340](https://github.com/bamiyanapp/karuta/issues/340)\n* **quiz-room:** 画面ロック・バックグラウンド復帰後にWebSocketを再接続する ([#637](https://github.com/bamiyanapp/karuta/issues/637)) ([539c77d](https://github.com/bamiyanapp/karuta/commit/539c77dc730172745aefe26f52575c129815537a)), closes [#614](https://github.com/bamiyanapp/karuta/issues/614) [#614](https://github.com/bamiyanapp/karuta/issues/614)\n\n\n### Features\n\n* **quiz-room:** 管理者がポイントを明示的にリセットできるようにする ([#644](https://github.com/bamiyanapp/karuta/issues/644)) ([20c9a9c](https://github.com/bamiyanapp/karuta/commit/20c9a9ca5b759ea35629e092533ea0c25dd5dd4b)), closes [#615](https://github.com/bamiyanapp/karuta/issues/615)"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.46.0",
+  "version": "1.46.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.46.0",
+      "version": "1.46.1",
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.46.0"
+  "version": "1.46.1"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。