### PR TITLE
fix(ci): backendデプロイのファイルディスクリプタ上限をハードリミットまで引き上げる

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -82,9 +82,16 @@ jobs:
         # ランナーのデフォルトのファイルディスクリプタ上限（1024）を超えて
         # `EMFILE: too many open files`でデプロイが失敗することを確認した
         # （issue #608のPR #654マージ後の初回デプロイで実際に発生）。
-        # ソフトリミットをハードリミットまで引き上げて回避する
+        # ソフトリミットを65536へ引き上げる対応（PR #663）を行ったが、
+        # それでも別のパッケージ（@aws-sdk/s3-request-presigner配下の
+        # @smithy/core）でEMFILEが再発した（PR #663マージ後の実際のCD実行）。
+        # 65536でも足りないほどファイル数が多いため、ソフトリミットを
+        # ハードリミットまで引き上げる（実際の上限値はランナーによって
+        # 異なるためログへ出力し、以降の障害調査で参照できるようにする）
         run: |
-          ulimit -n 65536
+          echo "file descriptor limits: soft=$(ulimit -Sn) hard=$(ulimit -Hn)"
+          ulimit -n "$(ulimit -Hn)"
+          echo "file descriptor limit after adjustment: $(ulimit -n)"
           npx serverless deploy
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## ⚠️ 緊急度: 高（PR #663の続き）

[PR #663](https://github.com/bamiyanapp/karuta/pull/663)（`ulimit -n 65536`）マージ後の実際のCD実行（[workflow run 29647925032](``https://github.com/bamiyanapp/karuta/actions/runs/29647925032)）で、今度は別のパッケージで同じ'EMFILE'エラーが再発しました。``

```
Cannot read file node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/core/dist-es/submodules/config/property-provider/memoize.js due to: EMFILE: too many open files
```

65536でも足りないほど、`.npmrc`の`install-strategy=nested`によるファイル数の膨張が深刻であることが分かりました。**本番Lambda（backend）はissue #608の移行以降、依然として一度もデプロイされていません。**

## Summary

- `deploy-backend`ジョブのファイルディスクリプタ上限を、固定値65536ではなくハードリミット（`ulimit -Hn`）まで引き上げるよう変更
- 調整前後の値をログへ出力し、以降の障害調査で実際の上限値を参照できるようにした

## Test plan

- [x] YAML構文をPythonの`yaml`モジュールで検証済み
- [ ] 実際のCD実行での`serverless deploy`成功は、本サンドボックスにAWS認証情報・デプロイ用ネットワークアクセスが無いため検証できません。マージ後のCD実行結果でご確認ください
- [ ] これでも解消しない場合は、Lambda関数のバンドル化（esbuild等でzip対象ファイル数自体を減らす根本対応）を検討します

Refs #608


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_