### PR TITLE
fix(ci): backendデプロイのEMFILE(too many open files)エラーを回避する

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -76,7 +76,16 @@ jobs:
         run: npm ci
       - name: 🚀 Deploy Backend (Serverless Framework)
         working-directory: backend
-        run: npx serverless deploy
+        # npm workspaces移行（issue #608）で`install-strategy=nested`にした結果、
+        # 各Lambda関数のzip作成（package.individually: true、11関数）が同一の
+        # node_modules配下を関数ごとに繰り返し走査するようになり、GitHub Actions
+        # ランナーのデフォルトのファイルディスクリプタ上限（1024）を超えて
+        # `EMFILE: too many open files`でデプロイが失敗することを確認した
+        # （issue #608のPR #654マージ後の初回デプロイで実際に発生）。
+        # ソフトリミットをハードリミットまで引き上げて回避する
+        run: |
+          ulimit -n 65536
+          npx serverless deploy
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## ⚠️ 緊急度: 高

[PR #661](https://github.com/bamiyanapp/karuta/pull/661)（semantic-releaseの修正）マージ後の実際のCD実行（[workflow run 29645159618](``https://github.com/bamiyanapp/karuta/actions/runs/29645159618)）で、'release'ジョブと'build-and-deploy-frontend'ジョブは成功しましたが、'deploy-backend'ジョブが以下のエラーで失敗しました。``

```
Error: EMFILE: too many open files, open '/home/runner/work/karuta/karuta/backend/.serverless/judgeQuizRoomBuzz.zip'
```

これにより、**本番Lambda（backend）がissue #608のnpm workspaces移行以降まだ一度もデプロイされていません**（issue #616/#617のバックエンド変更も含め未反映の状態です）。

## Summary

- `.github/workflows/cd.yml`の`deploy-backend`ジョブ、`serverless deploy`実行前に`ulimit -n 65536`を追加

## 原因

issue #608（npm workspaces移行）で導入した`.npmrc`の`install-strategy=nested`により、`package.individually: true`（11関数）でLambda関数ごとにzipを作成する構成のところ、各関数のzip作成のたびに同一のnode_modules配下を走査するファイルディスクリプタが十分に解放されないまま蓄積し、GitHub Actionsランナーのデフォルトのソフトリミット（1024）を関数を跨いで超過していました。

`nested`戦略自体はbackendの実行時依存欠落問題を回避するために必須のため維持し、今回はファイルディスクリプタ上限を引き上げることで即座に復旧する方針にしました。根本的な解消（Lambda関数のバンドル化等でzip対象ファイル数自体を減らす）は別途検討の余地がありますが、まずは本番デプロイが止まっている状態を早急に解消することを優先しています。

## Test plan

- [x] YAML構文をPythonの`yaml`モジュールで検証済み
- [ ] 実際のCD実行での`serverless deploy`成功は、本サンドボックスにAWS認証情報・デプロイ用ネットワークアクセスが無いため検証できません。マージ後のCD実行結果でご確認ください

Refs #608


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_