### PR TITLE
fix(deps): CD releaseジョブがsemantic-releaseのプリセット解決で失敗する問題を修正する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@semantic-release/github": "^12.0.0",
         "@semantic-release/npm": "^13.1.3",
         "@semantic-release/release-notes-generator": "^14.0.1",
+        "conventional-changelog-conventionalcommits": "^10.2.1",
         "semantic-release": "^25.0.2"
       }
     },
@@ -48282,9 +48283,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -48306,9 +48304,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -48330,9 +48325,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -48354,9 +48346,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -48627,9 +48616,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -48647,9 +48633,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -48667,9 +48650,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -48687,9 +48667,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -48707,9 +48684,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -48727,9 +48701,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -50903,29 +50874,6 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
-      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@conventional-changelog/template": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits/node_modules/@conventional-changelog/template": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.1.tgz",
-      "integrity": "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
-      }
     },
     "node_modules/@semantic-release/changelog": {
       "version": "6.0.3",
@@ -56776,6 +56724,29 @@
     "node_modules/backend": {
       "resolved": "backend",
       "link": true
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits/node_modules/@conventional-changelog/template": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.1.tgz",
+      "integrity": "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/frontend": {
       "resolved": "frontend",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@semantic-release/github": "^12.0.0",
     "@semantic-release/npm": "^13.1.3",
     "@semantic-release/release-notes-generator": "^14.0.1",
+    "conventional-changelog-conventionalcommits": "^10.2.1",
     "semantic-release": "^25.0.2"
   },
   "version": "1.46.2"


### PR DESCRIPTION
## ⚠️ 緊急度: 高

[PR #654](https://github.com/bamiyanapp/karuta/pull/654)（issue #608、npm workspaces移行）のマージ以降、**CDの`release`ジョブが毎回失敗し、リリース（バージョン採番・CHANGELOG更新・GitHub Pages/Lambdaへのデプロイ）が完全に停止しています**。

- [workflow run 29643149970](https://github.com/bamiyanapp/karuta/actions/runs/29643149970)（PR #654マージ後の初回CD）: `release`ジョブが`npx semantic-release`実行時に`Error: Cannot find module 'conventional-changelog-conventionalcommits'`で失敗
- 後続の[workflow run 29643305553](https://github.com/bamiyanapp/karuta/actions/runs/29643305553)（Renovate PR #349マージ後）でも同様に失敗しており、一過性ではなく恒常的な問題です

## Summary

- ルート`package.json`に`conventional-changelog-conventionalcommits`（`^10.2.1`）を直接devDependencyとして追加

## 原因

issue #608で導入した`.npmrc`の`install-strategy=nested`により、`dev-standards/release-config.cjs`が`@semantic-release/commit-analyzer`に指定している`preset: "conventionalcommits"`（動的importで`conventional-changelog-conventionalcommits`パッケージ名として解決される）が、プロジェクトルートから解決できなくなっていました。このパッケージは`@commitlint/config-conventional`の内部依存としてのみ存在し、`nested`戦略下ではcommitlintの依存ツリー配下に閉じ込められます（hoisted戦略なら自動的にルートへ持ち上がっていたため、これまで問題になっていませんでした）。

frontendの`vite-plugin-pwa`/`workbox-window`で発生したのと同種の、「peerDependency的に暗黙にルートでの解決を前提にしたパッケージが`nested`戦略で壊れる」パターンです。

`nested`戦略自体（`.npmrc`）はbackendのServerless Frameworkパッケージング（Lambdaデプロイ）に必須のため維持し、今回は個別の依存を明示追加することで対応しました。

## Test plan

- [x] `frontend`: lint（0 problems）/ vitest（200 tests）/ build 成功
- [x] `backend`: lint（0 problems）/ vitest（1502 tests）成功
- [x] ローカルで`dev-standards/release-config.cjs`を一時的にコピーし`npx semantic-release --dry-run --no-ci`を実行し、修正前に発生していた`Cannot find module`エラーが再現しないことを確認（`analyzeCommits`ステップを正常に通過）
- [ ] 実際のCD実行（マージ後）でのrelease成功は、本サンドボックスからはmainへの実際のpushができないため、マージ後のCD実行結果でご確認ください

Refs #608


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_