### PR TITLE
feat(e2e): captureScreenshot()とspec-source-map.jsonをテストケース単位に対応させる

### DIFF
--- a/frontend/e2e/screenshot.js
+++ b/frontend/e2e/screenshot.js
@@ -30,4 +30,9 @@ export async function captureScreenshot(page, testInfo, name, caption) {
   // これとspec-source-map.jsonの宣言、PRの変更ファイル一覧を突き合わせて
   // 関連の有無を判定する
   fs.writeFileSync(path.join(SCREENSHOT_DIR, `${name}.spec.txt`), path.basename(testInfo.file), 'utf-8');
+  // issue #651: スペックファイル単位のグループ化では、同じファイル内の複数の
+  // 無関係なシナリオが一括りにされ折りたたみ単位として粗いため、テストケース名
+  // （testInfo.title）も記録する。CI側（reusable-ci.yml、dev-standards#88）は
+  // これがあればスペックファイル単位ではなくテストケース単位でグループ化する
+  fs.writeFileSync(path.join(SCREENSHOT_DIR, `${name}.title.txt`), testInfo.title, 'utf-8');
 }

--- a/frontend/e2e/spec-source-map.json
+++ b/frontend/e2e/spec-source-map.json
@@ -1,19 +1,39 @@
 {
-  "quiz-room.spec.js": [
-    "frontend/src/App.jsx",
-    "frontend/src/views/QuizRoomView.jsx",
-    "frontend/src/views/QuizRoomInfoView.jsx",
-    "frontend/src/hooks/useQuizRoomAdmin.js",
-    "frontend/src/utils/quizRoomParticipants.js",
-    "backend/quizRoomHandler.js"
-  ],
-  "app-flows.spec.js": [
-    "frontend/src/App.jsx",
-    "frontend/src/PwaUpdatePrompt.jsx",
-    "frontend/src/views/AllPhrasesView.jsx",
-    "frontend/src/views/DetailView.jsx",
-    "frontend/src/views/ChangelogView.jsx",
-    "frontend/src/views/CommentsView.jsx",
-    "frontend/src/views/PrintEfudaView.jsx"
-  ]
+  "quiz-room.spec.js": {
+    "admin creates a quiz room and a participant sees the same card update in real time": [
+      "frontend/src/App.jsx",
+      "frontend/src/hooks/useQuizRoomAdmin.js",
+      "frontend/src/hooks/useQuizRoomSync.js",
+      "frontend/src/views/QuizRoomView.jsx",
+      "backend/quizRoomHandler.js"
+    ],
+    "when the admin reloads mid-game, the quiz room association is lost and the participant gets no notification (issue #640)": [
+      "frontend/src/App.jsx",
+      "frontend/src/hooks/useQuizRoomAdmin.js",
+      "frontend/src/views/QuizRoomView.jsx",
+      "backend/quizRoomHandler.js"
+    ],
+    "admin judges a buzz, and the responder vs. other participants end up in different states (issue #545, #546)": [
+      "frontend/src/App.jsx",
+      "frontend/src/views/QuizRoomView.jsx",
+      "frontend/src/views/QuizRoomInfoView.jsx",
+      "frontend/src/utils/quizRoomParticipants.js",
+      "backend/quizRoomHandler.js"
+    ],
+    "joining with a room code that does not exist shows an immediate error instead of retrying the WebSocket connection (issue #616)": [
+      "frontend/src/views/QuizRoomView.jsx",
+      "backend/quizRoomHandler.js"
+    ]
+  },
+  "app-flows.spec.js": {
+    "normal read-aloud flow (category select -> phrase -> result), then browses print/reference views (issue #576)": [
+      "frontend/src/App.jsx",
+      "frontend/src/PwaUpdatePrompt.jsx",
+      "frontend/src/views/AllPhrasesView.jsx",
+      "frontend/src/views/DetailView.jsx",
+      "frontend/src/views/ChangelogView.jsx",
+      "frontend/src/views/CommentsView.jsx",
+      "frontend/src/views/PrintEfudaView.jsx"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

issue #651の残作業（karuta側）。dev-standards側のグルーピングロジック改善（[dev-standards#88](``https://github.com/bamiyanapp/dev-standards/pull/88)、v1.4.0でリリース済み、現在ci.ymlはv1.5.0参照）は完了していたが、karuta側で実際に有効化する対応が未着手だった。``

- `frontend/e2e/screenshot.js`の`captureScreenshot()`に、撮影したテストケース名（`testInfo.title`）を`<name>.title.txt`として書き出す処理を追加
- `frontend/e2e/spec-source-map.json`を「スペックファイル→ソースパス一覧」から「スペックファイル→（テストケース名→ソースパス一覧）」の構造へ移行し、`quiz-room.spec.js`内の4テストケースそれぞれに実際に検証対象とするソースパスを個別に宣言

これにより、E2Eスクリーンショットの折りたたみ判定がスペックファイル単位（`quiz-room.spec.js`内の4テストケース全体が1グループ）からテストケース単位（4テストケースがそれぞれ独立したグループ）に変わります。

## Test plan

- [x] `frontend`: lint（0 problems）/ vitest（200 tests）/ build 成功
- [x] `backend`: lint（0 problems）/ vitest（1502 tests）成功
- [x] `spec-source-map.json`のJSON構文とテストタイトルが実際の`test()`呼び出しと一致することを確認
- [x] `captureScreenshot()`がモックの`page`/`testInfo`を使って`<name>.title.txt`を正しく書き出すことを手動確認
- [ ] 実際のCI実行時の折りたたみ動作（テストケース単位でのグループ化）は、本PRのCI実行結果（`frontend-e2e-test`ジョブのPRコメント）でご確認ください

Closes #651


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_