### PR TITLE
debug(frontend): クイズ大会モードの効果音再生エラーを画面上に一時表示する

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -902,6 +902,7 @@ function App() {
     quizRoomCreateError,
     openQuizRooms,
     quizRoomBuzzedBy,
+    quizRoomSfxError,
     quizRoomPoints,
     quizRoomParticipants,
     quizRoomConnectionStatus,
@@ -1179,6 +1180,13 @@ function App() {
           answer={currentPhrase?.answer}
           onJudge={judgeQuizRoomBuzz}
         />
+        {/* issue #679診断用（後で削除予定）: 効果音再生エラーの原因調査のため、
+            スマホの画面上に直接エラー内容を表示する */}
+        {quizRoomSfxError && (
+          <div className="position-fixed bottom-0 start-0 end-0 alert alert-danger small m-2 mb-0" role="alert">
+            効果音再生エラー（診断用）: {quizRoomSfxError}
+          </div>
+        )}
       </>
     );
   }
@@ -1660,6 +1668,13 @@ function App() {
             answer={currentPhrase?.answer}
             onJudge={judgeQuizRoomBuzz}
           />
+          {/* issue #679診断用（後で削除予定）: 効果音再生エラーの原因調査のため、
+              スマホの画面上に直接エラー内容を表示する */}
+          {quizRoomSfxError && (
+            <div className="position-fixed bottom-0 start-0 end-0 alert alert-danger small m-2 mb-0" role="alert">
+              効果音再生エラー（診断用）: {quizRoomSfxError}
+            </div>
+          )}
         </div>
       ) : (
         <div className="mb-4 d-flex flex-wrap gap-3 justify-content-center align-items-start">

--- a/frontend/src/hooks/useQuizRoomAdmin.js
+++ b/frontend/src/hooks/useQuizRoomAdmin.js
@@ -41,6 +41,10 @@ export function useQuizRoomAdmin({
   // QuizRoomView.jsxのbuzzRoundKeyと同じ考え方で、resultの間はリセットしない）
   const [quizRoomBuzzedBy, setQuizRoomBuzzedBy] = useState(null);
   const [quizRoomBuzzRoundKey, setQuizRoomBuzzRoundKey] = useState(null);
+  // issue #679診断用（後で削除予定）: 効果音の再生に失敗した場合、原因調査のため
+  // 画面上にエラー内容を表示する。スマホオンリーの開発環境ではブラウザの
+  // devtoolsでconsole出力を確認できないため、console.errorだけでは診断できない
+  const [quizRoomSfxError, setQuizRoomSfxError] = useState(null);
   // ポイント制（issue #519）: 名前→累計ポイントのマップ。管理者には参加者ごとの
   // ポイントを一覧表示する
   const [quizRoomPoints, setQuizRoomPoints] = useState({});
@@ -102,7 +106,10 @@ export function useQuizRoomAdmin({
     onState: noop,
     onBuzz: (buzzedBy) => {
       // issue #613: 参加者の早押しを管理者側にも音で通知する
-      playQuizSfx("buzz", "/quiz-buzz.mp3").catch(() => {});
+      playQuizSfx("buzz", "/quiz-buzz.mp3").catch((error) => {
+        // issue #679診断用（後で削除予定）
+        setQuizRoomSfxError(`buzz: ${error?.name || error}`);
+      });
       setQuizRoomBuzzedBy(buzzedBy);
     },
     onPoints: setQuizRoomPoints,
@@ -123,7 +130,10 @@ export function useQuizRoomAdmin({
     // issue #613: 正誤判定した瞬間に管理者側でも結果を音で確認できるようにする。
     // ボタン押下という実際のユーザー操作の中で呼ぶため、事前のunlockAudioPlayback()
     // なしでも再生できる
-    playQuizSfx(correct ? "correct" : "incorrect", correct ? "/quiz-correct.mp3" : "/quiz-incorrect.mp3").catch(() => {});
+    playQuizSfx(correct ? "correct" : "incorrect", correct ? "/quiz-correct.mp3" : "/quiz-incorrect.mp3").catch((error) => {
+      // issue #679診断用（後で削除予定）
+      setQuizRoomSfxError(`${correct ? "correct" : "incorrect"}: ${error?.name || error}`);
+    });
     if (correct) {
       await revealCurrentResult(winner);
     }
@@ -227,6 +237,7 @@ export function useQuizRoomAdmin({
     quizRoomCreateError,
     openQuizRooms,
     quizRoomBuzzedBy,
+    quizRoomSfxError,
     quizRoomPoints,
     quizRoomParticipants,
     quizRoomConnectionStatus,

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -86,6 +86,10 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   // 早押し正誤判定（issue #546）: 不正解と判定された場合、そのラウンド中は
   // 自分だけ早押しボタンを再表示しない
   const [excludedThisRound, setExcludedThisRound] = useState(false);
+  // issue #679診断用（後で削除予定）: 効果音の再生に失敗した場合、原因調査のため
+  // 画面上にエラー内容を表示する。スマホオンリーの開発環境ではブラウザの
+  // devtoolsでconsole出力を確認できないため、console.errorだけでは診断できない
+  const [sfxError, setSfxError] = useState(null);
   // ポイント制（issue #519）: 名前→累計ポイントのマップ。集計単位はconnectionIdではなく
   // name（早押し機能の実装参照）なので、自分のポイントはpoints[confirmedName]で引く
   const [points, setPoints] = useState({});
@@ -172,7 +176,10 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   const handleRoundReset = ({ excludedName }) => {
     // issue #613: 不正解の判定結果を参加者全員に音で伝える（除外された本人以外にとっては
     // 「次に早押しできるようになった」合図でもあるが、判定内容自体は不正解のため同じ音を使う）
-    playQuizSfx("incorrect", "/quiz-incorrect.mp3").catch(() => {});
+    playQuizSfx("incorrect", "/quiz-incorrect.mp3").catch((error) => {
+      // issue #679診断用（後で削除予定）
+      setSfxError(`incorrect: ${error?.name || error}`);
+    });
     if (excludedName === confirmedName) {
       setExcludedThisRound(true);
     } else {
@@ -188,7 +195,10 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     onState: setRoomState,
     onBuzz: (buzzedByParam) => {
       // issue #613: 早押し発生（自分・他の参加者いずれの場合も）を音で通知する
-      playQuizSfx("buzz", "/quiz-buzz.mp3").catch(() => {});
+      playQuizSfx("buzz", "/quiz-buzz.mp3").catch((error) => {
+        // issue #679診断用（後で削除予定）
+        setSfxError(`buzz: ${error?.name || error}`);
+      });
       setBuzzedBy(buzzedByParam);
     },
     onPoints: setPoints,
@@ -263,7 +273,10 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   // なった瞬間にだけ再生されるようdepsをshowCelebrationのみにする
   useEffect(() => {
     if (showCelebration) {
-      playQuizSfx("correct", "/quiz-correct.mp3").catch(() => {});
+      playQuizSfx("correct", "/quiz-correct.mp3").catch((error) => {
+        // issue #679診断用（後で削除予定）
+        setSfxError(`correct: ${error?.name || error}`);
+      });
     }
   }, [showCelebration]);
 
@@ -457,6 +470,13 @@ function QuizRoomView({ setView, wsBaseUrl }) {
             <button onClick={handleBuzz} className="btn btn-danger btn-lg rounded-pill px-5">
               回答する
             </button>
+          </div>
+        )}
+        {/* issue #679診断用（後で削除予定）: 効果音再生エラーの原因調査のため、
+            スマホの画面上に直接エラー内容を表示する */}
+        {sfxError && (
+          <div className="position-fixed bottom-0 start-0 end-0 alert alert-danger small m-2 mb-0" role="alert">
+            効果音再生エラー（診断用）: {sfxError}
           </div>
         )}
         {(() => {


### PR DESCRIPTION
## 概要

issue #679（早押し/正解/不正解の効果音が鳴らない）の原因調査用PR。コードレビューだけでは決定的な原因を特定できなかったため、効果音再生失敗時のエラーを画面上に直接表示する診断用の変更を入れる。**恒久対応ではない**。

## 背景

- 管理者側の「正解」「不正解」判定（`judgeQuizRoomBuzz`）は直接のクリックハンドラ内で同期的に`play()`を呼んでおり、ブラウザの自動再生ポリシー上は理論上ブロックされないはずだが、それでも鳴らないとの報告がある
- 単純な自動再生ポリシー起因と決めつけて場当たり的に直すのはリスクがあるため、まず実際のエラー内容を確認する必要がある
- ユーザーの開発環境はスマートフォンのみで、ブラウザのdevtoolsでconsole出力を確認できない。ログに残すだけでは診断に使えない

## 変更内容

`playQuizSfx()`の呼び出し箇所（計5箇所）で従来`.catch(() => {})`により握りつぶしていたエラーを、画面下部に固定表示する赤いバナーとして表示するようにした。

- `frontend/src/views/QuizRoomView.jsx`: `onBuzz`・`handleRoundReset`・`showCelebration`のeffect（参加者側の3箇所）
- `frontend/src/hooks/useQuizRoomAdmin.js`: `onBuzz`・`judgeQuizRoomBuzz`（管理者側の2箇所）、`quizRoomSfxError`を新設してApp.jsx側へ公開
- `frontend/src/App.jsx`: `quizRoomSfxError`を受け取り、管理者画面の該当箇所2箇所に表示

再生に成功する限り、従来どおり何も表示されない。

## 設計

- **選定**: 効果音再生エラーを画面上に一時表示する診断用パッチ
- **却下**: (1) 確証のないまま推測で修正する案、(2) `console.error`のみでログに残す案（スマホオンリーの開発環境ではdevtoolsを確認できないため無効）
- **理由**: 実機での再現・エラー内容の確認なしに、この種のブラウザ固有の音声再生問題を確定的に診断することはできない

## 影響

- 効果音の再生に失敗した場合のみ、画面下部に赤いエラーバナーが一時的に表示されるようになる
- 本PRはissue #679の恒久対応ではなく診断用。実際のエラー内容が判明次第、正しい修正を別PRで行い、本PRで追加した診断表示は削除する想定

## テスト

- [x] `frontend`・`backend`ともにlint・vitestが0件エラーで成功することを確認
- [x] `frontend`のbuildが成功することを確認
- [x] 既存テストはいずれも効果音再生自体が成功するモック環境で実行されるため、新設したエラーバナーはどのテストでも表示されず、既存テストへの影響がないことを確認
- [ ] エラーバナーが実際にどのようなエラー内容を表示するかは、実機で再現するまで確認できない

Refs: #679


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_