### PR TITLE
chore(release): v1.48.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.48.0](https://github.com/bamiyanapp/karuta/compare/v1.47.4...v1.48.0) (2026-07-18)
+
+
+### Features
+
+* **frontend:** カテゴリ確定と絵札印刷の導線を統合する ([#675](https://github.com/bamiyanapp/karuta/issues/675)) ([0c9a911](https://github.com/bamiyanapp/karuta/commit/0c9a91179cd72433b7349b7673079960f48bfb9a)), closes [#642](https://github.com/bamiyanapp/karuta/issues/642)
+
 ## [1.47.4](https://github.com/bamiyanapp/karuta/compare/v1.47.3...v1.47.4) (2026-07-18)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.47.4",
+    "version": "1.48.0",
     "date": "2026/07/18",
+    "body": "### Features\n\n* **frontend:** カテゴリ確定と絵札印刷の導線を統合する ([#675](https://github.com/bamiyanapp/karuta/issues/675)) ([0c9a911](https://github.com/bamiyanapp/karuta/commit/0c9a91179cd72433b7349b7673079960f48bfb9a)), closes [#642](https://github.com/bamiyanapp/karuta/issues/642)"
+  },
+  {
+    "version": "1.47.4",
+    "date": "2026/07/18 21:05",
     "body": "### Bug Fixes\n\n* **ci:** CI/CDのNode.jsバージョンをbackend Lambdaランタイムに合わせて統一する ([#672](https://github.com/bamiyanapp/karuta/issues/672)) ([8ae035f](https://github.com/bamiyanapp/karuta/commit/8ae035fd1f1e79945b7730b8dc7da29105836338))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.47.4",
+  "version": "1.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.47.4",
+      "version": "1.48.0",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.47.4"
+  "version": "1.48.0"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。