### PR TITLE
fix(frontend): クイズ大会効果音の絶対パスをbase設定に合わせ相対化する

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -902,7 +902,6 @@ function App() {
     quizRoomCreateError,
     openQuizRooms,
     quizRoomBuzzedBy,
-    quizRoomSfxError,
     quizRoomPoints,
     quizRoomParticipants,
     quizRoomConnectionStatus,
@@ -1180,13 +1179,6 @@ function App() {
           answer={currentPhrase?.answer}
           onJudge={judgeQuizRoomBuzz}
         />
-        {/* issue #679診断用（後で削除予定）: 効果音再生エラーの原因調査のため、
-            スマホの画面上に直接エラー内容を表示する */}
-        {quizRoomSfxError && (
-          <div className="position-fixed bottom-0 start-0 end-0 alert alert-danger small m-2 mb-0" role="alert">
-            効果音再生エラー（診断用）: {quizRoomSfxError}
-          </div>
-        )}
       </>
     );
   }
@@ -1668,13 +1660,6 @@ function App() {
             answer={currentPhrase?.answer}
             onJudge={judgeQuizRoomBuzz}
           />
-          {/* issue #679診断用（後で削除予定）: 効果音再生エラーの原因調査のため、
-              スマホの画面上に直接エラー内容を表示する */}
-          {quizRoomSfxError && (
-            <div className="position-fixed bottom-0 start-0 end-0 alert alert-danger small m-2 mb-0" role="alert">
-              効果音再生エラー（診断用）: {quizRoomSfxError}
-            </div>
-          )}
         </div>
       ) : (
         <div className="mb-4 d-flex flex-wrap gap-3 justify-content-center align-items-start">

--- a/frontend/src/hooks/useQuizRoomAdmin.js
+++ b/frontend/src/hooks/useQuizRoomAdmin.js
@@ -41,10 +41,6 @@ export function useQuizRoomAdmin({
   // QuizRoomView.jsxのbuzzRoundKeyと同じ考え方で、resultの間はリセットしない）
   const [quizRoomBuzzedBy, setQuizRoomBuzzedBy] = useState(null);
   const [quizRoomBuzzRoundKey, setQuizRoomBuzzRoundKey] = useState(null);
-  // issue #679診断用（後で削除予定）: 効果音の再生に失敗した場合、原因調査のため
-  // 画面上にエラー内容を表示する。スマホオンリーの開発環境ではブラウザの
-  // devtoolsでconsole出力を確認できないため、console.errorだけでは診断できない
-  const [quizRoomSfxError, setQuizRoomSfxError] = useState(null);
   // ポイント制（issue #519）: 名前→累計ポイントのマップ。管理者には参加者ごとの
   // ポイントを一覧表示する
   const [quizRoomPoints, setQuizRoomPoints] = useState({});
@@ -106,10 +102,10 @@ export function useQuizRoomAdmin({
     onState: noop,
     onBuzz: (buzzedBy) => {
       // issue #613: 参加者の早押しを管理者側にも音で通知する
-      playQuizSfx("buzz", "/quiz-buzz.mp3").catch((error) => {
-        // issue #679診断用（後で削除予定）
-        setQuizRoomSfxError(`buzz: ${error?.name || error}`);
-      });
+      // issue #679: base: "./"（vite.config.js）でサブパス配下にデプロイされるため、
+      // 絶対パス（先頭スラッシュ）だとドメインルート宛になり音声ファイルが見つからず
+      // NotSupportedErrorになる。favicon.png等と同じ相対パスにする
+      playQuizSfx("buzz", "quiz-buzz.mp3").catch(() => {});
       setQuizRoomBuzzedBy(buzzedBy);
     },
     onPoints: setQuizRoomPoints,
@@ -130,10 +126,7 @@ export function useQuizRoomAdmin({
     // issue #613: 正誤判定した瞬間に管理者側でも結果を音で確認できるようにする。
     // ボタン押下という実際のユーザー操作の中で呼ぶため、事前のunlockAudioPlayback()
     // なしでも再生できる
-    playQuizSfx(correct ? "correct" : "incorrect", correct ? "/quiz-correct.mp3" : "/quiz-incorrect.mp3").catch((error) => {
-      // issue #679診断用（後で削除予定）
-      setQuizRoomSfxError(`${correct ? "correct" : "incorrect"}: ${error?.name || error}`);
-    });
+    playQuizSfx(correct ? "correct" : "incorrect", correct ? "quiz-correct.mp3" : "quiz-incorrect.mp3").catch(() => {});
     if (correct) {
       await revealCurrentResult(winner);
     }
@@ -237,7 +230,6 @@ export function useQuizRoomAdmin({
     quizRoomCreateError,
     openQuizRooms,
     quizRoomBuzzedBy,
-    quizRoomSfxError,
     quizRoomPoints,
     quizRoomParticipants,
     quizRoomConnectionStatus,

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -409,7 +409,7 @@ describe('useQuizRoomAdmin (via App)', () => {
     expect(ws.sent).toContainEqual(JSON.stringify({ action: 'judgeBuzz', correct: false }));
     expect(screen.queryByText('🔔 はなこ さんが回答中')).not.toBeInTheDocument();
     // issue #613: 不正解の判定結果も音で通知する
-    expect(window.Audio.mock.results.map((r) => r.value).some((a) => a.src === '/quiz-incorrect.mp3')).toBe(true);
+    expect(window.Audio.mock.results.map((r) => r.value).some((a) => a.src === 'quiz-incorrect.mp3')).toBe(true);
   }, 40000);
 
   it('shows the buzz judgment modal even while the admin is on the room info screen (issue #613)', async () => {
@@ -472,13 +472,13 @@ describe('useQuizRoomAdmin (via App)', () => {
     // ルーム情報画面自体も表示されたままであることを確認する
     expect(screen.getByText('ABC123')).toBeInTheDocument();
     // issue #613: 早押し発生を管理者側にも音で通知する
-    expect(window.Audio.mock.results.map((r) => r.value).some((a) => a.src === '/quiz-buzz.mp3')).toBe(true);
+    expect(window.Audio.mock.results.map((r) => r.value).some((a) => a.src === 'quiz-buzz.mp3')).toBe(true);
 
     fireEvent.click(screen.getByText('正解'));
     expect(ws.sent).toContainEqual(JSON.stringify({ action: 'judgeBuzz', correct: true }));
     expect(screen.queryByText('🔔 はなこ さんが回答中')).not.toBeInTheDocument();
     // issue #613: 正誤判定の結果も音で通知する
-    expect(window.Audio.mock.results.map((r) => r.value).some((a) => a.src === '/quiz-correct.mp3')).toBe(true);
+    expect(window.Audio.mock.results.map((r) => r.value).some((a) => a.src === 'quiz-correct.mp3')).toBe(true);
   }, 40000);
 
   it('shows the current phrase\'s answer in the judgment modal, so the admin can tell whether the response was correct (issue #586)', async () => {

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -86,10 +86,6 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   // 早押し正誤判定（issue #546）: 不正解と判定された場合、そのラウンド中は
   // 自分だけ早押しボタンを再表示しない
   const [excludedThisRound, setExcludedThisRound] = useState(false);
-  // issue #679診断用（後で削除予定）: 効果音の再生に失敗した場合、原因調査のため
-  // 画面上にエラー内容を表示する。スマホオンリーの開発環境ではブラウザの
-  // devtoolsでconsole出力を確認できないため、console.errorだけでは診断できない
-  const [sfxError, setSfxError] = useState(null);
   // ポイント制（issue #519）: 名前→累計ポイントのマップ。集計単位はconnectionIdではなく
   // name（早押し機能の実装参照）なので、自分のポイントはpoints[confirmedName]で引く
   const [points, setPoints] = useState({});
@@ -176,10 +172,10 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   const handleRoundReset = ({ excludedName }) => {
     // issue #613: 不正解の判定結果を参加者全員に音で伝える（除外された本人以外にとっては
     // 「次に早押しできるようになった」合図でもあるが、判定内容自体は不正解のため同じ音を使う）
-    playQuizSfx("incorrect", "/quiz-incorrect.mp3").catch((error) => {
-      // issue #679診断用（後で削除予定）
-      setSfxError(`incorrect: ${error?.name || error}`);
-    });
+    // issue #679: base: "./"（vite.config.js）でサブパス配下にデプロイされるため、
+    // 絶対パス（先頭スラッシュ）だとドメインルート宛になり音声ファイルが見つからず
+    // NotSupportedErrorになる。favicon.png等と同じ相対パスにする
+    playQuizSfx("incorrect", "quiz-incorrect.mp3").catch(() => {});
     if (excludedName === confirmedName) {
       setExcludedThisRound(true);
     } else {
@@ -195,10 +191,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     onState: setRoomState,
     onBuzz: (buzzedByParam) => {
       // issue #613: 早押し発生（自分・他の参加者いずれの場合も）を音で通知する
-      playQuizSfx("buzz", "/quiz-buzz.mp3").catch((error) => {
-        // issue #679診断用（後で削除予定）
-        setSfxError(`buzz: ${error?.name || error}`);
-      });
+      playQuizSfx("buzz", "quiz-buzz.mp3").catch(() => {});
       setBuzzedBy(buzzedByParam);
     },
     onPoints: setPoints,
@@ -273,10 +266,7 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   // なった瞬間にだけ再生されるようdepsをshowCelebrationのみにする
   useEffect(() => {
     if (showCelebration) {
-      playQuizSfx("correct", "/quiz-correct.mp3").catch((error) => {
-        // issue #679診断用（後で削除予定）
-        setSfxError(`correct: ${error?.name || error}`);
-      });
+      playQuizSfx("correct", "quiz-correct.mp3").catch(() => {});
     }
   }, [showCelebration]);
 
@@ -470,13 +460,6 @@ function QuizRoomView({ setView, wsBaseUrl }) {
             <button onClick={handleBuzz} className="btn btn-danger btn-lg rounded-pill px-5">
               回答する
             </button>
-          </div>
-        )}
-        {/* issue #679診断用（後で削除予定）: 効果音再生エラーの原因調査のため、
-            スマホの画面上に直接エラー内容を表示する */}
-        {sfxError && (
-          <div className="position-fixed bottom-0 start-0 end-0 alert alert-danger small m-2 mb-0" role="alert">
-            効果音再生エラー（診断用）: {sfxError}
           </div>
         )}
         {(() => {

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -786,7 +786,7 @@ describe('QuizRoomView', () => {
       emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
       emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
 
-      const buzzAudio = audioInstances.find((a) => a.src === '/quiz-buzz.mp3');
+      const buzzAudio = audioInstances.find((a) => a.src === 'quiz-buzz.mp3');
       expect(buzzAudio).toBeDefined();
       expect(buzzAudio.play).toHaveBeenCalled();
     });
@@ -799,12 +799,12 @@ describe('QuizRoomView', () => {
       emitState({ type: 'phrase', content: { category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '3' } });
       // 早押しなし（winnerなし）の結果表示では鳴らさない
       emitState({ type: 'result', content: { time: 1.2, answer: '答え1', winner: null } });
-      expect(audioInstances.find((a) => a.src === '/quiz-correct.mp3')).toBeUndefined();
+      expect(audioInstances.find((a) => a.src === 'quiz-correct.mp3')).toBeUndefined();
 
       emitState({ type: 'phrase', content: { category: 'Cat1', kana: 'あ', phrase: '読み札2', level: '3' } });
       emitState({ type: 'result', content: { time: 0.8, answer: '答え2', winner: 'たろう' } });
 
-      const correctAudio = audioInstances.find((a) => a.src === '/quiz-correct.mp3');
+      const correctAudio = audioInstances.find((a) => a.src === 'quiz-correct.mp3');
       expect(correctAudio).toBeDefined();
       expect(correctAudio.play).toHaveBeenCalled();
     });
@@ -818,7 +818,7 @@ describe('QuizRoomView', () => {
       emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
       emitRoundReset({ excludedName: 'はなこ' });
 
-      const incorrectAudio = audioInstances.find((a) => a.src === '/quiz-incorrect.mp3');
+      const incorrectAudio = audioInstances.find((a) => a.src === 'quiz-incorrect.mp3');
       expect(incorrectAudio).toBeDefined();
       expect(incorrectAudio.play).toHaveBeenCalled();
     });


### PR DESCRIPTION
## 概要

issue #679（早押し/正解/不正解の効果音が鳴らない）の恒久対応。[PR #681](https://github.com/bamiyanapp/karuta/pull/681)で追加した画面上の診断表示で、実際に`buzz: NotSupportedError`というエラーを確認できたことから原因を特定した。

## 原因

効果音ファイル（`quiz-buzz.mp3`・`quiz-correct.mp3`・`quiz-incorrect.mp3`）への参照が絶対パス（先頭スラッシュ、例: `"/quiz-buzz.mp3"`）になっており、`vite.config.js`の`base: "./"`設定（GitHub Pagesのプロジェクトページ `https://bamiyanapp.github.io/karuta/` 配下へのデプロイに対応するための設定）と矛盾していた。

先頭スラッシュ付きの絶対パスはドメインルート（`https://bamiyanapp.github.io/quiz-buzz.mp3`）を指してしまい、`/karuta/`配下ではない存在しないパスを誤って参照する。結果、mp3ではない別のレスポンス（404ページ等）が返り、ブラウザが音声としてデコードできず`NotSupportedError`になっていた。

既存の`favicon.png`（`src="favicon.png"`、先頭スラッシュ無し）は同じ問題を回避できていたため、これと同じ相対パスの書き方に統一した。

## 変更内容

- `frontend/src/views/QuizRoomView.jsx`: `onBuzz`・`handleRoundReset`・`showCelebration`のeffect（3箇所）のsrcを相対パス化
- `frontend/src/hooks/useQuizRoomAdmin.js`: `onBuzz`・`judgeQuizRoomBuzz`（2箇所）のsrcを相対パス化
- あわせて、原因が確定したため[PR #681](``https://github.com/bamiyanapp/karuta/pull/681)で追加した画面上の診断用エラーバナー（'sfxError'・'quizRoomSfxError'、恒久対応ではないと明記済み）を削除し、'catch'を元の'.catch((``) => {})`に戻した

## 設計

- **選定**: 効果音ファイルへの参照を絶対パスから相対パス（`favicon.png`と同じ書き方）へ統一する
- **却下**: `import.meta.env.BASE_URL`で明示的にbase URLを組み立てる案（このアプリはSPAでもURLのpathnameを一切変更しないため、単純な相対パスで必要十分であり不要な複雑さを避けた）
- **理由**: 上記のとおり

## 影響

- 本番環境（GitHub Pagesのプロジェクトページ配下）で早押し・正解・不正解の効果音が正しく再生されるようになる（想定）
- 画面上の診断用エラーバナーは表示されなくなる（恒久対応不要になったため意図した変更）

## テスト

- [x] `frontend`・`backend`ともにlint・vitestが0件エラーで成功することを確認
- [x] `frontend`のbuildが成功することを確認
- [x] src変更に合わせて`QuizRoomView.test.jsx`・`useQuizRoomAdmin.test.jsx`の該当アサーション（`audio.src`の期待値）を相対パスへ更新
- [ ] 実際にGitHub Pagesのプロジェクトページ配下で効果音が鳴るようになったことは、本PRマージ後の実環境での確認を待つ（このサンドボックスには音声再生を確認できる実ブラウザ環境が無い）

Refs: #679


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_