### PR TITLE
perf(frontend): クイズ大会syncポーリングの間隔を延長し非表示タブで停止する

### DIFF
--- a/frontend/src/hooks/useQuizRoomSync.js
+++ b/frontend/src/hooks/useQuizRoomSync.js
@@ -9,8 +9,14 @@ const MAX_RECONNECT_ATTEMPTS = 5; // 際限ない再接続ループを防ぐた�
 const ERROR_RETRY_INTERVAL_MS = 15000;
 // プッシュ通知（updateStateのブロードキャスト）が何らかの理由で届かなかった場合に備え、
 // 一定間隔でsyncを再要求し自己修復させる保険（本来はプッシュのみで完結するはずだが、
-// 個別のブロードキャスト送信が届かないケースを完全には排除できないため）
-const SYNC_POLL_INTERVAL_MS = 5000;
+// 個別のブロードキャスト送信が届かないケースを完全には排除できないため）。
+// issue #619: 保険である以上は低頻度で十分なため、参加者数に比例して定常的に発生する
+// Lambda実行・DynamoDB読み取り・WebSocket送信を削減する目的で5秒から延長した。
+// 固定間隔のsetIntervalではなく、送信のたびにランダムなジッターを加えて次回を
+// スケジュールし直す（下記scheduleNextSyncPoll）ことで、同一ルームの全接続が
+// 同時刻に送信を送って負荷が偏るのを防ぐ
+const SYNC_POLL_BASE_INTERVAL_MS = 45000;
+const SYNC_POLL_JITTER_MS = 15000;
 
 // connectionStatusの値ごとの表示ラベル。参加者画面（QuizRoomView.jsx）・
 // 管理者画面（App.jsx、issue #614で追加）の両方で同じ表記を使うため共有する
@@ -115,11 +121,22 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
         if (pendingNameRef.current !== null) {
           ws.send(JSON.stringify({ action: "setName", name: pendingNameRef.current }));
         }
-        pollTimerRef.current = setInterval(() => {
-          if (ws.readyState === WebSocket.OPEN) {
-            ws.send(JSON.stringify({ action: "sync" }));
-          }
-        }, SYNC_POLL_INTERVAL_MS);
+        // issue #619: 固定間隔のsetIntervalではなく、送信のたびにジッターを加えて
+        // 次回をスケジュールし直すsetTimeoutチェーンにする。あわせて、タブが
+        // 非表示（document.hidden）の間は送信自体をスキップしてコストを抑える
+        // （フォアグラウンド復帰時は下記のvisibilitychangeハンドラが即座に1回同期する）
+        const scheduleNextSyncPoll = () => {
+          const delay = SYNC_POLL_BASE_INTERVAL_MS + Math.random() * SYNC_POLL_JITTER_MS;
+          pollTimerRef.current = setTimeout(() => {
+            if (ws.readyState === WebSocket.OPEN) {
+              if (typeof document === "undefined" || document.visibilityState === "visible") {
+                ws.send(JSON.stringify({ action: "sync" }));
+              }
+              scheduleNextSyncPoll();
+            }
+          }, delay);
+        };
+        scheduleNextSyncPoll();
       };
 
       ws.onmessage = (event) => {
@@ -149,7 +166,7 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
 
       ws.onclose = () => {
         if (pollTimerRef.current) {
-          clearInterval(pollTimerRef.current);
+          clearTimeout(pollTimerRef.current);
           pollTimerRef.current = null;
         }
         if (closedByCleanupRef.current) {
@@ -178,7 +195,7 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
         clearTimeout(reconnectTimeoutRef.current);
       }
       if (pollTimerRef.current) {
-        clearInterval(pollTimerRef.current);
+        clearTimeout(pollTimerRef.current);
       }
       wsRef.current?.close();
     };
@@ -215,9 +232,17 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
       return undefined;
     }
     const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        forceReconnect();
+      if (document.visibilityState !== "visible") {
+        return;
       }
+      // issue #619: 非表示の間はポーリング（sync）自体を送っていないため、接続が
+      // 生きたままフォアグラウンドに復帰した場合はforceReconnect（読み込み中でない
+      // 場合は何もしない）に任せず、その場で1回同期して即座に最新状態を反映する
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        wsRef.current.send(JSON.stringify({ action: "sync" }));
+        return;
+      }
+      forceReconnect();
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
     window.addEventListener("online", forceReconnect);

--- a/frontend/src/hooks/useQuizRoomSync.test.js
+++ b/frontend/src/hooks/useQuizRoomSync.test.js
@@ -321,8 +321,11 @@ describe('useQuizRoomSync', () => {
     ]);
   });
 
