### PR TITLE
fix(frontend): 不正解時に誤答者へ明確なフィードバックを表示する

### DIFF
--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -176,10 +176,13 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     // 絶対パス（先頭スラッシュ）だとドメインルート宛になり音声ファイルが見つからず
     // NotSupportedErrorになる。favicon.png等と同じ相対パスにする
     playQuizSfx("incorrect", "quiz-incorrect.mp3").catch(() => {});
+    // issue #680: 除外された本人はbuzzedByを残したままにするとexcludedThisRoundが
+    // trueになっても表示分岐（下記JSX）でbuzzedByが優先され、「〇〇さんが回答中」の
+    // 表示が次の札が届くまで残り続けてしまう。自分自身が不正解と判定されたことを
+    // 表す専用の表示に切り替えるため、buzzedByもクリアする
+    setBuzzedBy(null);
     if (excludedName === confirmedName) {
       setExcludedThisRound(true);
-    } else {
-      setBuzzedBy(null);
     }
   };
 
@@ -453,9 +456,14 @@ function QuizRoomView({ setView, wsBaseUrl }) {
         </p>
         <p className="fw-bold text-dark">獲得ポイント: {points[confirmedName] || 0}</p>
         {renderParticipantContent(roomState)}
-        {buzzedBy ? (
+        {excludedThisRound ? (
+          // issue #680: 不正解と判定された本人には「回答中」ではなく、不正解だった
+          // ことと次の札を待つよう案内する専用の表示を出す。excludedThisRoundは
+          // 次の札が届いたタイミングでfalseに戻る（上記のラウンド切り替え判定）
+          <p className="fw-bold text-muted mt-4">不正解でした。次の問題まで待っててね</p>
+        ) : buzzedBy ? (
           <p className="fw-bold text-dark mt-4">🔔 {buzzedBy.name} さんが回答中</p>
-        ) : roomState?.type === "phrase" && !excludedThisRound && (
+        ) : roomState?.type === "phrase" && (
           <div className="mt-4">
             <button onClick={handleBuzz} className="btn btn-danger btn-lg rounded-pill px-5">
               回答する

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -413,6 +413,28 @@ describe('QuizRoomView', () => {
     expect(screen.queryByText('回答する')).not.toBeInTheDocument();
   });
 
+  it('tells the participant judged incorrect that they were wrong instead of leaving the stale "answering" display, and clears it once the next question arrives (issue #680)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName('はなこ');
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+    fireEvent.click(screen.getByText('回答する'));
+    emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
+    expect(screen.getByText('🔔 はなこ さんが回答中')).toBeInTheDocument();
+
+    emitRoundReset({ excludedName: 'はなこ' });
+
+    // 「〇〇さんが回答中」の古い表示が残り続けず、不正解だったことが分かる表示に切り替わる
+    expect(screen.queryByText('🔔 はなこ さんが回答中')).not.toBeInTheDocument();
+    expect(screen.getByText('不正解でした。次の問題まで待っててね')).toBeInTheDocument();
+
+    // 次の札が届いたら通常どおり早押しボタンに戻る
+    emitState({ type: 'phrase', content: { id: 'p2', category: 'Cat1', phrase: '読み札2', level: '3' } });
+    expect(screen.queryByText('不正解でした。次の問題まで待っててね')).not.toBeInTheDocument();
+    expect(screen.getByText('回答する')).toBeInTheDocument();
+  });
+
   it('shows the buzz button again for a participant not excluded after a roundReset (issue #546)', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);


### PR DESCRIPTION
## 概要

issue #680対応。早押し正誤判定（issue #546）で不正解と判定された本人の画面応答が分かりにくい問題を修正する。

## 原因

`handleRoundReset`内で、不正解と判定された本人（`excludedName === confirmedName`）は`excludedThisRound`をtrueにするだけで`buzzedBy`をクリアしておらず、表示分岐（JSX）は`buzzedBy`が残っている限り常に「🔔 〇〇さんが回答中」を表示し続けていた。結果、不正解になった本人だけ、次の札が届くまでずっと古い「回答中」表示が残り続け、自分がどういう状態なのか画面から分からなかった。

## 変更内容

- `handleRoundReset`で`excludedThisRound`をtrueにする際、`buzzedBy`もクリアするようにした
- 表示分岐の判定順序を`excludedThisRound` → `buzzedBy` → 回答ボタンの順に変更し、不正解と判定された本人には「不正解でした。次の問題まで待っててね」という専用の案内を表示するようにした
- `excludedThisRound`は既存の実装どおり次の札が届いたタイミングで`false`に戻るため、案内は次の問題が来るまで表示され続ける

## 設計

- **選定**: 既存の表示領域（回答ボタン・回答者表示の箇所）の出し分けを切り替える最小限の修正
- **却下**: モーダルやトースト等の新規UIコンポーネントを追加する案（既存のUI構造を変えずに要件を満たせるため不要と判断）
- **理由**: 上記のとおり

## 影響

- 不正解と判定された参加者本人の画面に、次の問題まで待つよう促す文言が表示されるようになる
- 不正解と判定されなかった他の参加者・正解した参加者の表示・挙動に変更はない

## テスト

- [x] `frontend`・`backend`ともにlint・vitestが0件エラーで成功することを確認
- [x] `frontend`のbuildが成功することを確認
- [x] `QuizRoomView.test.jsx`に、不正解判定後に「🔔 〇〇さんが回答中」の表示が消え「不正解でした。次の問題まで待っててね」に切り替わること、次の札が届くと通常の回答ボタンに戻ることを検証するテストを追加

Refs: #680


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_