### PR TITLE
feat(frontend): カテゴリ確定と絵札印刷の導線を統合する

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -113,7 +113,6 @@ function App() {
   // 直前値の追跡用
   const [lastPhraseForTakenByReset, setLastPhraseForTakenByReset] = useState(null);
 
-  const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [draftCategories, setDraftCategories] = useState([]);
 
   // コメント投稿用の状態
@@ -1061,18 +1060,27 @@ function App() {
 
   const handleDecideClick = () => {
     if (draftCategories.length === 0) return;
-    setShowConfirmModal(true);
-  };
-
-  const confirmCategory = () => {
     setSelectedCategories(draftCategories);
     setDraftCategories([]);
-    setShowConfirmModal(false);
     setView("game");
   };
 
-  const cancelCategory = () => {
-    setShowConfirmModal(false);
+  const handlePrintEfudaClick = () => {
+    if (draftCategories.length === 0) return;
+    setSelectedCategories(draftCategories);
+    setView("print-efuda");
+  };
+
+  // かるた選択画面から印刷画面へ直接遷移した場合（issue #636）はカテゴリを
+  // まだ「決定」していないため、戻る際はselectedCategoriesを空へ戻し
+  // かるた選択画面へ戻す。こども向け（issue #636の検討事項により、ゲーム画面
+  // フッターの印刷ボタンを引き続き使う）はゲーム画面から遷移しているため、
+  // selectedCategoriesはそのままゲーム画面へ戻す
+  const handlePrintEfudaBack = () => {
+    if (division === "engineer") {
+      setSelectedCategories([]);
+    }
+    setView("game");
   };
 
   const openDetail = (id, category) => {
@@ -1107,7 +1115,7 @@ function App() {
     return (
       <PrintEfudaView
         categoryLabel={categoryLabel}
-        setView={setView}
+        onBack={handlePrintEfudaBack}
         selectedCategories={selectedCategories}
         allPhrasesForCategory={allPhrasesForCategory}
         efudaPages={efudaPages}
@@ -1285,13 +1293,27 @@ function App() {
                   {draftCardCount >= MAX_EFUDA_PRINT_CARDS && "（上限に達しました）"}
                 </p>
               )}
-              <button
-                onClick={handleDecideClick}
-                disabled={draftCategories.length === 0}
-                className="btn btn-success btn-lg px-5 py-2 fw-bold rounded-pill shadow"
-              >
-                決定（{draftCategories.length}件選択中）
-              </button>
+              {draftCategoriesRequiringPossessionCheck.length > 0 && (
+                <p className="text-muted small mb-2">
+                  {draftCategoriesRequiringPossessionCheck.map(cat => `「${cat}」`).join("")}をお手元にご用意ください
+                </p>
+              )}
+              <div className="d-flex flex-column align-items-center gap-2">
+                <button
+                  onClick={handleDecideClick}
+                  disabled={draftCategories.length === 0}
+                  className="btn btn-success btn-lg px-5 py-2 fw-bold rounded-pill shadow"
+                >
+                  かるたを始める（{draftCategories.length}件選択中）
+                </button>
+                <button
+                  onClick={handlePrintEfudaClick}
+                  disabled={draftCategories.length === 0}
+                  className="btn btn-outline-dark px-4 rounded-pill"
+                >
+                  絵札を印刷する
+                </button>
+              </div>
             </div>
           )}
         </main>
@@ -1307,27 +1329,6 @@ function App() {
             更新履歴を見る
           </button>
         </div>
-
-        {showConfirmModal && (
-          <div className="modal fade show d-block modal-overlay" tabIndex="-1">
-            <div className="modal-dialog modal-dialog-centered">
-              <div className="modal-content rounded-4 border-0 shadow">
-                <div className="modal-body p-5 text-center">
-                  <h3 className="h5 mb-4 fw-bold">
-                    {draftCategoriesRequiringPossessionCheck.length > 0
-                      ? `${draftCategoriesRequiringPossessionCheck.map(cat => `「${cat}」`).join("")}をお手元に持っていますか？`
-                      : "ゲームを開始しますか？"}
-                  </h3>
-
-                  <div className="d-flex gap-2 justify-content-center">
-                    <button onClick={confirmCategory} className="btn btn-primary btn-lg px-4 rounded-pill shadow-sm fs-6">はい</button>
-                    <button onClick={cancelCategory} className="btn btn-outline-secondary btn-lg px-4 rounded-pill fs-6">いいえ</button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
       </div>
     );
   }
@@ -1616,7 +1617,12 @@ function App() {
         </section>
       <p className="text-muted small mb-4">履歴はこのタブを閉じるまで保持されます（リロードしても消えません）。</p>
       <div className="d-flex flex-wrap gap-2 justify-content-center mb-4">
-        <button onClick={() => setView("print-efuda")} className="btn btn-outline-dark px-4 rounded-pill">絵札を印刷する</button>
+        {division === "kids" && (
+          // こども向け（issue #636）はかるた選択画面に「決定」ボタンが無く印刷ボタンを
+          // 置けないため、従来どおりゲーム画面からの導線を残す。エンジニア向けは
+          // かるた選択画面の「かるたを始める」ボタン下に一本化したためここには置かない
+          <button onClick={() => setView("print-efuda")} className="btn btn-outline-dark px-4 rounded-pill">絵札を印刷する</button>
+        )}
         <button onClick={resetGame} className="btn btn-outline-dark px-4 rounded-pill">かるたの種類を選び直す</button>
       </div>
       {quizRoom ? (

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -153,7 +153,7 @@ describe('App', () => {
     await waitFor(() => {
       expect(screen.getByText('このかるたはまだありません。')).toBeInTheDocument();
     });
-    expect(screen.queryByText(/決定/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/かるたを始める/)).not.toBeInTheDocument();
   });
 
   it('keeps the secondary navigation links reachable from the category selection screen', async () => {
@@ -198,7 +198,7 @@ describe('App', () => {
     fireEvent.click(screen.getByText('こども向け'));
 
     const cat1Button = await screen.findByRole('button', { name: /Cat1/ });
-    expect(screen.queryByText(/決定/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/かるたを始める/)).not.toBeInTheDocument();
 
     fireEvent.click(cat1Button);
 
@@ -339,17 +339,14 @@ describe('App', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Cat1/ }));
     fireEvent.click(screen.getByRole('button', { name: /Cat2/ }));
-    fireEvent.click(screen.getByText(/決定/));
-
-    await waitFor(() => screen.getByText(/「Cat1」「Cat2」をお手元に持っていますか？/));
-    fireEvent.click(screen.getByText('はい'));
+    fireEvent.click(screen.getByText(/かるたを始める/));
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Cat1・Cat2' })).toBeInTheDocument();
     });
   });
 
-  it('skips the possession-check question and shows a generic prompt when all selected categories have requiresPossessionCheck: false', async () => {
+  it('shows no possession-check notice when all selected categories have requiresPossessionCheck: false', async () => {
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer', requiresPossessionCheck: false }, { name: 'Cat2', group: 'engineer', requiresPossessionCheck: false }] }) };
       if (url.includes('category=Cat1')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
@@ -370,18 +367,16 @@ describe('App', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Cat1/ }));
     fireEvent.click(screen.getByRole('button', { name: /Cat2/ }));
-    fireEvent.click(screen.getByText(/決定/));
+    expect(screen.queryByText(/をお手元にご用意ください/)).not.toBeInTheDocument();
 
-    await waitFor(() => screen.getByText('ゲームを開始しますか？'));
-    expect(screen.queryByText(/お手元に持っていますか/)).not.toBeInTheDocument();
-    fireEvent.click(screen.getByText('はい'));
+    fireEvent.click(screen.getByText(/かるたを始める/));
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Cat1・Cat2' })).toBeInTheDocument();
     });
   });
 
-  it('only asks about the possession of categories with requiresPossessionCheck: true when a mix is selected', async () => {
+  it('only shows the possession-check notice for categories with requiresPossessionCheck: true when a mix is selected', async () => {
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer', requiresPossessionCheck: true }, { name: 'Cat2', group: 'engineer', requiresPossessionCheck: false }] }) };
       if (url.includes('category=Cat1')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
@@ -402,9 +397,8 @@ describe('App', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Cat1/ }));
     fireEvent.click(screen.getByRole('button', { name: /Cat2/ }));
-    fireEvent.click(screen.getByText(/決定/));
 
-    await waitFor(() => screen.getByText('「Cat1」をお手元に持っていますか？'));
+    await waitFor(() => screen.getByText('「Cat1」をお手元にご用意ください'));
   });
 
   it('requests announceCategory=true when reading with multiple categories selected', async () => {
@@ -430,10 +424,7 @@ describe('App', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Cat1/ }));
     fireEvent.click(screen.getByRole('button', { name: /Cat2/ }));
-    fireEvent.click(screen.getByText(/決定/));
-
-    await waitFor(() => screen.getByText(/「Cat1」「Cat2」をお手元に持っていますか？/));
-    fireEvent.click(screen.getByText('はい'));
+    fireEvent.click(screen.getByText(/かるたを始める/));
 
     await waitFor(() => screen.getByText('次の札'));
     fireEvent.click(screen.getByText('次の札'));
@@ -650,9 +641,7 @@ describe('App', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /Cat1/ }));
     fireEvent.click(screen.getByRole('button', { name: /Cat2/ }));
-    fireEvent.click(screen.getByText(/決定/));
-    await waitFor(() => screen.getByText(/「Cat1」「Cat2」をお手元に持っていますか？/));
-    fireEvent.click(screen.getByText('はい'));
+    fireEvent.click(screen.getByText(/かるたを始める/));
 
     await waitFor(() => screen.getByText('次の札'));
     fireEvent.click(screen.getByText('次の札'));
@@ -927,8 +916,6 @@ describe('App', () => {
     categoryNames.forEach((name) => {
       fireEvent.click(screen.getByRole('button', { name: new RegExp(name) }));
     });
-    fireEvent.click(screen.getByText(/決定/));
-    fireEvent.click(screen.getByText('はい'));
 
     await waitFor(() => screen.getByText('絵札を印刷する'));
     fireEvent.click(screen.getByText('絵札を印刷する'));
@@ -1112,8 +1099,6 @@ describe('App', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Cat1/ }));
     fireEvent.click(screen.getByRole('button', { name: /Cat2/ }));
-    fireEvent.click(screen.getByText(/決定/));
-    fireEvent.click(screen.getByText('はい'));
 
     await waitFor(() => screen.getByText('絵札を印刷する'));
     fireEvent.click(screen.getByText('絵札を印刷する'));
@@ -1167,7 +1152,7 @@ describe('App', () => {
     expect(cat3Button).toBeDisabled();
     fireEvent.click(cat3Button);
     expect(cat3Button).toHaveAttribute('aria-pressed', 'false');
-    expect(screen.getByText(/決定/)).toHaveTextContent('決定（2件選択中）');
+    expect(screen.getByText(/かるたを始める/)).toHaveTextContent('かるたを始める（2件選択中）');
   });
 
   it('fills a page across the category boundary instead of leaving trailing blanks', async () => {
@@ -1206,8 +1191,6 @@ describe('App', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Cat1/ }));
     fireEvent.click(screen.getByRole('button', { name: /Cat2/ }));
-    fireEvent.click(screen.getByText(/決定/));
-    fireEvent.click(screen.getByText('はい'));
 
     await waitFor(() => screen.getByText('絵札を印刷する'));
     fireEvent.click(screen.getByText('絵札を印刷する'));
@@ -2394,10 +2377,7 @@ describe('App', () => {
 
     fireEvent.click(await screen.findByText('エンジニア向け'));
     fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
-    fireEvent.click(screen.getByText(/決定/));
-
-    await waitFor(() => screen.getByText(/「Cat1」をお手元に持っていますか？/));
-    fireEvent.click(screen.getByText('はい'));
+    fireEvent.click(screen.getByText(/かるたを始める/));
 
     // 参加者登録（issue #518）はカテゴリ確定モーダルではなく、読み札画面のボタンから行う
     await waitFor(() => screen.getByText('次の札'));
@@ -2434,7 +2414,7 @@ describe('App', () => {
     expect(within(hanakoCard).getByText(/0枚/)).toBeInTheDocument();
   }, 50000);
 
-  it('does not show the participant-registration UI in the category confirmation modal (issue #518)', async () => {
+  it('does not show the participant-registration UI on the category selection screen (issue #518)', async () => {
     fetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }] }),
@@ -2446,9 +2426,6 @@ describe('App', () => {
 
     fireEvent.click(await screen.findByText('エンジニア向け'));
     fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
-    fireEvent.click(screen.getByText(/決定/));
-
-    await waitFor(() => screen.getByText(/「Cat1」をお手元に持っていますか？/));
 
     expect(screen.queryByPlaceholderText('名前を入力')).not.toBeInTheDocument();
     expect(screen.queryByText('取った人を記録する参加者（任意）')).not.toBeInTheDocument();
@@ -2467,9 +2444,7 @@ describe('App', () => {
 
     fireEvent.click(await screen.findByText('エンジニア向け'));
     fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
-    fireEvent.click(screen.getByText(/決定/));
-    await waitFor(() => screen.getByText(/「Cat1」をお手元に持っていますか？/));
-    fireEvent.click(screen.getByText('はい'));
+    fireEvent.click(screen.getByText(/かるたを始める/));
     await waitFor(() => screen.getByText('次の札'));
 
     expect(screen.queryByPlaceholderText('名前を入力')).not.toBeInTheDocument();

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -79,9 +79,7 @@ describe('useQuizRoomAdmin (via App)', () => {
 
     fireEvent.click(await screen.findByText('エンジニア向け'));
     fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
-    fireEvent.click(screen.getByText(/決定/));
-    await waitFor(() => screen.getByText(/「Cat1」をお手元に持っていますか？/));
-    fireEvent.click(screen.getByText('はい'));
+    fireEvent.click(screen.getByText(/かるたを始める/));
     await waitFor(() => screen.getByText('次の札'));
 
     // クイズ大会ルーム作成前は、参加者登録ボタンがルーム作成ボタンと並んで表示される

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -59,7 +59,7 @@ const resolvePhraseIndex = (slotIndex, printSide) => {
   return row * EFUDA_GRID_COLUMNS + (EFUDA_GRID_COLUMNS - 1 - col);
 };
 
-function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrasesForCategory, efudaPages, efudaPerPage }) {
+function PrintEfudaView({ categoryLabel, onBack, selectedCategories, allPhrasesForCategory, efudaPages, efudaPerPage }) {
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
 
   // この画面を開いている間、PwaUpdatePromptの「オフラインで利用可能になりました」
@@ -136,7 +136,7 @@ function PrintEfudaView({ categoryLabel, setView, selectedCategories, allPhrases
     <div className="container efuda-print-container py-4 mx-auto">
       <header className="text-center mb-4 border-bottom pb-3 no-print">
         <div className="d-flex justify-content-between align-items-center">
-          <button onClick={() => setView("game")} className="btn btn-sm btn-outline-secondary rounded-pill">← 戻る</button>
+          <button onClick={onBack} className="btn btn-sm btn-outline-secondary rounded-pill">← 戻る</button>
           <h1 className="h4 m-0 fw-bold notranslate">{categoryLabel}の絵札印刷</h1>
           <div style={{ width: "60px" }}></div>
         </div>

--- a/frontend/src/views/PrintEfudaView.test.jsx
+++ b/frontend/src/views/PrintEfudaView.test.jsx
@@ -22,7 +22,7 @@ describe("PrintEfudaView", () => {
       <>
         <PrintEfudaView
           categoryLabel="テスト"
-          setView={() => {}}
+          onBack={() => {}}
           selectedCategories={[]}
           allPhrasesForCategory={[]}
           efudaPages={[]}


### PR DESCRIPTION
## 概要

issue #636（絵札印刷ボタンをかるた選択画面へ移動）とissue #642（カテゴリ選択後の確認モーダルを省略）を1つの変更として統合実装した。あわせて「決定」ボタンの名称を「かるたを始める」に変更した。

両issueは同じ「決定」ボタン・確認モーダル周辺のUI/遷移ロジックを扱っており、別々に実装すると同じ箇所を2回書き換えることになるため、1つの変更としてまとめている。

## 変更内容（エンジニア向け・division === "engineer"のみ）

- 「決定」ボタンを**「かるたを始める」に改称**し、押下時に確認モーダルを経由せず直接ゲーム画面へ遷移するようにした（issue #642）
- 「かるたを始める」ボタンの下に**「絵札を印刷する」ボタンを新設**し、確認モーダルを経由せず直接印刷画面へ遷移できるようにした（issue #636）
- 所持確認が必要なかるた種別の案内は、モーダルの質問文（「〇〇をお手元に持っていますか？」）ではなく、ボタン群の上に**常時表示する注意書き**（「〇〇をお手元にご用意ください」）に置き換えた。issue #642本文が「単純にモーダルごと削除すると案内が失われる」と挙げていた懸念に対応するもので、issue自身が候補として挙げていた解決策（常時表示化）を採用した
- 印刷画面の「戻る」ボタンは、かるた選択画面から遷移した場合はかるた選択画面へ、ゲーム画面から遷移した場合はゲーム画面へ、遷移元に応じて戻るようにした（`PrintEfudaView`の`setView` propを`onBack` propに変更）

## こども向け（division === "kids"）について

こども向けはそもそも「決定」ボタンが存在せず（カテゴリタップで即座にゲーム画面へ遷移）、issue #636自身も「検討事項」としてこの導線をどうするか未決定としていた。今回は**ゲーム画面フッターの既存「絵札を印刷する」ボタンをこども向けに限り残す**方針とした（ユーザー確認済み）。エンジニア向けは新設ボタンに一本化されるため導線の重複はない。

## 設計

- **選定**: 2issueの統合実装、決定ボタンの改称、所持確認案内の常時表示化への置き換え
- **却下**: こども向けの印刷導線を無条件で削除する案（issueの文言どおりに実装すると、こども向けが絵札印刷に一切到達できなくなる機能後退となるため）
- **理由**: 上記のとおり

## 影響

- `frontend/src/App.jsx`: 確認モーダル関連のstate・関数・JSXを削除し、`handleDecideClick`・`handlePrintEfudaClick`・`handlePrintEfudaBack`に整理
- `frontend/src/views/PrintEfudaView.jsx`: `setView` prop → `onBack` prop
- エンジニア向けの操作フロー（決定ボタン名・確認モーダルの有無・印刷ボタンの位置）が変わる。こども向けの操作に変更はない

## テスト

- [x] `frontend`・`backend`ともにlint・vitestが0件エラーで成功することを確認
- [x] 画面遷移・ボタン文言の変更に合わせて`frontend/src/App.test.jsx`・`frontend/src/hooks/useQuizRoomAdmin.test.jsx`の該当テストを更新
- [x] E2E（`frontend/e2e/*.spec.js`）はこども向けのフローのみを対象としており、こども向けの操作は変更していないため修正不要と判断（エンジニア向けのE2Eカバレッジは元々無い）

Refs: #636, #642


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_