-  it('periodically re-requests sync while connected, as a fallback in case a broadcast is missed', () => {
+  it('periodically re-requests sync while connected, as a fallback in case a broadcast is missed (issue #619: 45秒基準+ジッター)', () => {
     vi.useFakeTimers();
+    // ジッター（Math.random() * SYNC_POLL_JITTER_MS）を0固定にし、間隔を基準値
+    // （45秒）ちょうどに決定的にする
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
 
     act(() => {
@@ -331,7 +334,7 @@ describe('useQuizRoomSync', () => {
     expect(MockWebSocket.instances[0].sent).toEqual([JSON.stringify({ action: 'sync' })]);
 
     act(() => {
-      vi.advanceTimersByTime(5000);
+      vi.advanceTimersByTime(45000);
     });
     expect(MockWebSocket.instances[0].sent).toEqual([
       JSON.stringify({ action: 'sync' }),
@@ -339,9 +342,43 @@ describe('useQuizRoomSync', () => {
     ]);
 
     act(() => {
-      vi.advanceTimersByTime(5000);
+      vi.advanceTimersByTime(45000);
     });
     expect(MockWebSocket.instances[0].sent).toHaveLength(3);
+
+    randomSpy.mockRestore();
+  });
+
+  it('skips sending the periodic sync while the tab is hidden, and resumes once visible again (issue #619)', () => {
+    vi.useFakeTimers();
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    const setVisibilityState = (state) => {
+      Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+    };
+
+    renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn() }));
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+    });
+    expect(MockWebSocket.instances[0].sent).toHaveLength(1);
+
+    setVisibilityState('hidden');
+    act(() => {
+      vi.advanceTimersByTime(45000);
+    });
+    // 非表示の間はポーリングのsync送信自体をスキップする
+    expect(MockWebSocket.instances[0].sent).toHaveLength(1);
+
+    // フォアグラウンド復帰時、visibilitychangeハンドラが即座に1回同期する
+    setVisibilityState('visible');
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(MockWebSocket.instances[0].sent).toHaveLength(2);
+
+    randomSpy.mockRestore();
+    setVisibilityState('visible');
   });
 
   it('stops polling once the connection closes', () => {


### PR DESCRIPTION
## 概要

issue #619対応。クイズ大会モードの5秒間隔syncポーリングが参加者数に比例してWebSocket送信・DynamoDB読み取りを増幅させる問題について、対応方針案のうち(1)間隔延長+ジッターと(3)非表示タブでのポーリング停止を実装した。

## 変更内容

- `SYNC_POLL_INTERVAL_MS`（5秒固定）を廃止し、`SYNC_POLL_BASE_INTERVAL_MS`（45秒）+ `SYNC_POLL_JITTER_MS`（0〜15秒のランダム値）に変更
- 固定間隔の`setInterval`ではなく、送信のたびにジッターを加えて次回をスケジュールし直す`setTimeout`チェーンにすることで、同一ルームの全接続が同時刻に送信して負荷が偏るのを防ぐ
- `document.visibilityState`が`"visible"`でない間はポーリングの`sync`送信自体をスキップする
- フォアグラウンド復帰時は`visibilitychange`ハンドラで、既に接続が生きていれば（`readyState === OPEN`）その場で1回同期し、生きていなければ従来どおり`forceReconnect`で再接続する

## スコープ外（今回は実装しない）

issue #619が挙げていた(2)バージョン番号による差分応答は今回のスコープから除外した。ルーム状態にバージョンを持たせ、backend（`quizRoomHandler.js`）のsync処理・DynamoDBスキーマまで変更する必要があり実装コストが大きいため、別途検討することとした。

## 設計

- **選定**: 間隔延長+ジッター、非表示タブでの停止
- **却下**: バージョン番号による差分応答（実装コストが大きいため今回のスコープ外）
- **理由**: プッシュ配信が主経路であり、ポーリングはそれが届かなかった場合の自己修復用の保険という設計意図は変わらないため、保険としての頻度を下げても体験に影響しない

## 影響

- 進行中の体験（プッシュ配信によるリアルタイム更新）には影響しない
- プッシュ配信が届かなかった場合の自己修復までの時間が最大5秒から最大60秒程度に延びる
- タブが非表示の間はsyncポーリングを送らなくなり、フォアグラウンド復帰時に接続が生きていれば即座に1回同期する

## テスト

- [x] `frontend`・`backend`ともにlint・vitestが0件エラーで成功することを確認
- [x] `frontend`のbuildが成功することを確認
- [x] `useQuizRoomSync.test.js`の既存の定期syncテストを新しい間隔に更新し、非表示タブの間はsync送信をスキップし、フォアグラウンド復帰時に即座に1回同期することを検証する新規テストを追加
- [ ] 実際のAWS環境でLambda実行回数・DynamoDB読み取り量・WebSocketメッセージ数がどの程度削減されるかは、本番運用でのみ確認できる

Refs: #619


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_