### PR TITLE
クイズ大会モードの機能改善・見た目修正（issue #693-699）

### DIFF
--- a/backend/handler.js
+++ b/backend/handler.js
@@ -512,7 +512,7 @@ exports.getCategories = async (event) => {
   try {
     const scanParams = {
       TableName: process.env.TABLE_NAME,
-      ProjectionExpression: "category, #grp, answer",
+      ProjectionExpression: "category, #grp, answer, readCount",
       ExpressionAttributeNames: {
         "#grp": "group",
       },
@@ -531,11 +531,13 @@ exports.getCategories = async (event) => {
           group: item.group === "engineer" ? "engineer" : "kids",
           allHaveAnswer: hasAnswer,
           count: 1,
+          totalReadCount: item.readCount || 0,
         });
       } else {
         const info = categoryMap.get(name);
         info.allHaveAnswer = info.allHaveAnswer && hasAnswer;
         info.count += 1;
+        info.totalReadCount += (item.readCount || 0);
       }
     });
 
@@ -544,9 +546,13 @@ exports.getCategories = async (event) => {
       group: info.group,
       requiresPossessionCheck: !info.allHaveAnswer,
       count: info.count,
+      readCount: info.totalReadCount,
     }));
+
+    // カテゴリを人気順（readCount降順）にソート
+    categories.sort((a, b) => b.readCount - a.readCount);
     if (categories.length === 0) {
-      categories = [{ name: "大ピンチずかん", group: "kids", requiresPossessionCheck: true, count: 0 }];
+      categories = [{ name: "大ピンチずかん", group: "kids", requiresPossessionCheck: true, count: 0, readCount: 0 }];
     }
 
     return {

--- a/backend/handler.js
+++ b/backend/handler.js
@@ -326,7 +326,7 @@ exports.getPhrase = async (event) => {
       // それ以外は従来通りScan（またはQueryに最適化可能だが一旦Scan）
       const scanParams = {
         TableName: process.env.TABLE_NAME,
-        ProjectionExpression: "id, category, phrase, #lvl, kana, phrase_en, answer, readCount, averageTime, averageDifficulty, totalTime, totalDifficulty",
+        ProjectionExpression: "id, category, phrase, #lvl, kana, phrase_en, answer, explanation, readCount, averageTime, averageDifficulty, totalTime, totalDifficulty",
         ExpressionAttributeNames: {
           "#lvl": "level",
         },
@@ -473,7 +473,7 @@ exports.getPhrasesList = async (event) => {
         ExpressionAttributeValues: {
           ":cat": category,
         },
-        ProjectionExpression: "id, category, phrase, #lvl, kana, answer, readCount, averageTime, averageDifficulty, totalTime, totalDifficulty",
+        ProjectionExpression: "id, category, phrase, #lvl, kana, answer, explanation, readCount, averageTime, averageDifficulty, totalTime, totalDifficulty",
         ExpressionAttributeNames: {
           "#lvl": "level",
         },
@@ -483,7 +483,7 @@ exports.getPhrasesList = async (event) => {
     } else {
       const scanParams = {
         TableName: process.env.TABLE_NAME,
-        ProjectionExpression: "id, category, phrase, #lvl, kana, answer, readCount, averageTime, averageDifficulty, totalTime, totalDifficulty",
+        ProjectionExpression: "id, category, phrase, #lvl, kana, answer, explanation, readCount, averageTime, averageDifficulty, totalTime, totalDifficulty",
         ExpressionAttributeNames: {
           "#lvl": "level",
         },

--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -34,8 +34,8 @@ describe('getCategories', () => {
 
     expect(response.statusCode).toBe(200);
     expect(body.categories).toEqual([
-      { name: 'Category1', group: 'kids', requiresPossessionCheck: true, count: 2 },
-      { name: 'Category2', group: 'engineer', requiresPossessionCheck: true, count: 1 },
+      { name: 'Category1', group: 'kids', requiresPossessionCheck: true, count: 2, readCount: 0 },
+      { name: 'Category2', group: 'engineer', requiresPossessionCheck: true, count: 1, readCount: 0 },
     ]);
   });
 
@@ -52,8 +52,8 @@ describe('getCategories', () => {
 
     expect(response.statusCode).toBe(200);
     expect(body.categories).toEqual([
-      { name: 'Category1', group: 'kids', requiresPossessionCheck: true, count: 1 },
-      { name: 'Category2', group: 'kids', requiresPossessionCheck: true, count: 1 },
+      { name: 'Category1', group: 'kids', requiresPossessionCheck: true, count: 1, readCount: 0 },
+      { name: 'Category2', group: 'kids', requiresPossessionCheck: true, count: 1, readCount: 0 },
     ]);
   });
 
@@ -66,7 +66,7 @@ describe('getCategories', () => {
     const body = JSON.parse(response.body);
 
     expect(response.statusCode).toBe(200);
-    expect(body.categories).toEqual([{ name: '大ピンチずかん', group: 'kids', requiresPossessionCheck: true, count: 0 }]);
+    expect(body.categories).toEqual([{ name: '大ピンチずかん', group: 'kids', requiresPossessionCheck: true, count: 0, readCount: 0 }]);
   });
 
   it('should mark a category as not requiring possession check when every phrase has answer data', async () => {
@@ -83,8 +83,8 @@ describe('getCategories', () => {
 
     expect(response.statusCode).toBe(200);
     expect(body.categories).toEqual([
-      { name: 'OriginalCat', group: 'engineer', requiresPossessionCheck: false, count: 2 },
-      { name: 'CommercialCat', group: 'kids', requiresPossessionCheck: true, count: 1 },
+      { name: 'OriginalCat', group: 'engineer', requiresPossessionCheck: false, count: 2, readCount: 0 },
+      { name: 'CommercialCat', group: 'kids', requiresPossessionCheck: true, count: 1, readCount: 0 },
     ]);
   });
 
@@ -101,7 +101,7 @@ describe('getCategories', () => {
 
     expect(response.statusCode).toBe(200);
     expect(body.categories).toEqual([
-      { name: 'MixedCat', group: 'engineer', requiresPossessionCheck: true, count: 2 },
+      { name: 'MixedCat', group: 'engineer', requiresPossessionCheck: true, count: 2, readCount: 0 },
     ]);
   });
 

--- a/backend/phrases.csv
+++ b/backend/phrases.csv
@@ -1,827 +1,827 @@
-id,category,level,kana,phrase,phrase_en,answer,group
-3,大ピンチずかん,77,え,エスカレーターが　ぎゃくだった,The escalator was going the opposite way.,-,kids
-4,大ピンチずかん,20,あ,アイスが　とけてきた,The ice cream started melting.,-,kids
-5,大ピンチずかん,4,へ,へんな　ひやけを　した,Made a strange face.,-,kids
-6,大ピンチずかん,30,た,たんじょうびケーキが　たおれて　イチゴが　ころがった,The birthday cake fell over and the strawberries rolled away.,-,kids
-7,大ピンチずかん,23,ご,ごはんつぶを　ふんだ,Stepped on a grain of rice.,-,kids
-8,大ピンチずかん,21,お,おふろの　ごみが　すくえない,Can't scoop the debris out of the bathtub.,-,kids
-9,大ピンチずかん,18,ふ,ふたが　ない,There is no lid.,-,kids
-10,大ピンチずかん,6,て,テープの　はしが　みつからない,Can't find the end of the tape.,-,kids
-11,大ピンチずかん,28,え,えだまめが　とんだ,The edamame flew away.,-,kids
-12,大ピンチずかん,24,か,カップめんの　おゆが　たりない,Not enough hot water for the cup noodles.,-,kids
-13,大ピンチずかん,68,う,うんてんしている　くるまのなかに　クモが　でてきた,There is a big spider in the car while driving.,-,kids
-14,大ピンチずかん,35,ゆ,ゆでたまごが　ボロボロ,The boiled egg is falling apart.,-,kids
-15,大ピンチずかん,5,す,ストローが　とれない,Can't take out the straw.,-,kids
-16,大ピンチずかん,27,う,「う」の　もじが　はんたいだった,The letter 'u' was backwards.,-,kids
-17,大ピンチずかん,19,け,おちたけしゴムがみつからない,Can't find the dropped eraser.,-,kids
-18,大ピンチずかん,17,し,しょうゆをいれすぎた,Poured too much soy sauce.,-,kids
-19,大ピンチずかん,34,し,シャワーがみつからない,Can't find the shower.,-,kids
-20,大ピンチずかん,3,こ,こおりがしたにくっついた,The ice stuck to my tongue.,-,kids
-21,大ピンチずかん,26,た,たんじょうびケーキがたおれそう,The birthday cake is about to fall.,-,kids
-22,大ピンチずかん,22,じ,じゅうでんができていなかった,It wasn't charged.,-,kids
-23,大ピンチずかん,14,し,シャボンえきをすった,Accidentally inhaled the bubble solution.,-,kids
-24,大ピンチずかん,33,け,ケチャップがとんだ,Ketchup splattered.,-,kids
-25,大ピンチずかん,31,ぽ,ポケットからすながたくさんでてきた,A lot of sand came out of the pocket.,-,kids
-26,大ピンチずかん,25,せ,せんたくきのうしろにくつしたがおちた,A sock fell behind the washing machine.,-,kids
-27,大ピンチずかん,90,ふ,フンをふんだ,Stepped on poop.,-,kids
-28,大ピンチずかん,55,い,いおうとしていたことをわすれた,Forgot what I was about to say.,-,kids
-29,大ピンチずかん,46,に,にくがきれない,Can't cut the meat.,-,kids
-30,大ピンチずかん,39,た,たんじょうびケーキのろうそくがきえない,The birthday cake candles won't go out.,-,kids
-32,大ピンチずかん,54,れ,れいとうこがあかない,The freezer won't open.,-,kids
-33,大ピンチずかん,48,ふ,ふくの　タグが　きになって　しかたがない,The loose thread on my clothes is bothering me.,-,kids
-34,大ピンチずかん,43,し,しゅくだいノートと　じゆうちょうをまちがえた,Confused the homework notebook with the sketchbook.,-,kids
-35,大ピンチずかん,38,ふ,ふたがしまらない,The lid won't close.,-,kids
-36,大ピンチずかん,32,め,めんつゆがすごくあまった,A lot of noodle dipping sauce was left over.,-,kids
-37,大ピンチずかん,53,な,ながしのみずがスプーンではねた,The water in the sink splashed off the spoon.,-,kids
-38,大ピンチずかん,49,べ,べんざをあけたまますわった,Sat down with the toilet seat up.,-,kids
-39,大ピンチずかん,37,あ,アメリカンドッグがまわる,The corn dog is spinning.,-,kids
-40,大ピンチずかん,76,ね,ねむれない,Can't sleep.,-,kids
-41,大ピンチずかん,47,し,シャンプーがめにはいった,Got shampoo in my eyes.,-,kids
-42,大ピンチずかん,51,ば,バッグのなかですいとうがもれた,The water bottle leaked inside the bag.,-,kids
-43,大ピンチずかん,56,な,なまえがおもいだせない,Can't remember the name.,-,kids
-44,大ピンチずかん,64,き,きんじょの　おばさんに　なまえを　いつも　まちがえられる,The neighborhood lady has been getting my name wrong for a long time.,-,kids
-45,大ピンチずかん,50,お,おゆがない,There is no hot water.,-,kids
-46,大ピンチずかん,45,ど,ドアをあけられてさむい,Someone opened the door and it's cold.,-,kids
-47,大ピンチずかん,40,せ,せんせいのメガネがとんだ,The teacher's glasses flew off.,-,kids
-48,大ピンチずかん,36,ほ,ほねを　とるのに　しっぱいして　みが　くずれた,It became a mess while I was trying to remove the bones.,-,kids
-49,大ピンチずかん,29,ぎ,ぎゅうにゅうがこぼれた,The milk spilled.,-,kids
-50,大ピンチずかん,96,か,かさがうらがえった,The umbrella turned inside out.,-,kids
-51,大ピンチずかん,97,じ,じてんしゃがドミノだおし,The bicycles fell over like dominoes.,-,kids
-52,大ピンチずかん,98,お,おもったよりみじかくなった,It became shorter than I thought.,-,kids
-53,大ピンチずかん,99,ね,ネコがついてくる,A cat is following me.,-,kids
-54,大ピンチずかん,100,ど,どしゃぶりなのにかさがない,It's pouring rain but I don't have an umbrella.,-,kids
-55,大ピンチずかん,58,れ,れいとうこがしまらない,The freezer won't close.,-,kids
-56,大ピンチずかん,59,さ,さげたあたまの　いきおいで　ランドセルの　なかみが　ぜんぶとびだした,Everything fell out of my backpack when I bowed to say goodbye.,-,kids
-57,大ピンチずかん,84,ま,まいご,I'm lost.,-,kids
-58,大ピンチずかん,82,か,かいものがながい,Shopping is taking a long time.,-,kids
-59,大ピンチずかん,81,じ,じてんしゃにハチがとまっている,A bee is sitting on the bicycle.,-,kids
-60,大ピンチずかん,60,せ,せんせいに　おかあさんといってしまった,I accidentally called my teacher 'Mom'.,-,kids
-61,大ピンチずかん,61,ぎ,ギターのなかにおかしがおちた,A snack fell inside the guitar.,-,kids
-62,大ピンチずかん,62,ず,ズボンのゴムがきれた,The elastic in my pants snapped.,-,kids
-63,大ピンチずかん,63,さ,さなぎからかえった　カブトムシが　まよなかに　へやじゅうを　とびまわっている,The beetle that emerged from its pupa escaped at night and is flying around.,-,kids
-64,大ピンチずかん,57,け,けしゴムに　ついた　えんぴつのしんの　あとが　けすたびに　うつる,The pencil lead stuck in the eraser leaves marks when I erase.,-,kids
-65,大ピンチずかん,89,お,おきられない,Can't wake up.,-,kids
-66,大ピンチずかん,91,で,かばしらに　じてんしゃで　つっこんだ,Crashed my bicycle into a mosquito swarm.,-,kids
-67,大ピンチずかん,93,と,トイレがつまった,The toilet is clogged.,-,kids
-68,大ピンチずかん,94,お,おかあさんがイライラしている,Mom is getting irritated.,-,kids
-69,大ピンチずかん,95,お,プレゼントをわすれた,Forgot the present.,-,kids
-70,大ピンチずかん,86,し,しんしつに　だれかいる,Someone is in the bedroom.,-,kids
-71,大ピンチずかん,87,く,クモのすにかかった,Got caught in a spider web.,-,kids
-72,大ピンチずかん,88,と,トイレにおおきなガがとまっている,A large moth is sitting in the toilet.,-,kids
-73,大ピンチずかん,9,し,しゃっくりがとまらない,Can't stop hiccuping.,-,kids
-74,大ピンチずかん,16,わ,わりばしがうまくわれない,Can't split the chopsticks properly.,-,kids
-75,大ピンチずかん,11,ご,ゴミばこがやまもり,The trash can is overflowing.,-,kids
-76,大ピンチずかん,70,お,おなかがすいてうごけない,So hungry I can't move.,-,kids
-77,大ピンチずかん,67,ま,まちがえてシャワーがでた,The shower came on by mistake.,-,kids
-78,大ピンチずかん,13,け,パンがくろこげ,The bread is burnt to a crisp.,-,kids
-79,大ピンチずかん,10,け,けずりかすいれがはいってなかった,The pencil shavings container wasn't in.,-,kids
-80,大ピンチずかん,71,ふ,ふとんのなかでおならがでた,Farted under the covers.,-,kids
-81,大ピンチずかん,69,じ,じぶんのいえでトイレがつまった,The toilet at my own house is clogged.,-,kids
-82,大ピンチずかん,8,あ,あたまにつけたわゴムがとれない,Can't remove the rubber band I put on my head.,-,kids
-83,大ピンチずかん,12,や,ビニールぶくろがめくれない,Can't open the plastic bag.,-,kids
-84,大ピンチずかん,15,し,しょくばんを　スライスしたら　ぺったんこに　つぶれた,The bread got squashed while I was trying hard to slice it.,-,kids
-85,大ピンチずかん,7,ぺ,ペンがしみてつくえについた,The pen leaked onto the desk.,-,kids
-86,大ピンチずかん,80,や,やっぱりさむかった,It was cold after all.,-,kids
-87,大ピンチずかん,74,と,トイレのかみがない,There is no toilet paper.,-,kids
-88,大ピンチずかん,73,わ,ワサビいりだった,It had wasabi in it.,-,kids
-89,大ピンチずかん,72,お,おべんとうをわすれた,Forgot my lunch box.,-,kids
-90,大ピンチずかん,66,あ,あしがつちだらけ,Feet are covered in mud.,-,kids
-91,大ピンチずかん,65,は,ハエがじぶんにばかりとまる,Flies only land on me.,-,kids
-92,大ピンチずかん,83,い,イヌがすごくなめてくる,The dog is licking me a lot.,-,kids
-93,大ピンチずかん,75,し,しらないひとのてをにぎっていた,Was holding a stranger's hand.,-,kids
-94,大ピンチずかん,85,し,シロツメクサで　つくった　かんむりに　アブラムシが　いっぱいついていた,"When I looked closely at the clover crown, it was full of aphids.",-,kids
-95,大ピンチずかん,79,ば,バッグにアリがあつまってきた,Ants gathered on the bag.,-,kids
-96,大ピンチずかん,78,し,しんしつの　てんじょうに　ひとのかおみたいな　もようが　ある,The wood grain on the bedroom ceiling started to look like a person's face.,-,kids
-97,大ピンチずかん,41,や,やすみじかんに　おいた　すいとうを　とりに　いくのを　わすれた,The water bottle I left during recess is still there.,-,kids
-98,大ピンチずかん,42,ご,ごはんが　たりない,Not enough food.,-,kids
-99,大ピンチずかん,44,は,はなしを　きいてなかった,Wasn't listening.,-,kids
-100,大ピンチずかん,2,の,のんだガムに　まだあじが　たくさんのこっていた,Swallowed the gum; it still had a lot of flavor left.,-,kids
-101,大ピンチずかん,52,む,むかしの　おにぎりが　でてきた,An old rice ball appeared.,-,kids
-102,国旗王,上級,し,人口密度が高い,High population density.,-,kids
-103,国旗王,上級,ひ,一人当たりGDPが高い,High GDP per capita.,-,kids
-104,国旗王,上級,し,首都 最東,Easternmost capital.,-,kids
-105,国旗王,上級,し,首都が最北,Northernmost capital.,-,kids
-106,国旗王,上級,は,排他的経済水域,Exclusive Economic Zone.,-,kids
-107,国旗王,上級,く,軍事費が最小,Smallest military expenditure.,-,kids
-108,国旗王,上級,へ,平均寿命が短い,Short average life expectancy.,-,kids
-109,国旗王,初級,し,人口が多い,Large population.,-,kids
-110,国旗王,初級,め,面積が最小,Smallest area.,-,kids
-111,国旗王,初級,は,排他的経済水域が最小,Smallest Exclusive Economic Zone.,-,kids
-112,国旗王,上級,さ,最高地点が高い,Highest point is high.,-,kids
-113,国旗王,初級,こ,国内総生産GDPが低い,Low GDP.,-,kids
-114,国旗王,初級,し,人口が少ない,Small population.,-,kids
-115,国旗王,初級,せ,正式国名が長い,Long official country name.,-,kids
-116,国旗王,上級,く,軍事費が大きい,Large military expenditure.,-,kids
-117,国旗王,上級,さ,最高地点が低い,Highest point is low.,-,kids
-118,国旗王,初級,こ,国内総生産GDPが高い,High GDP.,-,kids
-119,国旗王,初級,せ,正式国名が短い,Short official country name.,-,kids
-120,国旗王,初級,め,面積が大きい,Large area.,-,kids
-121,国旗王,上級,へ,平均寿命が長い,Long average life expectancy.,-,kids
-122,国旗王,初級,ひ,一人当たりGDPが低い,Low GDP per capita.,-,kids
-123,国旗王,初級,し,人口密度が低い,Low population density.,-,kids
-124,国旗王,初級,せ,正式国名 五十音順 アに近い,Official name closest to 'A' in Japanese syllabary.,-,kids
-125,国旗王,初級,し,首都が最南,Southernmost capital.,-,kids
-126,おばけかるた,-,ふ,ふでこぞうが　ひとふでがき,Fudekozo draws with a single stroke.,ふでこぞう,kids
-127,おばけかるた,-,ね,ねこまたも　ねがおはかわいい,Even Nekomata looks cute when sleeping.,ねこまた,kids
-128,おばけかるた,-,ち,ちょうちんぶらり　こっちへ　くるぞ,Chochin-burari is coming this way!,ちょうちんぶらり,kids
-129,おばけかるた,-,た,たまごがわれて　てんぐがうまれた,An egg cracked and a Tengu was born.,てんぐ,kids
-130,おばけかるた,-,け,けむくじゃらな　うでだ　まけるな！,"It's a hairy arm, don't lose!",けむくじゃらなうで,kids
-131,おばけかるた,-,く,くずかごからくろいてが！！！　きゃっ！！！,A black hand from the wastebasket!!! Kya!!!,くろいて,kids
-132,おばけかるた,-,あ,あめふりこぞうが　びちゃびちゃあるく,Amefuri-kozo walks with a squish-squish.,あめふりこぞう,kids
-133,おばけかるた,-,ひ,ひとつめのくには　ひとつめだらけだってさ,They say the one-eyed country is full of one-eyes.,ひとつめ,kids
-134,おばけかるた,-,ぬ,ぬらりとわらう　ぬっぺっぽう,Nureppon smiles eerily.,ぬっぺっぽう,kids
-135,おばけかるた,-,つ,つきよにでていくつく　もがみ,Tsuku-mogami goes out on a moonlit night.,つくもがみ,kids
-136,おばけかるた,-,そ,そろってあるく　ぞうりのおばけ,Zori ghosts walk in pairs.,ぞうりのおばけ,kids
-137,おばけかるた,-,こ,こんばんは～　どろどろどろどろ～,Good evening~ Doro-doro-doro-doro~,ゆうれい,kids
-138,おばけかるた,-,き,きゅうびのきつねは　ばけるめいじん,The nine-tailed fox is a master of disguise.,きゅうびのきつね,kids
-139,おばけかるた,-,い,いったんもめんは　そらとべていいなあ,"Ittan-momen, it's nice to fly in the sky.",いったんもめん,kids
-140,おばけかるた,-,は,はたらけはたらけ　おばけもはたらけ,"Work, work, ghosts also work.",おばけ,kids
-141,おばけかるた,-,に,にっこりわらう　にかいのおんな,The woman on the second floor smiles.,にかいのおんな,kids
-142,おばけかるた,-,て,てんぐのはながおれては　かわいそう,It would be pitiful if Tengu's nose broke.,てんぐ,kids
-143,おばけかるた,-,せ,せんすだって　すてればばける,Even a fan will transform if you throw it away.,せんす,kids
-144,おばけかるた,-,さ,さかさくびは　ぺろぺろなめる,Sakasa-kubi licks with a flick-flick.,さかさくび,kids
-145,おばけかるた,-,か,かあさんかっぱ　とこどものかっぱ,Mother Kappa and baby Kappa.,かっぱ,kids
-146,おばけかるた,-,う,うみぼうずのがっこう　せいとをぼしゅう,Umibozu's school is recruiting students.,うみぼうず,kids
-147,おばけかるた,-,の,のんきなのぶすま　のんびりとんだ,Carefree Nobusuma flew leisurely.,のぶすま,kids
-148,おばけかるた,-,な,なきなきかえった　ちいさなゆうれい,A small ghost returned crying.,ちいさなゆうれい,kids
-149,おばけかるた,-,と,とらがねてたら　かみなりどしーん！！,"If a tiger sleeps, lightning strikes with a boom!!",かみなり,kids
-150,おばけかるた,-,す,すりばちこぞうは　なにすってるの？,What is Suribachi-kozo grinding?,すりばちこぞう,kids
-151,おばけかるた,-,し,しろくてみえない　ゆきのひのゆうれい,A white and invisible ghost on a snowy day.,ゆきのひのゆうれい,kids
-152,おばけかるた,-,お,おにもおじいさんになる,Even an ogre grows old.,おに,kids
-153,おばけかるた,-,え,えだをもやしたら　えんえんらがでたぞ,"When I burned a branch, Enenra came out!",えんえんら,kids
-154,おばけかるた,-,る,るすばんしてるは　ぶるぶるひとり,"Staying home alone, trembling.",ゆうれい,kids
-155,おばけかるた,-,り,りゅうがいねむり　そらからおちる,"A dragon sleeping, falling from the sky.",りゅう,kids
-156,おばけかるた,-,む,むじなもばけたが　ちょっとむりだった,"Mujina tried to transform, but it was a bit impossible.",むじな,kids
-157,おばけかるた,-,み,みこしにゅうどう　みかけよりよわい,"Mikoshi-Nyudo, weaker than he looks.",みこしにゅうどう,kids
-158,おばけかるた,-,れ,れいぎただしい　ゆうれいもいる,There are polite ghosts too.,ゆうれい,kids
-159,おばけかるた,-,ら,らしょうもんの　おにはらんぼうだ,The demon of Rashomon is wild.,らしょうもんのおに,kids
-160,おばけかるた,-,め,めだまをとられた　ひとつめこぞう,A one-eyed monster whose eye was taken.,ひとつめこぞう,kids
-161,おばけかるた,-,ま,まくらがえしは　まいばんうるさい,Makura-gaeshi is noisy every night.,まくらがえし,kids
-162,おばけかるた,-,ろ,ろくろくねなかった　ろくろっくび,Rokurokubi who didn't sleep at all.,ろくろっくび,kids
-163,おばけかるた,-,よ,よみちをこわがる　よわむしにゅうどう,A timid Nyudo who is scared of night roads.,よわむしにゅうどう,kids
-164,おばけかるた,-,も,もりんじのかまは　たぬきがばけた,Morinji's kettle was a transformed raccoon dog.,たぬき,kids
-165,おばけかるた,-,ほ,ほうきのおばけは　ほめてやろう,Let's praise the broom ghost.,ほうきのおばけ,kids
-166,おばけかるた,-,を,「あしをけして　てをまえに」ゆうれいのおけいこ,"Delete legs, hands forward - a ghost's practice.",ゆうれい,kids
-167,おばけかるた,-,わ,わ、にゅうどうだ　わぁーっこわい！,"Oh, it's a Nyudo! Ahh, scary!",にゅうどう,kids
-168,おばけかるた,-,ゆ,ゆきおんな　おゆにはいってとけちゃった,Yuki-onna went into hot water and melted.,ゆきおんな,kids
-169,おばけかるた,-,や,やなぎのしたで　ゆうれいけんか,Ghosts fighting under a willow tree.,ゆうれい,kids
-170,おばけかるた,-,へ,へびよりこわい　ろくろっくび,"Rokurokubi, scarier than a snake.",ろくろっくび,kids
-171,いろはかるた,-,ま,嘘から出たまこと,A lie can sometimes turn into the truth,でたらめに言ったことが、偶然にも事実になってしまうこと,kids
-172,いろはかるた,-,こ,弘法にも筆の誤り,Even experts make mistakes,どんな名人でも失敗することがあるというたとえ,kids
-173,いろはかるた,-,あ,得手に帆を揚げる,To take advantage of a good opportunity,物事を行うのに絶好の機会を得ること,kids
-174,いろはかるた,-,あ,味なもの縁は異なもの,Romance works in mysterious ways,男女の仲は理屈では説明できないものだということ,kids
-175,いろはかるた,-,ぞ,芋の煮えたも御存じない,Completely clueless,物事の様子がまったく分からない人をからかう言い方,kids
-176,いろはかるた,-,て,文はやりたし書く手は持たぬ,Wanting to write a letter but lacking the skill,やりたい気持ちはあるが能力が伴わず困っていること,kids
-177,いろはかるた,-,す,亭主の好きな赤烏帽子,One must go along with the head of the household,家長の好みには家族も従うべきだという考え,kids
-178,いろはかるた,-,し,知らぬが仏,Ignorance is bliss,知らなければ悩まずにすむこともあるということ,kids
-179,いろはかるた,-,は,背に腹はかえられぬ,Needs must when driven,大きな目的のためには多少の犠牲は仕方ないということ,kids
-180,いろはかるた,-,げ,芸は身を助ける,A skill will always help you,身につけた技や芸が困ったときに役立つこと,kids
-181,いろはかるた,-,の,喉元過ぎれば熱さを忘れる,"Once the pain is gone, the lesson is forgotten",苦しい経験をしても時間がたつと忘れてしまうこと,kids
-182,いろはかるた,-,あ,頭隠して尻隠さず,Trying to hide something but failing,一部しか隠していないのに全部隠したつもりでいること,kids
-183,いろはかるた,-,み,身から出た錆,You reap what you sow,自分のした悪い行いの結果で自分が苦しむこと,kids
-184,いろはかるた,-,も,門前の小僧習わぬ経を読む,You learn things naturally by exposure,日頃見聞きしているうちに自然と身につくことがある,kids
-185,いろはかるた,-,お,鬼に金棒,Adding strength to the strong,強いものがさらに力を得て一層強くなること,kids
-186,いろはかるた,-,ま,負けるが勝ち,Sometimes losing leads to winning,一歩引いた方が結果的に有利になることがある,kids
-187,いろはかるた,-,さ,三遍回って煙草にしょ,Take time and be careful,急がず慎重に行動することが大切だということ,kids
-188,いろはかるた,-,め,目の上のたん瘤,A thorn in one’s side,自分にとって邪魔で目障りな存在のたとえ,kids
-189,いろはかるた,-,ひ,貧乏暇なし,The poor have no leisure,貧しい人ほど仕事に追われ時間の余裕がないこと,kids
-190,いろはかるた,-,く,臭い物に蓋をする,To cover up an inconvenient truth,都合の悪いことを一時的に隠そうとすること,kids
-191,いろはかるた,-,や,安物買いの銭失い,Buying cheap ends up costing more,安い物を買うとかえって損をすること,kids
-192,いろはかるた,-,き,聞いて極楽見て地獄,Hearing and seeing are very different,聞くのと実際に見るのとでは大きな違いがあること,kids
-193,いろはかるた,-,ゆ,油断大敵,Carelessness is dangerous,油断すると失敗や災難を招くということ,kids
-194,いろはかるた,-,い,犬も歩けば棒に当たる,Every action brings some result,行動すれば良くも悪くも何かが起こるということ,kids
-195,いろはかるた,-,ら,楽あれば苦あり,Life has ups and downs,人生には楽しいことと苦しいことの両方がある,kids
-196,いろはかるた,-,む,無理が通れば道理が引っ込む,"When force prevails, reason disappears",無茶がまかり通る世の中では道理が通らなくなる,kids
-197,いろはかるた,-,と,年寄りの冷や水,An old person acting recklessly,年齢を考えず無理な振る舞いをすること,kids
-198,いろはかるた,-,す,粋は身を食う,Showing off can ruin you,気取った振る舞いが身を滅ぼすことがある,kids
-199,いろはかるた,-,き,京の夢大阪の夢,Dreams are fleeting and strange,夢というものはとりとめなく不思議なものだということ,kids
-200,いろはかるた,-,へ,下手の長談義,The unskilled talk the longest,下手な人ほど話が長くなること,kids
-201,いろはかるた,-,ろ,論より証拠,Proof is better than argument,理屈よりも実際の証拠が大切だということ,kids
-202,いろはかるた,-,く,くたびれ儲け,All effort and no reward,苦労したわりに何の得もないこと,kids
-203,いろはかるた,-,に,憎まれっ子世にはばかる,The disliked often survive well,憎まれるような人ほど世渡りがうまいこと,kids
-204,いろはかるた,-,ち,塵も積もれば山となる,Many small things add up,小さなことでも積み重なれば大きな成果になる,kids
-205,いろはかるた,-,こ,律義者の子だくさん,Honest people tend to have many children,律義な人は家庭を大切にし子どもが多くなるという考え,kids
-206,いろはかるた,-,ぬ,盗人の昼寝,Even bad acts have consequences,どんな行いにも必ず報いがあるということ,kids
-207,いろはかるた,-,は,花より団子,Practicality over appearance,見た目より実利を重んじること,kids
-208,いろはかるた,-,る,瑠璃も玻璃も照らせば光る,True talent shines anywhere,才能のある人はどんな環境でも力を発揮する,kids
-209,いろはかるた,-,な,泣きっ面に蜂,Misfortune never comes alone,不運なときにさらに不幸が重なること,kids
-210,いろはかるた,-,あ,葦の髄から天井のぞく,Judging the whole from a tiny part,わずかな知識で全て分かったつもりになること,kids
-211,いろはかるた,-,か,蛙の面に水,Completely unfazed,何をされても平然としていること,kids
-212,いろはかるた,-,わ,破れ鍋に綴じ蓋,Every pot has its lid,どんな人にもふさわしい相手がいるということ,kids
-213,いろはかるた,-,を,老いては子に従え,Let the younger generation lead,年を取ったら若い者の意見に従うのがよい,kids
-214,いろはかるた,-,ね,念には念を入れよ,Double-check everything,十分注意した上でさらに注意を重ねること,kids
-215,いろはかるた,-,た,旅は道連れ世は情け,Life is about helping each other,人は助け合って生きていくものだということ,kids
-216,いろはかるた,-,れ,良薬は口に苦し,Good medicine tastes bitter,忠告は耳に痛いが自分のためになる,kids
-217,いろはかるた,-,そ,総領の甚六,The eldest son is often naive,長男は大事に育てられ世間知らずになりがちだということ,kids
-218,いろはかるた,-,つ,月とすっぽん,Like night and day,似ているようで実際は大きな違いがある,kids
-219,いろはかるた（意味）,-,ま,でたらめに言ったことが、偶然にも事実になってしまうこと,A lie can sometimes turn into the truth,嘘から出たまこと,kids
-220,いろはかるた（意味）,-,こ,どんな名人でも失敗することがあるというたとえ,Even experts make mistakes,弘法にも筆の誤り,kids
-221,いろはかるた（意味）,-,あ,物事を行うのに絶好の機会を得ること,To take advantage of a good opportunity,得手に帆を揚げる,kids
-222,いろはかるた（意味）,-,あ,男女の仲は理屈では説明できないものだということ,Romance works in mysterious ways,味なもの縁は異なもの,kids
-223,いろはかるた（意味）,-,ぞ,物事の様子がまったく分からない人をからかう言い方,Completely clueless,芋の煮えたも御存じない,kids
-224,いろはかるた（意味）,-,て,やりたい気持ちはあるが能力が伴わず困っていること,Wanting to write a letter but lacking the skill,文はやりたし書く手は持たぬ,kids
-225,いろはかるた（意味）,-,す,家長の好みには家族も従うべきだという考え,One must go along with the head of the household,亭主の好きな赤烏帽子,kids
-226,いろはかるた（意味）,-,し,知らなければ悩まずにすむこともあるということ,Ignorance is bliss,知らぬが仏,kids
-227,いろはかるた（意味）,-,は,大きな目的のためには多少の犠牲は仕方ないということ,Needs must when driven,背に腹はかえられぬ,kids
-228,いろはかるた（意味）,-,げ,身につけた技や芸が困ったときに役立つこと,A skill will always help you,芸は身を助ける,kids
-229,いろはかるた（意味）,-,の,苦しい経験をしても時間がたつと忘れてしまうこと,"Once the pain is gone, the lesson is forgotten",喉元過ぎれば熱さを忘れる,kids
-230,いろはかるた（意味）,-,あ,一部しか隠していないのに全部隠したつもりでいること,Trying to hide something but failing,頭隠して尻隠さず,kids
-231,いろはかるた（意味）,-,み,自分のした悪い行いの結果で自分が苦しむこと,You reap what you sow,身から出た錆,kids
-232,いろはかるた（意味）,-,も,日頃見聞きしているうちに自然と身につくことがある,You learn things naturally by exposure,門前の小僧習わぬ経を読む,kids
-233,いろはかるた（意味）,-,お,強いものがさらに力を得て一層強くなること,Adding strength to the strong,鬼に金棒,kids
-234,いろはかるた（意味）,-,ま,一歩引いた方が結果的に有利になることがある,Sometimes losing leads to winning,負けるが勝ち,kids
-235,いろはかるた（意味）,-,さ,急がず慎重に行動することが大切だということ,Take time and be careful,三遍回って煙草にしょ,kids
-236,いろはかるた（意味）,-,め,自分にとって邪魔で目障りな存在のたとえ,A thorn in one’s side,目の上のたん瘤,kids
-237,いろはかるた（意味）,-,ひ,貧しい人ほど仕事に追われ時間の余裕がないこと,The poor have no leisure,貧乏暇なし,kids
-238,いろはかるた（意味）,-,く,都合の悪いことを一時的に隠そうとすること,To cover up an inconvenient truth,臭い物に蓋をする,kids
-239,いろはかるた（意味）,-,や,安い物を買うとかえって損をすること,Buying cheap ends up costing more,安物買いの銭失い,kids
-240,いろはかるた（意味）,-,き,聞くのと実際に見るのとでは大きな違いがあること,Hearing and seeing are very different,聞いて極楽見て地獄,kids
-241,いろはかるた（意味）,-,ゆ,油断すると失敗や災難を招くということ,Carelessness is dangerous,油断大敵,kids
-242,いろはかるた（意味）,-,い,行動すれば良くも悪くも何かが起こるということ,Every action brings some result,犬も歩けば棒に当たる,kids
-243,いろはかるた（意味）,-,ら,人生には楽しいことと苦しいことの両方がある,Life has ups and downs,楽あれば苦あり,kids
-244,いろはかるた（意味）,-,む,無茶がまかり通る世の中では道理が通らなくなる,"When force prevails, reason disappears",無理が通れば道理が引っ込む,kids
-245,いろはかるた（意味）,-,と,年齢を考えず無理な振る舞いをすること,An old person acting recklessly,年寄りの冷や水,kids
-246,いろはかるた（意味）,-,す,気取った振る舞いが身を滅ぼすことがある,Showing off can ruin you,粋は身を食う,kids
-247,いろはかるた（意味）,-,き,夢というものはとりとめなく不思議なものだということ,Dreams are fleeting and strange,京の夢大阪の夢,kids
-248,いろはかるた（意味）,-,へ,下手な人ほど話が長くなること,The unskilled talk the longest,下手の長談義,kids
-249,いろはかるた（意味）,-,ろ,理屈よりも実際の証拠が大切だということ,Proof is better than argument,論より証拠,kids
-250,いろはかるた（意味）,-,く,苦労したわりに何の得もないこと,All effort and no reward,くたびれ儲け,kids
-251,いろはかるた（意味）,-,に,憎まれるような人ほど世渡りがうまいこと,The disliked often survive well,憎まれっ子世にはばかる,kids
-252,いろはかるた（意味）,-,ち,小さなことでも積み重なれば大きな成果になる,Many small things add up,塵も積もれば山となる,kids
-253,いろはかるた（意味）,-,こ,律義な人は家庭を大切にし子どもが多くなるという考え,Honest people tend to have many children,律義者の子だくさん,kids
-254,いろはかるた（意味）,-,ぬ,どんな行いにも必ず報いがあるということ,Even bad acts have consequences,盗人の昼寝,kids
-255,いろはかるた（意味）,-,は,見た目より実利を重んじること,Practicality over appearance,花より団子,kids
-256,いろはかるた（意味）,-,る,才能のある人はどんな環境でも力を発揮する,True talent shines anywhere,瑠璃も玻璃も照らせば光る,kids
-257,いろはかるた（意味）,-,な,不運なときにさらに不幸が重なること,Misfortune never comes alone,泣きっ面に蜂,kids
-258,いろはかるた（意味）,-,あ,わずかな知識で全て分かったつもりになること,Judging the whole from a tiny part,葦の髄から天井のぞく,kids
-259,いろはかるた（意味）,-,か,何をされても平然としていること,Completely unfazed,蛙の面に水,kids
-260,いろはかるた（意味）,-,わ,どんな人にもふさわしい相手がいるということ,Every pot has its lid,破れ鍋に綴じ蓋,kids
-261,いろはかるた（意味）,-,を,年を取ったら若い者の意見に従うのがよい,Let the younger generation lead,老いては子に従え,kids
-262,いろはかるた（意味）,-,ね,十分注意した上でさらに注意を重ねること,Double-check everything,念には念を入れよ,kids
-263,いろはかるた（意味）,-,た,人は助け合って生きていくものだということ,Life is about helping each other,旅は道連れ世は情け,kids
-264,いろはかるた（意味）,-,れ,忠告は耳に痛いが自分のためになる,Good medicine tastes bitter,良薬は口に苦し,kids
-265,いろはかるた（意味）,-,そ,長男は大事に育てられ世間知らずになりがちだということ,The eldest son is often naive,総領の甚六,kids
-266,いろはかるた（意味）,-,つ,似ているようで実際は大きな違いがある,Like night and day,月とすっぽん,kids
-267,百人一首,-,あ,あきのたの かりほのいおの とまをあらみ わがころもでは つゆにぬれつつ,"In the autumn field, in the temporary hut's rough rush-mats, my sleeves are getting wet with dew.",わがころもでは つゆにぬれつつ,kids
-268,百人一首,-,あ,あきかぜに たなびくくもの たえまより もれいづるつきの かげのさやけさ,"Through the rifts in the clouds trailing in the autumn wind, how clear the moonlight leaks out.",もれいづるつきの かげのさやけさ,kids
-269,百人一首,-,あ,あしびきの やまどりのをの しだりをの ながながしよを ひとりかもねむ,"Must I sleep alone through the long, long night, like the long, trailing tail of the mountain pheasant?",ながながしよを ひとりかもねむ,kids
-270,百人一首,-,あ,あまのはら ふりさけみれば かすがなる みかさのやまに いでしつきかも,"When I look out over the plain of heaven, is that the same moon that rose over Mount Mikasa in Kasuga?",みかさのやまに いでしつきかも,kids
-271,百人一首,-,あ,あわれとも いうべきひとは おもほえで みのいたずらに なりぬべきかな,"Since there is no one who might feel pity for me, I suppose I shall just pass away in vain.",みのいたずらに なりぬべきかな,kids
-272,百人一首,-,い,いまはただ おもひたえなむ とばかりを ひとづてならで いうよしもがな,Now I just want to give up my love; if only I could tell you this directly and not through others.,ひとづてならで いうよしもがな,kids
-273,百人一首,-,い,いまこむと いいしばかりに ながつきの ありあけのつきを まちいでつるかな,"Just because you said 'I'll come soon', I have waited until the morning moon of the long month appeared.",ありあけのつきを まちいでつるかな,kids
-274,百人一首,-,い,いろはにほへど ちりぬるを わがよたれぞ つねならむ,"Though flowers are fragrant, they will fall; in our world, who can remain forever?",わがよたれぞ つねならむ,kids
-275,百人一首,-,い,いのちながくは かたみにあはず ひとりして ものおもふよぞ ながかりける,"If I live long, we might not meet again; the night I spend alone in thought is so very long.",ものおもふよぞ ながかりける,kids
-276,百人一首,-,い,いにしへの ならのみやこの やへざくら けふここのへに にほひぬるかな,The eight-layered cherry blossoms of the ancient capital of Nara are fragrantly blooming today in the imperial palace.,けふここのへに にほひぬるかな,kids
-277,百人一首,-,う,うかりける ひとをはつせの やまおろしよ はげしかれとは いのらぬものを,"O mountain wind of Hatsuse, I did not pray for you to be so harsh, though she is cold to me.",はげしかれとは いのらぬものを,kids
-278,百人一首,-,う,うらみわび ほさぬそでだに あるものを こひにくちなむ なこそをしけれ,"I resent her and am weary; my sleeves never dry, and I fear my reputation will rot away in this love.",こひにくちなむ なこそをしけれ,kids
-279,百人一首,-,え,えにしあらば あはむとぞおもふ いざさらば わがなとひとは わすれざらなむ,"If there is fate, I believe we shall meet; now farewell, and may you not forget my name.",わがなとひとは わすれざらなむ,kids
-280,百人一首,-,お,おおえやま いくののみちの とおければ まだふみもみず あまのはしだて,The road to Ikuno over Mount Oe is so far that I have seen neither a letter nor Amanohashidate.,まだふみもみず あまのはしだて,kids
-281,百人一首,-,お,おくやまに もみぢふみわけ なくしかの こゑきくときぞ あきはかなしき,"When I hear the voice of the stag crying as he steps through the maple leaves deep in the mountains, autumn is truly sad.",こゑきくときぞ あきはかなしき,kids
-282,百人一首,-,か,かささぎの わたせるはしに おくしもの しろきをみれば よぞふけにける,"When I see the white frost on the bridge the magpies are said to have spread, I know the night has deepened.",しろきをみれば よぞふけにける,kids
-283,百人一首,-,か,かぜをいたみ いはうつなみの おのれのみ くだけてものを おもふころかな,"Like the waves breaking against the rocks in the fierce wind, I alone am broken as I think of my love.",くだけてものを おもふころかな,kids
-284,百人一首,-,き,きみがため はるののにいでて わかなつむ わがころもでに ゆきはふりつつ,"For your sake, I went out to the spring fields to pick young greens, while snow fell on my sleeves.",わがころもでに ゆきはふりつつ,kids
-285,百人一首,-,き,きみがため をしからざりし いのちさへ ながくもがなと おもひけるかな,"For your sake, I did not value my life, but now I wish it would be long.",ながくもがなと おもひけるかな,kids
-286,百人一首,-,く,くさもきも いろかはれども わたつみの なみのはなにぞ あきなかりける,"Though the colors of plants and trees change, there is no autumn in the flowers of the sea waves.",なみのはなにぞ あきなかりける,kids
-287,百人一首,-,く,くれなゐに みづくくるとは ききしかど あきぞこのはに まじりけるかな,"I heard that the water is dyed crimson, but it seems autumn has mixed into the leaves.",あきぞこのはに まじりけるかな,kids
-288,百人一首,-,こ,こころあてに をらばやをらむ はつしもの おきまどはせる しらぎくのはな,"If I were to pick them at random, I might pick the white chrysanthemums that the first frost has confused.",おきまどはせる しらぎくのはな,kids
-289,百人一首,-,こ,このたびは ぬさもとりあへず たむけやま もみぢのにしき かみのまにまに,"At this time, I could not even bring an offering; let the gods take the brocade of maple leaves on Mount Tamuke.",もみぢのにしき かみのまにまに,kids
-290,百人一首,-,さ,さびしさに やどをたちいでて ながむれば いづこもおなじ あきのゆふぐれ,"In my loneliness, I leave my house and look out; everywhere it is the same autumn evening.",いづこもおなじ あきのゆふぐれ,kids
-291,百人一首,-,し,しのぶれど いろにいでにけり わがこひは ものやおもふと ひとのとふまで,"Though I try to hide it, my love shows in my face, until people ask if I am lost in thought.",ものやおもふと ひとのとふまで,kids
-292,百人一首,-,す,すみのえの きしによるなみ よるさへや ゆめのかよひぢ ひとめよくらむ,"Like the waves approaching the shore of Suminoe, even at night do you avoid people's eyes on the dream path?",ゆめのかよひぢ ひとめよくらむ,kids
-293,百人一首,-,せ,せをはやみ いはにせかるる たきがはの われてもすゑに あはむとぞおもふ,"Like the river current split by a rock in the rapids, though divided, I know we shall meet in the end.",われてもすゑに あはむとぞおもふ,kids
-294,百人一首,-,そ,そらしらぬ ゆきふみわけて いでつるは ひとつのえだに つるをたづねて,"I went out treading through the snow I didn't know, seeking a vine on a single branch.",ひとつのえだに つるをたづねて,kids
-295,百人一首,-,た,たごのうらに うちいでてみれば しろたへの ふじのたかねに ゆきはふりつつ,"When I go out to the shore of Tago and look, snow is falling on the white peak of Mount Fuji.",ふじのたかねに ゆきはふりつつ,kids
-296,百人一首,-,ち,ちはやぶる かみよもきかず たつたがは からくれなゐに みづくくるとは,"Never heard of even in the age of the mighty gods, that the Tatsuta River is dyed in deep crimson.",からくれなゐに みづくくるとは,kids
-297,百人一首,-,つ,つくばねの みねよりおつる みなのがは こひぞつもりて ふちとなりぬる,"Like the Minano River falling from the peak of Tsukubane, my love has accumulated and become a deep pool.",こひぞつもりて ふちとなりぬる,kids
-298,百人一首,-,て,てふことも いまはむかしに なりぬれば たがためにかは なにかうらみむ,"Since even that has become a thing of the past, for whose sake should I hold any resentment?",たがためにかは なにかうらみむ,kids
-299,百人一首,-,と,ともしびを かきたつるまも なつかしき いづれのよひに みえぬまにまに,"Even while trimming the lamp, I miss you; on which evening did I not see you?",いづれのよひに みえぬまにまに,kids
-300,百人一首,-,な,ながからむ こころもしらず くろかみの みだれてけさは ものをこそおもへ,"Uncertain of how long his heart will stay,my black hair lies in disarray this morning and so, I am lost in troubled thoughts.",みだれてけさは ものをこそおもへ,kids
-301,百人一首,-,に,にしきなる ふくろにいれて いはざかり いづれのやまを こえぬとぞおもふ,I put it in a brocade bag; I wonder which mountain it crossed in its peak of silence.,いづれのやまを こえぬとぞおもふ,kids
-302,百人一首,-,ぬ,ぬさもとりあへず たむけやま もみぢのにしき かみのまにまに,I could not even bring an offering; let the gods take the brocade of maple leaves on Mount Tamuke.,もみぢのにしき かみのまにまに,kids
-303,百人一首,-,ね,ねがはくは はなのしたにて はるしなむ そのきさらぎの もちづきのころ,"My wish is to die in spring under the flowers, around the time of the full moon in the second month.",そのきさらぎの もちづきのころ,kids
-304,百人一首,-,の,のちのよを おもへばかろし ほととぎす あかつきかけて なきつるものを,"Thinking of the afterlife makes it seem light, while the cuckoo cries toward the dawn.",あかつきかけて なきつるものを,kids
-305,百人一首,-,は,はるすぎて なつきにけらし しろたへの ころもほすてふ あまのかぐやま,Spring has passed and summer seems to have come; white robes are said to be dried on the heavenly Mount Kagu.,ころもほすてふ あまのかぐやま,kids
-306,百人一首,-,ひ,ひさかたの ひかりのどけき はるのひに しづこころなく はなのちるらむ,"On this spring day when the light is so calm, why do the cherry blossoms scatter with such unquiet hearts?",しづこころなく はなのちるらむ,kids
-307,百人一首,-,ふ,ふくからに あきのくさきの しをるれば むべやまかぜを あらしといふらむ,"Since the autumn plants and trees wither as soon as it blows, it is no wonder the mountain wind is called a storm.",むべやまかぜを あらしといふらむ,kids
-308,百人一首,-,へ,へにける いくよをかさね たまづさの ふみをひらけば こひぞつもりぬる,"As I open the letter after many passing nights, my love has truly accumulated.",ふみをひらけば こひぞつもりぬる,kids
-309,百人一首,-,ほ,ほととぎす なきつるかたを ながむれば ただありあけの つきぞのこれる,"When I look toward where the cuckoo cried, only the morning moon remains.",ただありあけの つきぞのこれる,kids
-310,百人一首,-,ま,まつとしき たかしのはまの あまごろも ぬれにぞぬれし いろはかはらず,"Waiting on the beach of Takashi, the fisher's robe got soaked and soaked, but its color remained unchanged.",ぬれにぞぬれし いろはかはらず,kids
-311,百人一首,-,み,みかのはら わきてながるる いづみがは いつみきとてか こひしかるらむ,"Like the Izumi River flowing through the plain of Mika, when did I see you that I should love you so?",いつみきとてか こひしかるらむ,kids
-312,百人一首,-,む,むらさめの つゆもまだひぬ まきのはに きりたちのぼる あきのゆふぐれ,"Before the dew of the passing shower has dried on the fir leaves, the mist rises on an autumn evening.",きりたちのぼる あきのゆふぐれ,kids
-313,百人一首,-,め,めぐりあひて みしやそれとも わかぬまに くもがくれにし よはのつきかな,"Meeting by chance, before I could even tell if it was you, you were hidden by clouds like the midnight moon.",くもがくれにし よはのつきかな,kids
-314,百人一首,-,も,ももしきや ふるきのきばの しのぶにも なほあまりある むかしなりけり,"In the palace, even the ferns on the old eaves make me yearn for the past more than I can bear.",なほあまりある むかしなりけり,kids
-315,百人一首,-,や,やすらはで ねなましものを さよふけて かたぶくまでの つきをみしかな,I should have gone to sleep without waiting; I watched the moon until it began to sink late at night.,かたぶくまでの つきをみしかな,kids
-316,百人一首,-,ゆ,ゆらのとを わたるふなびと かぢをたえ ゆくへもしらぬ こひのみちかな,"Like a mariner crossing the Yura Strait with a lost oar, I know not where the path of my love leads.",ゆくへもしらぬ こひのみちかな,kids
-317,百人一首,-,よ,よをこめて とりのそらねは はかるとも よにあふさかの せきはゆるさじ,"Though you try to deceive with a bird's false cry in the dead of night, the gate of Osaka shall not let you pass.",よにあふさかの せきはゆるさじ,kids
-318,百人一首,-,ら,らいしやうの いのちのはてを しらぬまに けふをかぎりと おもひけるかな,"Not knowing the end of my life in the next world, I thought today would be the limit.",けふをかぎりと おもひけるかな,kids
-319,百人一首,-,り,りくかぜの さむきにたへて みちのくの しのぶもぢずり たれゆゑにけむ,"Enduring the cold land wind, for whose sake was the tangled print of Michinoku's Shinobu?",しのぶもぢずり たれゆゑにけむ,kids
-320,百人一首,-,る,るりのつぼ いづれのひとも すむらむと こころをかけし いろはみえず,"In the lapis lazuli jar where everyone might live, I cannot see the colors I set my heart on.",こころをかけし いろはみえず,kids
-321,百人一首,-,れ,れいよりも こころをつくせ さくらばな ちりぬるのちも にほひをこそ,"Exert your heart more than usual, cherry blossoms; even after you fall, leave your fragrance.",ちりぬるのちも にほひをこそ,kids
-322,百人一首,-,ろ,ろばたにて こまをつなぎて みるほどに はなぞちりける さくらかな,"While tethering my horse by the roadside, the cherry blossoms were scattering.",はなぞちりける さくらかな,kids
-323,百人一首,-,わ,わたのはら やそしまかけて こぎいでぬと ひとにはつげよ あまのつりぶね,"Tell the people that I have rowed out over the wide sea toward the many islands, O fisher's boat.",ひとにはつげよ あまのつりぶね,kids
-324,百人一首,-,を,をぐらやま みねのもみぢば こころあらば いまひとたびの みゆきまたなむ,"O maple leaves on the peak of Mount Ogura, if you have a heart, wait for one more imperial visit.",いまひとたびの みゆきまたなむ,kids
-325,百人一首,-,ん,んにゃくにしゅう つねのことばを うたにして こころをつたふ みちぞたふとき,"Turning ordinary words into songs to convey the heart, the path is truly noble.",こころをつたふ みちぞたふとき,kids
-326,大ピンチずかん,92,た,たからものいれが　あかない,I can't open treasure box.,-,kids
-327,大ピンチずかん,1,が,がむを　のんだ,I swallowed gum.,-,kids
-400,しょうがっこうかるた,-,あ,あさきたら あいさつしよう げんきよく,"When morning comes, greet cheerfully.",-,kids
-401,しょうがっこうかるた,-,い,いねむりは たいちょうくずす はじまりだ,Dozing off is the start of feeling unwell.,-,kids
-402,しょうがっこうかるた,-,う,うんどうで からだをきたえ よくねよう,Exercise your body and sleep well.,-,kids
-403,しょうがっこうかるた,-,え,えがおでね すごせばみんな うれしいよ,"If you spend time smiling, everyone is happy.",-,kids
-404,しょうがっこうかるた,-,お,おはようと げんきなこえで あいさつだ,Say good morning with a cheerful voice.,-,kids
-405,しょうがっこうかるた,-,か,かさをさし あめのひだって たのしいよ,Even rainy days can be fun with an umbrella.,-,kids
-406,しょうがっこうかるた,-,き,きちんとね つかったあとは かたづけよう,"After using things, tidy them properly.",-,kids
-407,しょうがっこうかるた,-,く,くつぬいで そろえておけば きもちいい,Take off and line up your shoes neatly.,-,kids
-408,しょうがっこうかるた,-,け,けいさんは あせらずゆっくり かくにんだ,Do calculations calmly and check carefully.,-,kids
-409,しょうがっこうかるた,-,こ,こころには あんぜんまもる やくそくだ,Keep safety rules in your heart.,-,kids
-410,しょうがっこうかるた,-,さ,さくらさく にゅうがくきせつ はるがきた,Cherry blossoms bloom—spring and school begin.,-,kids
-411,しょうがっこうかるた,-,し,しゃべらずに どうろをあるこう あぶないよ,Walk quietly on roads—it’s dangerous otherwise.,-,kids
-412,しょうがっこうかるた,-,す,すきなもの ちゃんとえらんで たいせつに,Choose what you like and value it.,-,kids
-413,しょうがっこうかるた,-,せ,せいりして つかえばいつも きもちいい,Keep things organized and feel good.,-,kids
-414,しょうがっこうかるた,-,そ,そうじして みんなできれいに しようね,Let’s all clean and make it neat.,-,kids
-415,しょうがっこうかるた,-,た,たのしいね みんなであそぶと えがおさく,Playing together brings smiles.,-,kids
-416,しょうがっこうかるた,-,ち,ちいさくても ルールまもれば りっぱだよ,Even small acts matter if you follow rules.,-,kids
-417,しょうがっこうかるた,-,つ,つかうもの たいせつにして ながくつかう,Take care of things and use them long.,-,kids
-418,しょうがっこうかるた,-,て,てをあらい きれいにすれば びょうきよぼう,Wash your hands to prevent illness.,-,kids
-419,しょうがっこうかるた,-,と,ともだちと なかよくすごす がっこうだ,School is for getting along with friends.,-,kids
-420,しょうがっこうかるた,-,な,なかよくね けんかしないで すごそうよ,Let’s get along without fighting.,-,kids
-421,しょうがっこうかるた,-,に,にこにこと えがおであいさつ きもちいい,Smiling greetings feel good.,-,kids
-422,しょうがっこうかるた,-,ぬ,ぬいだくつ そろえておけば きれいだね,Neatly arranged shoes look nice.,-,kids
-423,しょうがっこうかるた,-,ね,ねるまえに あしたのじゅんび しておこう,Prepare for tomorrow before sleeping.,-,kids
-424,しょうがっこうかるた,-,の,のこさずに きゅうしょくたべて げんきだよ,Eat your lunch fully to stay healthy.,-,kids
-425,しょうがっこうかるた,-,は,はやおきで こころもからだも げんきだよ,Waking early keeps you healthy.,-,kids
-426,しょうがっこうかるた,-,ひ,ひとりでも できることから がんばろう,"Do what you can, even alone.",-,kids
-427,しょうがっこうかるた,-,ふ,ふざけずに じゅぎょううけよう しっかりと,Take class seriously without fooling around.,-,kids
-428,しょうがっこうかるた,-,へ,へやのなか きれいにすれば きもちいい,A clean room feels nice.,-,kids
-429,しょうがっこうかるた,-,ほ,ほんをよみ こころをそだて かしこくね,Read books to grow your mind.,-,kids
-430,しょうがっこうかるた,-,ま,まいにちを たいせつにして すごそうね,Cherish each day.,-,kids
-431,しょうがっこうかるた,-,み,みんなでね ちからをあわせ がんばろう,Let’s work together.,-,kids
-432,しょうがっこうかるた,-,む,むりしない じぶんのペースで すすもうね,Go at your own pace.,-,kids
-433,しょうがっこうかるた,-,め,めあてもち がくしゅうすれば ちからつく,Study with goals to improve.,-,kids
-434,しょうがっこうかるた,-,も,ものはね たいせつにして つかおうね,Take care of your belongings.,-,kids
-435,しょうがっこうかるた,-,や,やくそくを まもればみんな しんらいだ,Keeping promises builds trust.,-,kids
-436,しょうがっこうかるた,-,ゆ,ゆっくりと あせらずいこう だいじょうぶ,"Take it slow, no need to rush.",-,kids
-437,しょうがっこうかるた,-,よ,よるふかし しないでねむろう はやめにね,"Don’t stay up late, sleep early.",-,kids
-438,しょうがっこうかるた,-,ら,らくがきは してはいけない たいせつに,Don’t scribble—respect things.,-,kids
-439,しょうがっこうかるた,-,り,りゆうある こうどうすれば せいちょうだ,Act with purpose to grow.,-,kids
-440,しょうがっこうかるた,-,る,ルールまもり みんながたのしく すごせるよ,Follow rules so everyone enjoys.,-,kids
-441,しょうがっこうかるた,-,れ,れいぎよく あいさつできる いいこだね,Polite greetings are great.,-,kids
-442,しょうがっこうかるた,-,ろ,ろうかでは はしらずあるこう あんぜんに,Walk in hallways safely.,-,kids
-443,しょうがっこうかるた,-,わ,わすれもの しないようにね かくにんだ,Check so you don’t forget things.,-,kids
-444,しょうがっこうかるた,-,し,しゅくだいを きちんとやろう わすれずに,Do your homework properly without forgetting.,-,kids
-445,しょうがっこうかるた,-,さ,さんかんび パパやママは みてるかな,"On open school day, I wonder if mom and dad are watching.",-,kids
-1001,HTTP大ピンチ,10,2,祈るように送ったリクエストがちゃんと成功で返ってきた,"I sent the request nervously, and it actually succeeded.",200 OK,engineer
-1002,HTTP大ピンチ,15,2,新規登録ボタンを押したらきちんと新しいデータが生まれた,"I clicked the register button, and a brand-new record was created.",201 Created,engineer
-1003,HTTP大ピンチ,20,2,削除ボタンを押したら成功なのに画面には何も表示されない,"I clicked delete, and it succeeded but nothing came back.",204 No Content,engineer
-1004,HTTP大ピンチ,21,3,昔のURLを開いたらもう新しい住所に引っ越していた,"I opened the old URL, and it had permanently moved house.",301 Moved Permanently,engineer
-1005,HTTP大ピンチ,25,3,ログイン後だけいつも知らないページに飛ばされる,"Only after logging in, I always get redirected elsewhere, but only for now.",302 Found,engineer
-1006,HTTP大ピンチ,26,3,更新したつもりがキャッシュのままだと言われた,"I tried to refresh it, but I was told nothing had changed since last time.",304 Not Modified,engineer
-1007,HTTP大ピンチ,16,4,送ったデータの形がそもそも変だったらしい,Apparently the data I sent was malformed from the start.,400 Bad Request,engineer
-1008,HTTP大ピンチ,17,4,ログインすらしていないのに画面を見ようとした,I tried to view the page without even logging in.,401 Unauthorized,engineer
-1009,HTTP大ピンチ,22,4,ログインはできたのにその先には入れてもらえない,"I was logged in, but still not allowed past this point.",403 Forbidden,engineer
-1010,HTTP大ピンチ,11,4,そのページはもうどこにも存在しないらしい,Apparently that page doesn't exist anywhere.,404 Not Found,engineer
-1011,HTTP大ピンチ,27,4,GETでアクセスしたらここはPOST専用だと言われた,"I accessed it with GET, but apparently only POST is allowed here.",405 Method Not Allowed,engineer
-1012,HTTP大ピンチ,28,4,返事を待ち続けたけど間に合わなかった,"I kept waiting for a reply, but it never came in time.",408 Request Timeout,engineer
-1013,HTTP大ピンチ,31,4,同時に更新したらお互いの内容がぶつかった,"Two updates happened at once, and they collided.",409 Conflict,engineer
-1014,HTTP大ピンチ,32,4,前はたしかにあったのにもう永遠に戻ってこないらしい,"It definitely used to be here, but now it's gone for good.",410 Gone,engineer
-1015,HTTP大ピンチ,29,4,大きすぎる画像を送ったら受け取ってもらえなかった,"I tried sending too large a file, and it got rejected.",413 Payload Too Large,engineer
-1016,HTTP大ピンチ,30,4,送ったファイルの形式がそもそも対応していないらしい,The file format I sent apparently isn't supported at all.,415 Unsupported Media Type,engineer
-1017,HTTP大ピンチ,33,4,形式は合っているのに内容がおかしいと突き返された,"The format was fine, but the content itself got rejected.",422 Unprocessable Entity,engineer
-1018,HTTP大ピンチ,36,4,焦って何度も送ったらしばらく待つよう言われた,I sent too many requests in a panic and got told to slow down.,429 Too Many Requests,engineer
-1019,HTTP大ピンチ,18,5,サーバーの中でなにか予想外のことが起きたらしい,Something unexpected happened deep inside the server.,500 Internal Server Error,engineer
-1020,HTTP大ピンチ,34,5,そんな機能はサーバーがそもそも知らないと言われた,The server said it has no idea what that feature even is.,501 Not Implemented,engineer
-1021,HTTP大ピンチ,37,5,問い合わせた先のサーバーからおかしな返事が来た,The upstream server sent back a broken reply.,502 Bad Gateway,engineer
-1022,HTTP大ピンチ,35,5,今だけサーバーが対応できないと断られた,The server said it just can't handle anything right now.,503 Service Unavailable,engineer
-1023,HTTP大ピンチ,38,5,問い合わせた先からの返事がいつまでも来なかった,The upstream server never replied in time.,504 Gateway Timeout,engineer
-1101,Linuxコマンドかるた,-,L,ディレクトリ一覧を表示する,Display a list of directory contents.,ls,engineer
-1102,Linuxコマンドかるた,-,P,現在のディレクトリを表示する,Display the current directory.,pwd,engineer
-1103,Linuxコマンドかるた,-,C,ディレクトリを移動する,Change the current directory.,cd,engineer
-1104,Linuxコマンドかるた,-,M,新しいディレクトリを作成する,Create a new directory.,mkdir,engineer
-1105,Linuxコマンドかるた,-,R,空のディレクトリを削除する,Remove an empty directory.,rmdir,engineer
-1106,Linuxコマンドかるた,-,R,ファイルを削除する,Delete a file.,rm,engineer
-1107,Linuxコマンドかるた,-,C,ファイルをコピーする,Copy a file.,cp,engineer
-1108,Linuxコマンドかるた,-,M,ファイルを移動する、または名前を変更する,Move or rename a file.,mv,engineer
-1109,Linuxコマンドかるた,-,T,空のファイルを作成する、タイムスタンプを更新する,Create an empty file or update its timestamp.,touch,engineer
-1110,Linuxコマンドかるた,-,C,ファイルの内容を表示する,Display the contents of a file.,cat,engineer
-1111,Linuxコマンドかるた,-,F,ファイルを検索する,Search for files.,find,engineer
-1112,Linuxコマンドかるた,-,G,ファイルの中から文字列を検索する,Search for a string within files.,grep,engineer
-1113,Linuxコマンドかるた,-,C,ファイルの権限を変更する,Change file permissions.,chmod,engineer
-1114,Linuxコマンドかるた,-,C,ファイルの所有者を変更する,Change file ownership.,chown,engineer
-1115,Linuxコマンドかるた,-,P,実行中のプロセスを表示する,Display running processes.,ps,engineer
-1116,Linuxコマンドかるた,-,K,プロセスを終了させる,Terminate a process.,kill,engineer
-1117,Linuxコマンドかるた,-,T,システムのリソース使用状況をリアルタイムで表示する,Display real-time system resource usage.,top,engineer
-1118,Linuxコマンドかるた,-,D,ディスクの空き容量を表示する,Display free disk space.,df,engineer
-1119,Linuxコマンドかるた,-,D,ファイルやディレクトリのサイズを表示する,Display the size of files or directories.,du,engineer
-1120,Linuxコマンドかるた,-,T,複数のファイルをひとつにまとめて圧縮・展開する,Archive or extract multiple files.,tar,engineer
-1121,Linuxコマンドかるた,-,S,別のサーバーにリモートでログインする,Log in to a remote server.,ssh,engineer
-1122,Linuxコマンドかるた,-,S,サーバー間でファイルを安全にコピーする,Securely copy files between servers.,scp,engineer
-1123,Linuxコマンドかるた,-,C,URLを指定してデータを送受信する,Transfer data to or from a URL.,curl,engineer
-1124,Linuxコマンドかるた,-,W,URLからファイルをダウンロードする,Download a file from a URL.,wget,engineer
-1125,Linuxコマンドかるた,-,M,コマンドの使い方を調べる,Look up how to use a command.,man,engineer
-1126,Linuxコマンドかるた,-,H,これまでに実行したコマンドの履歴を表示する,Display the history of executed commands.,history,engineer
-1127,Linuxコマンドかるた,-,E,文字列を画面に出力する,Print a string to the screen.,echo,engineer
-1128,Linuxコマンドかるた,-,L,ファイルの内容をスクロールしながら表示する,View a file's contents one screen at a time.,less,engineer
-1129,Linuxコマンドかるた,-,H,ファイルの先頭部分を表示する,Display the beginning of a file.,head,engineer
-1130,Linuxコマンドかるた,-,T,ファイルの末尾部分を表示する,Display the end of a file.,tail,engineer
-1131,Linuxコマンドかるた,-,S,行を並び替える,Sort lines of text.,sort,engineer
-1132,Linuxコマンドかるた,-,U,重複する行を取り除く,Remove duplicate adjacent lines.,uniq,engineer
-1133,Linuxコマンドかるた,-,W,行数や単語数、文字数を数える,"Count lines, words, and characters.",wc,engineer
-1134,Linuxコマンドかるた,-,L,ファイルのリンクを作成する,Create a link to a file.,ln,engineer
-1135,Linuxコマンドかるた,-,A,コマンドに別名をつける,Define a shortcut name for a command.,alias,engineer
-1136,Linuxコマンドかるた,-,E,環境変数を設定する,Set an environment variable.,export,engineer
-1137,Linuxコマンドかるた,-,S,管理者権限でコマンドを実行する,Run a command with administrator privileges.,sudo,engineer
-1138,Linuxコマンドかるた,-,W,コマンドの実行ファイルの場所を調べる,Find the location of a command's executable.,which,engineer
-1139,Linuxコマンドかるた,-,W,現在ログインしているユーザー名を表示する,Display the current logged-in user name.,whoami,engineer
-1140,Linuxコマンドかるた,-,H,コンピュータのホスト名を表示する,Display the computer's host name.,hostname,engineer
-1201,Git大ピンチ,10,I,「まずpushして」と言われたけどGitを始めてもいなかった,You were told to push before initializing Git.,git init,engineer
-1202,Git大ピンチ,11,C,URLだけ渡されて「触っといて」と言われた,You only received a repository URL.,git clone,engineer
-1203,Git大ピンチ,12,S,コミットしたつもりが「nothing to commit」だった,"You thought you committed, but nothing happened.",git status → git add → git commit,engineer
-1204,Git大ピンチ,15,D,レビューで「何を変更したの？」と聞かれ固まった,Someone asked what changed.,git diff,engineer
-1205,Git大ピンチ,28,L,昨日から壊れてるらしい。いつ壊した？,The bug appeared yesterday. Which commit caused it?,git log,engineer
-1206,Git大ピンチ,16,B,mainで直接開発していたことに気付いた,You accidentally developed on main.,git switch -c,engineer
-1207,Git大ピンチ,20,M,レビューOK！でも取り込み方が分からない,The PR was approved. Now what?,git merge,engineer
-1208,Git大ピンチ,21,R,コミット履歴が「fix」「fix2」「fix3」だらけ,Your commit history is messy.,git rebase -i,engineer
-1209,Git大ピンチ,29,S,上司に呼ばれた。今の作業を消さずに別ブランチへ行きたい,You must switch tasks immediately.,git stash,engineer
-1210,Git大ピンチ,22,P,自分だけ動く。みんなには見えない,Only your machine has the changes.,git push,engineer
-1211,Git大ピンチ,38,P,取り込みしないまま続けたら地獄のコンフリクト,You skipped pull before starting work.,git pull,engineer
-1212,Git大ピンチ,30,F,最新は見たい。でもまだ混ぜたくない,You only want the latest remote state.,git fetch,engineer
-1213,Git大ピンチ,39,R,昨日の作業全部なかったことにしたい,You want to discard yesterday's work.,git reset --hard,engineer
-1214,Git大ピンチ,44,R,本番に出したコミットだけ安全に取り消したい,Undo only one released commit.,git revert,engineer
-1215,Git大ピンチ,45,C,あのバグ修正だけ今のブランチにも欲しい,You only need one commit.,git cherry-pick,engineer
-1216,Git大ピンチ,40,B,「誰がこのバグ入れた？」会議室が静まり返る,Who introduced this bug?,git blame,engineer
-1217,Git大ピンチ,23,S,このコミット、本当に何を変更した？,What exactly changed in this commit?,git show,engineer
-1218,Git大ピンチ,31,R,リモートが増えすぎてpush先が分からない,Too many remotes. Which one am I using?,git remote -v,engineer
-1219,Git大ピンチ,17,C,知らない名前でコミットされていた,Your commit author is wrong.,git config --global,engineer
-1220,Git大ピンチ,32,T,v2.0ってどのコミット？誰も分からない,Nobody knows where version 2.0 is.,git tag,engineer
-1221,Git大ピンチ,24,R,間違えてファイルを削除してしまった,You deleted the wrong file.,git restore,engineer
-1222,Git大ピンチ,33,C,ブランチを切り替えたらファイルが消えた,Files disappeared after switching branches.,git checkout,engineer
-1223,Git大ピンチ,13,A,ファイルを追加したのにコミットに入っていなかった,The new file wasn't included.,git add,engineer
-1224,Git大ピンチ,25,C,コミットした瞬間、誤字を見つけた,You spotted a typo right after committing.,git commit --amend,engineer
-1225,Git大ピンチ,34,S,コンフリクトを直したつもりなのにまだ終わらない,"You resolved conflicts, but Git disagrees.",git status → git add → git commit,engineer
-1226,Git大ピンチ,41,S,コンフリクトを直したのに「まだ終わってない」と言われた,Git still thinks the merge isn't finished.,git status → git add → git commit,engineer
-1227,Git大ピンチ,50,R,間違えてmainへpushしてしまった,You accidentally pushed directly to main.,git revert,engineer
-1228,Git大ピンチ,35,S,ブランチを切り替えたいのに変更が邪魔して進めない,Uncommitted changes block switching branches.,git stash → git switch,engineer
-1229,Git大ピンチ,46,F,最新を取り込んだら大量コンフリクトになった,Pull caused a huge merge conflict.,git fetch → git merge,engineer
-1230,Git大ピンチ,47,L,「昨日動いてた版に戻して」と言われた,Go back to yesterday's version.,git log → git checkout <commit>,engineer
-1231,Git大ピンチ,14,S,どのブランチにいるのか分からなくなった,You forgot which branch you're on.,git status,engineer
-1232,Git大ピンチ,26,D,レビューで「差分が見えません」と言われた,The reviewer can't tell what changed.,git diff,engineer
-1233,Git大ピンチ,27,C,レビュー後に1文字だけ直したい,You only need to fix one typo after review.,git commit --amend,engineer
-1234,Git大ピンチ,42,T,リリース版がどのコミットか誰も覚えていない,Nobody knows which commit was released.,git tag,engineer
-1235,Git大ピンチ,36,B,「このコード誰が書いた？」全員目をそらした,Nobody admits writing the code.,git blame,engineer
-1236,Git大ピンチ,43,R,間違えて別ブランチで1時間作業してしまった,You worked on the wrong branch for an hour.,git stash → git switch → git stash pop,engineer
-1237,Git大ピンチ,48,C,「その修正だけ持ってきて」と言われた,Only bring over that one fix.,git cherry-pick,engineer
-1238,Git大ピンチ,49,S,マージした瞬間にビルドが壊れた,The build broke immediately after merging.,git show,engineer
-1239,Git大ピンチ,37,R,リモートが多すぎてpush先を間違えそう,Too many remotes to remember.,git remote -v,engineer
-1240,Git大ピンチ,18,G,新しいPCなのにコミットできない,Git isn't configured on the new PC.,git config --global,engineer
-1301,SQLかるた,-,S,取得する列を指定する,Specify which columns to retrieve.,SELECT,engineer
-1302,SQLかるた,-,F,データを取得するテーブルを指定する,Specify the table to retrieve data from.,FROM,engineer
-1303,SQLかるた,-,W,条件に一致するデータを取得する,Retrieve data that matches a condition.,WHERE,engineer
-1304,SQLかるた,-,G,指定した列の値でグループ化する,Group rows by the values of specified columns.,GROUP BY,engineer
-1305,SQLかるた,-,H,グループ化した後の結果に条件をつける,Filter results after grouping.,HAVING,engineer
-1306,SQLかるた,-,O,結果を並び替える,Sort the results.,ORDER BY,engineer
-1307,SQLかるた,-,L,取得する件数を制限する,Limit the number of rows returned.,LIMIT,engineer
-1308,SQLかるた,-,I,一致する行だけを複数テーブルから結合する,"Join tables, returning only matching rows.",INNER JOIN,engineer
-1309,SQLかるた,-,L,左側のテーブルを基準に結合する,"Join tables, keeping all rows from the left table.",LEFT JOIN,engineer
-1310,SQLかるた,-,R,右側のテーブルを基準に結合する,"Join tables, keeping all rows from the right table.",RIGHT JOIN,engineer
-1311,SQLかるた,-,F,両方のテーブルの行をすべて結合する,"Join tables, keeping all rows from both tables.",FULL OUTER JOIN,engineer
-1312,SQLかるた,-,U,複数の検索結果を縦に結合する,Combine the results of multiple queries.,UNION,engineer
-1313,SQLかるた,-,D,重複を除外する,Exclude duplicate rows.,DISTINCT,engineer
-1314,SQLかるた,-,I,新しい行を追加する,Insert a new row.,INSERT INTO,engineer
-1315,SQLかるた,-,U,既存の行を更新する,Update existing rows.,UPDATE,engineer
-1316,SQLかるた,-,D,行を削除する,Delete rows.,DELETE,engineer
-1317,SQLかるた,-,C,新しいテーブルを作成する,Create a new table.,CREATE TABLE,engineer
-1318,SQLかるた,-,A,テーブルの構造を変更する,Modify a table's structure.,ALTER TABLE,engineer
-1319,SQLかるた,-,D,テーブルを削除する,Delete a table.,DROP TABLE,engineer
-1320,SQLかるた,-,P,行を一意に識別する列を指定する,Designate a column that uniquely identifies each row.,PRIMARY KEY,engineer
-1321,SQLかるた,-,F,他のテーブルの行を参照する制約,A constraint that references a row in another table.,FOREIGN KEY,engineer
-1322,SQLかるた,-,N,値が存在しないことを表す,Represents the absence of a value.,NULL,engineer
-1323,SQLかるた,-,B,指定した範囲内のデータを取得する,Retrieve data within a specified range.,BETWEEN,engineer
-1324,SQLかるた,-,L,文字列のパターンに一致するか調べる,Check whether a string matches a pattern.,LIKE,engineer
-1325,SQLかるた,-,I,複数の値のいずれかに一致するか調べる,Check whether a value matches any in a list.,IN,engineer
-1326,SQLかるた,-,C,行数を数える,Count the number of rows.,COUNT,engineer
-1327,SQLかるた,-,S,値の合計を求める,Calculate the sum of values.,SUM,engineer
-1328,SQLかるた,-,A,値の平均を求める,Calculate the average of values.,AVG,engineer
-1329,SQLかるた,-,A,列やテーブルに別名をつける,Give a column or table an alias.,AS,engineer
-1330,SQLかるた,-,C,条件によって異なる値を返す,Return different values depending on a condition.,CASE WHEN,engineer
-1331,SQLかるた,-,C,変更をデータベースに確定する,Commit changes to the database.,COMMIT,engineer
-1332,SQLかるた,-,R,変更を取り消して元に戻す,Undo changes and revert to the previous state.,ROLLBACK,engineer
-1401,AWSかるた,-,L,サーバレスでコードを実行する,Run code without managing servers.,Lambda,engineer
-1402,AWSかるた,-,S,オブジェクトストレージ,Object storage.,S3,engineer
-1403,AWSかるた,-,D,NoSQLデータベース,A NoSQL database.,DynamoDB,engineer
-1404,AWSかるた,-,E,仮想サーバーを提供する,Provides virtual servers.,EC2,engineer
-1405,AWSかるた,-,R,マネージドなリレーショナルデータベース,A managed relational database.,RDS,engineer
-1406,AWSかるた,-,V,仮想的なネットワーク環境を作る,Create an isolated virtual network.,VPC,engineer
-1407,AWSかるた,-,I,ユーザーや権限を管理する,Manage users and permissions.,IAM,engineer
-1408,AWSかるた,-,C,コンテンツ配信網(CDN)サービス,A content delivery network (CDN) service.,CloudFront,engineer
-1409,AWSかるた,-,R,DNSサービス,A DNS service.,Route 53,engineer
-1410,AWSかるた,-,A,APIの作成・公開・管理を行う,"Create, publish, and manage APIs.",API Gateway,engineer
-1411,AWSかるた,-,S,メッセージを溜めておくキューサービス,A queue service for storing messages.,SQS,engineer
-1412,AWSかるた,-,S,メッセージを配信する通知サービス,A notification service for delivering messages.,SNS,engineer
-1413,AWSかるた,-,C,リソースの監視やログ収集を行う,Monitor resources and collect logs.,CloudWatch,engineer
-1414,AWSかるた,-,C,インフラをコードで構築・管理する,Provision and manage infrastructure as code.,CloudFormation,engineer
-1415,AWSかるた,-,E,コンテナを管理・実行するサービス,A service for managing and running containers.,ECS,engineer
-1416,AWSかるた,-,E,マネージドなKubernetesサービス,A managed Kubernetes service.,EKS,engineer
-1417,AWSかるた,-,F,サーバー管理が不要なコンテナ実行環境,A serverless container runtime that needs no server management.,Fargate,engineer
-1418,AWSかるた,-,E,アプリケーションのデプロイを簡単にする,Simplifies application deployment.,Elastic Beanstalk,engineer
-1419,AWSかるた,-,A,負荷に応じてサーバー台数を自動調整する,Automatically adjusts server count based on load.,Auto Scaling,engineer
-1420,AWSかるた,-,E,通信を複数サーバーに振り分ける,Distributes traffic across multiple servers.,Elastic Load Balancing,engineer
-1421,AWSかるた,-,G,データを抽出・変換・ロードするETLサービス,"An ETL service for extracting, transforming, and loading data.",Glue,engineer
-1422,AWSかるた,-,A,S3のデータをSQLで分析する,Analyze data in S3 using SQL.,Athena,engineer
-1423,AWSかるた,-,K,大量のストリーミングデータを処理する,Process large volumes of streaming data.,Kinesis,engineer
-1424,AWSかるた,-,S,複数のサービスをワークフローでつなぐ,Coordinate multiple services into a workflow.,Step Functions,engineer
-1425,AWSかるた,-,C,ユーザーの認証や認可を管理する,Manage user authentication and authorization.,Cognito,engineer
-1426,AWSかるた,-,S,パスワードなどの機密情報を管理する,Manage secrets such as passwords.,Secrets Manager,engineer
-1427,AWSかるた,-,C,ビルドからデプロイまでを自動化する,Automate the process from build to deployment.,CodePipeline,engineer
-1428,AWSかるた,-,E,EC2にアタッチするブロックストレージ,Block storage attached to EC2 instances.,EBS,engineer
-1429,AWSかるた,-,A,高い性能を持つマネージドリレーショナルDB,A high-performance managed relational database.,Aurora,engineer
-1430,AWSかるた,-,R,大規模なデータウェアハウス,A large-scale data warehouse.,Redshift,engineer
-1501,Java大ピンチ,10,N,nullのはずの変数を当然のように呼び出してしまった,I called a method on something that turned out to be null.,NullPointerException,engineer
-1502,Java大ピンチ,15,I,ファイルを読み込もうとしたら途中で失敗した,Reading the file failed partway through.,IOException,engineer
-1503,Java大ピンチ,28,H,名前で検索したいのに配列だと毎回全部探してしまう,"I wanted to look things up by name, but the array made me scan everything.",HashMap,engineer
-1504,Java大ピンチ,11,A,配列の最後のつもりがその一個先を見ていた,"I thought I was at the last index, but I was already one past it.",ArrayIndexOutOfBoundsException,engineer
-1505,Java大ピンチ,35,C,そのクラスは実行時にはどこにも見つからなかった,"At runtime, that class was nowhere to be found.",ClassNotFoundException,engineer
-1506,Java大ピンチ,16,N,文字列を数値に変換しようとしたら数字になっていなかった,"I tried to convert a string to a number, but it wasn't numeric at all.",NumberFormatException,engineer
-1507,Java大ピンチ,17,I,渡された引数がそもそも受け取れない値だった,The argument I received was simply not acceptable.,IllegalArgumentException,engineer
-1508,Java大ピンチ,20,I,呼んではいけないタイミングでそのメソッドを呼んでしまった,I called that method at a moment it shouldn't have been called.,IllegalStateException,engineer
-1509,Java大ピンチ,12,A,0で割ってしまって計算がそこで止まった,"I divided by zero, and the calculation stopped right there.",ArithmeticException,engineer
-1510,Java大ピンチ,29,C,ループで回している最中にそのコレクションをいじってしまった,I modified the collection while still looping through it.,ConcurrentModificationException,engineer
-1511,Java大ピンチ,36,O,メモリを使い切ってJVMがついに音を上げた,"Memory ran out, and the JVM finally gave up.",OutOfMemoryError,engineer
-1512,Java大ピンチ,30,S,再帰呼び出しが終わる条件を見失って深くなりすぎた,The recursive calls lost their stopping point and went too deep.,StackOverflowError,engineer
-1513,Java大ピンチ,21,A,配列のつもりだったのに要素を増やしたり減らしたりしたくなった,"I started with a plain array, but then wanted to resize it freely.",ArrayList,engineer
-1514,Java大ピンチ,31,L,真ん中への挿入ばかりで配列のコピーに時間がかかっていた,Inserting in the middle kept forcing slow array copies.,LinkedList,engineer
-1515,Java大ピンチ,22,H,同じ値がリストの中に何個も紛れ込んでいた,The same value kept sneaking into the list multiple times.,HashSet,engineer
-1516,Java大ピンチ,32,T,キーの並び順がいつもバラバラで整列させたかった,"The key order was always scrambled, and I wanted it sorted.",TreeMap,engineer
-1517,Java大ピンチ,23,S,文字列を+で繋ぐたびに新しいオブジェクトが量産されていた,Every string concatenation quietly created a brand-new object.,StringBuilder,engineer
-1518,Java大ピンチ,33,O,戻り値がnullかもしれないのにそのまま呼び出してしまいそうだった,"The return value might be null, and I almost called it blindly.",Optional,engineer
-1519,Java大ピンチ,37,S,forループを何重にも書いていたらコードが読みにくくなった,Nested for-loops piled up until the code became unreadable.,Stream,engineer
-1520,Java大ピンチ,24,I,実装は持たずにメソッドの形だけ決めておきたかった,"I wanted to define only the method shapes, with no implementation.",Interface,engineer
-1521,Java大ピンチ,25,A,共通の処理だけ用意して残りは子クラスに任せたかった,I wanted to share some logic but leave the rest to subclasses.,Abstract Class,engineer
-1522,Java大ピンチ,38,G,同じクラスを型ごとにいくつも書きそうになった,I was about to duplicate the same class for every type.,Generics,engineer
-1523,Java大ピンチ,26,T,例外が起きても最後の後始末だけは必ずやりたかった,"Even if an exception occurs, the cleanup still has to run.",try-catch-finally,engineer
-1524,Java大ピンチ,40,S,複数のスレッドが同時に同じ値を書き換えにきた,Multiple threads tried to rewrite the same value at once.,synchronized,engineer
-1525,Java大ピンチ,39,T,重い処理のせいで画面が固まったように見えた,A heavy task made everything look frozen.,Thread,engineer
-1526,Java大ピンチ,27,O,親クラスと同じ動きしかせず子クラスらしい振る舞いに変えられなかった,"The subclass behaved just like its parent, and I needed to change that.",Override,engineer
-1527,Java大ピンチ,34,E,中身が同じはずのオブジェクトが別物として扱われてしまった,Two objects with identical content were treated as different.,equals/hashCode,engineer
-1528,Java大ピンチ,18,F,あとから値を変えられないように絶対に守りたかった,I wanted to make sure that value could never be changed again.,final,engineer
-1529,Java大ピンチ,19,S,インスタンスを作らなくてもその機能だけ使いたかった,I wanted to use that feature without ever creating an instance.,static,engineer
-1601,コードレビューかるた,-,D,同じコードが複数箇所に存在する,The same code exists in multiple places.,DRY原則,engineer
-1602,コードレビューかるた,-,か,変数名から役割が分からない,It's unclear what a variable does from its name.,可読性,engineer
-1603,コードレビューかるた,-,た,1つのメソッドが長すぎる,A single method is too long.,単一責任の原則,engineer
-1604,コードレビューかるた,-,ま,意味のわからない数値が直接書かれている,An unexplained number is hard-coded directly in the code.,マジックナンバー,engineer
-1605,コードレビューかるた,-,ね,条件分岐が何重にも入れ子になっている,Conditional branches are nested many levels deep.,ネストが深い,engineer
-1606,コードレビューかるた,-,め,変数名やクラス名のつけ方が統一されていない,Variable and class naming is inconsistent.,命名規則違反,engineer
-1607,コードレビューかるた,-,て,重要な処理にテストが書かれていない,Critical logic has no tests.,テストカバレッジ不足,engineer
-1608,コードレビューかるた,-,は,設定値がコード中に直接埋め込まれている,Configuration values are embedded directly in the code.,ハードコーディング,engineer
-1609,コードレビューかるた,-,れ,catchした例外を何もせず無視している,A caught exception is silently ignored.,例外の握りつぶし,engineer
-1610,コードレビューかるた,-,ぐ,どこからでも書き換えられる変数を多用している,Overuse of variables that can be modified from anywhere.,グローバル変数の濫用,engineer
-1611,コードレビューかるた,-,こ,複雑な処理の意図が説明されていない,The intent behind complex logic is not explained.,コメント不足,engineer
-1612,コードレビューかるた,-,じ,同じロジックが何箇所にもコピーされている,The same logic is copy-pasted in many places.,重複コード,engineer
-1613,コードレビューかるた,-,そ,条件を満たしたらすぐに関数を抜けず深く入れ子にしている,"Doesn't exit early when a condition is met, leading to deep nesting.",早期return,engineer
-1614,コードレビューかるた,-,ふ,名前から想像できない値の変更を行う関数,A function that changes values in ways its name doesn't suggest.,副作用のある関数,engineer
-1615,コードレビューかるた,-,み,クラス同士が内部実装に強く依存している,Classes depend heavily on each other's internal implementation.,密結合,engineer
-1616,コードレビューかるた,-,で,呼び出されない不要なコードが残っている,Unused code that is never called remains in the codebase.,デッドコード,engineer
-1617,コードレビューかるた,-,S,ユーザー入力をそのままSQLに組み込んでいる,User input is embedded directly into SQL without sanitization.,SQLインジェクション脆弱性,engineer
-1618,コードレビューかるた,-,ふ,使われていないモジュールが読み込まれている,Unused modules are imported.,不要なimport,engineer
-1619,コードレビューかるた,-,ろ,エラー発生時に原因を追えるログがない,There are no logs to trace the cause when an error occurs.,ログ出力不足,engineer
-1620,コードレビューかるた,-,ば,入力値の検証が行われていない,Input values are not validated.,バリデーション漏れ,engineer
-1621,コードレビューかるた,-,れ,並行処理の実行順序によって結果が変わる不具合,A bug where the result depends on the timing of concurrent execution.,レースコンディション,engineer
-1622,コードレビューかるた,-,か,将来使うかもしれない機能を先に作り込んでいる,Building functionality preemptively for hypothetical future use.,過剰な抽象化,engineer
-1701,セキュリティ大ピンチ,10,は,アカウント全部　同じパスワードだった,I used the same password for every account.,パスワードリスト攻撃,engineer
-1702,セキュリティ大ピンチ,15,ふ,いそいで振り込め　メールを信じた,I trusted an urgent payment email.,フィッシング,engineer
-1703,セキュリティ大ピンチ,12,ま,USBを拾って　そのまま挿した,I plugged in a USB drive I found.,マルウェア,engineer
-1704,セキュリティ大ピンチ,40,し,APIキーを　GitHubで公開した,I exposed an API key on GitHub.,シークレット管理,engineer
-1705,セキュリティ大ピンチ,16,ふ,おなじログイン画面だと　思い込んだ,I assumed the login page was genuine.,フィッシングサイト,engineer
-1706,セキュリティ大ピンチ,21,て,開発用パスワードを　本番でも使った,I used a development password in production.,デフォルトパスワード,engineer
-1707,セキュリティ大ピンチ,27,し,きょうもパッチを　後回しにした,I postponed installing security patches again.,脆弱性,engineer
-1708,セキュリティ大ピンチ,28,ら,暗号化されても　バックアップがない,Everything was encrypted and I had no backup.,ランサムウェア,engineer
-1709,セキュリティ大ピンチ,41,え,検索欄から　データベースが壊れた,The database broke through the search box.,SQLインジェクション,engineer
-1710,セキュリティ大ピンチ,42,く,コメントを書いたら　勝手に画面が動いた,A comment caused unexpected script execution.,XSS,engineer
-1711,セキュリティ大ピンチ,45,し,サイトを見ただけで　退会していた,I was logged out or unsubscribed just by visiting a page.,CSRF,engineer
-1712,セキュリティ大ピンチ,35,に,知らない人まで　管理画面に入れた,Unauthorized users reached the admin screen.,認可不備,engineer
-1713,セキュリティ大ピンチ,22,あ,すでに退職した人が　まだログインしていた,A former employee could still log in.,アカウント管理,engineer
-1714,セキュリティ大ピンチ,30,さ,全員を管理者に　してしまった,I gave everyone administrator privileges.,最小権限の原則,engineer
-1715,セキュリティ大ピンチ,17,て,そのままHTTPで　ログインした,I logged in over HTTP.,TLS,engineer
-1716,セキュリティ大ピンチ,23,か,だれが操作したか　分からない,Nobody knew who performed the operation.,監査ログ,engineer
-1717,セキュリティ大ピンチ,36,せ,社内だから安全と　思い込んでいた,I assumed the internal network was safe.,ゼロトラスト,engineer
-1718,セキュリティ大ピンチ,43,あ,つうしんの異常に　誰も気付かなかった,Nobody noticed the suspicious traffic.,IDS,engineer
-1719,セキュリティ大ピンチ,46,あ,敵は見つけたのに　止められなかった,We detected the attack but couldn't stop it.,IPS,engineer
-1720,セキュリティ大ピンチ,44,え,取りつかれても　誰も気付かなかった,The endpoint was compromised without anyone noticing.,EDR,engineer
-1721,セキュリティ大ピンチ,24,せ,長いこと更新を　していなかった,The server hadn't been updated for a long time.,セキュリティパッチ,engineer
-1722,セキュリティ大ピンチ,18,た,認証が　パスワードだけだった,Only a password protected the account.,多要素認証,engineer
-1723,セキュリティ大ピンチ,37,せ,ぬすまれたCookieで　ログインされた,Someone logged in using my stolen cookie.,セッションハイジャック,engineer
-1724,セキュリティ大ピンチ,25,あ,ねだんより　個人情報を守れ,Personal data was stored without protection.,暗号化,engineer
-1725,セキュリティ大ピンチ,19,て,残っていた初期設定で　入られた,Someone logged in with default credentials.,デフォルト認証情報,engineer
-1726,セキュリティ大ピンチ,26,と,アクセスが急に　100万件来た,A million requests suddenly flooded the server.,DoS攻撃,engineer
-1727,セキュリティ大ピンチ,38,こ,秘密鍵を　メールで送ってしまった,I emailed a private key.,公開鍵暗号方式,engineer
-1728,セキュリティ大ピンチ,39,せ,古い設定をコピーしたら　穴だらけだった,I copied an insecure server configuration.,セキュア設定,engineer
-1729,セキュリティ大ピンチ,31,し,へいきだろうで　本番公開した,I released it to production assuming it was safe.,脆弱性診断,engineer
-1730,セキュリティ大ピンチ,20,さ,ほんとうに開いてよかった？　その添付ファイル,Should I really have opened that attachment?,サンドボックス,engineer
-1731,セキュリティ大ピンチ,70,え,まさか社内サーバが　外から操作された,The internal server was manipulated from outside.,SSRF,engineer
-1732,セキュリティ大ピンチ,80,え,見せるはずのない　サーバのファイルが見えた,Internal server files became visible.,XXE,engineer
-1733,セキュリティ大ピンチ,71,お,無害な入力のはずが　コマンドが動いた,A harmless input executed a command.,OSコマンドインジェクション,engineer
-1734,セキュリティ大ピンチ,85,し,メンバーなのに　管理者になっていた,A normal user became an administrator.,JWT,engineer
-1735,セキュリティ大ピンチ,65,お,もれたトークンで　勝手に操作された,A leaked token was used for unauthorized access.,OAuth,engineer
-1736,セキュリティ大ピンチ,55,に,やっぱり開発環境だからと　チェックを外した,I disabled authentication because it was only a development environment.,認証,engineer
-1737,セキュリティ大ピンチ,60,に,ユーザー画面だけで　権限チェックしていた,Authorization was checked only on the client side.,認可,engineer
-1801,Webアプリ大ピンチ,10,き,更新したのに昨日の画面のままだった,The page still showed yesterday's version after deployment.,キャッシュ,engineer
-1802,Webアプリ大ピンチ,15,せ,ログインしたのにすぐログアウトされた,I was logged out right after logging in.,セッション,engineer
-1803,Webアプリ大ピンチ,20,と,注文ボタンを連打したら二重登録された,Clicking the order button repeatedly created duplicate records.,トランザクション,engineer
-1804,Webアプリ大ピンチ,16,く,これを消したらログインできるようになった,Deleting cookies fixed the login problem.,Cookie,engineer
-1805,Webアプリ大ピンチ,21,H,404しか返ってこない,Everything returned a 404 error.,HTTPステータスコード,engineer
-1806,Webアプリ大ピンチ,30,り,POSTしたのに画面が別ページへ飛んだ,"After POST, I was sent to another page.",リダイレクト,engineer
-1807,Webアプリ大ピンチ,31,ふ,画面遷移したら入力内容が消えなかった,The input remained after changing pages.,フォワード,engineer
-1808,Webアプリ大ピンチ,22,さ,画面は開くのにデータが表示されない,The page loads but no data appears.,Servlet,engineer
-1809,Webアプリ大ピンチ,32,J,コードを直したのに画面が変わらない,I edited a JSP but nothing changed.,JSP,engineer
-1810,Webアプリ大ピンチ,36,E,HTMLの中にJavaだらけで読めない,The JSP is full of Java code and unreadable.,EL式,engineer
-1811,Webアプリ大ピンチ,37,J,同じ処理を何度もJSPに書いてしまった,I duplicated the same logic across JSPs.,JSTL,engineer
-1812,Webアプリ大ピンチ,42,え,DBにはあるのに画面には表示されない,The data exists in the database but isn't shown.,MVC,engineer
-1813,Webアプリ大ピンチ,43,J,SQLは成功したのに画面が更新されない,The SQL succeeded but the screen didn't update.,JDBC,engineer
-1814,Webアプリ大ピンチ,23,S,コードを書き換えたらデータが入っていない,Changing one SQL query broke everything.,SQL,engineer
-1815,Webアプリ大ピンチ,54,い,検索だけやたら遅い,Only searches are extremely slow.,インデックス,engineer
-1816,Webアプリ大ピンチ,50,こ,接続数がいっぱいでDBにつながらない,The database refused more connections.,コネクションプール,engineer
-1817,Webアプリ大ピンチ,24,M,データベースが起動していなかった,The database server wasn't running.,MySQL,engineer
-1818,Webアプリ大ピンチ,38,P,再起動したら直った,Restarting the server fixed it.,Payara,engineer
-1819,Webアプリ大ピンチ,33,わ,デプロイしたのに反映されない,I deployed it but nothing changed.,WAR,engineer
-1820,Webアプリ大ピンチ,44,G,依存ライブラリを追加したのに読み込まれない,The dependency wasn't picked up after adding it.,Gradle,engineer
-1821,Webアプリ大ピンチ,45,い,昨日までビルドできたのに今日は失敗する,Yesterday's build worked but today's doesn't.,依存関係,engineer
-1822,Webアプリ大ピンチ,25,び,ソースは変えていないのに実行できない,"I changed nothing, but it no longer runs.",ビルド,engineer
-1823,Webアプリ大ピンチ,26,J,ボタンを押しても何も起きない,Clicking the button does nothing.,JavaScript,engineer
-1824,Webアプリ大ピンチ,34,D,要素が見つからないと言われた,The browser says the element can't be found.,DOM,engineer
-1825,Webアプリ大ピンチ,17,し,画面レイアウトがぐちゃぐちゃになった,The page layout completely broke.,CSS,engineer
-1826,Webアプリ大ピンチ,39,J,APIの返却結果が読めない,I can't parse the API response.,JSON,engineer
-1827,Webアプリ大ピンチ,40,A,画面はあるのにデータだけ取れない,The page loads but no data comes back.,AJAX,engineer
-1828,Webアプリ大ピンチ,46,ば,入力したのに保存できない,The form won't save my input.,バリデーション,engineer
-1829,Webアプリ大ピンチ,47,れ,エラー画面しか出ない,Only an error page is displayed.,例外処理,engineer
-1830,Webアプリ大ピンチ,27,ろ,何が起きたのか全然分からない,I have no idea what happened.,ログ,engineer
-1831,Webアプリ大ピンチ,48,す,エラーは出たけど原因が読めない,I see an error but can't identify the cause.,スタックトレース,engineer
-1832,Webアプリ大ピンチ,28,で,調べたら動いてしまう,The bug disappears during debugging.,デバッグ,engineer
-1833,Webアプリ大ピンチ,41,も,文字が全部「???」になった,All the text turned into question marks.,文字コード,engineer
-1834,Webアプリ大ピンチ,35,U,日本語だけ文字化けした,Only Japanese characters are garbled.,UTF-8,engineer
-1835,Webアプリ大ピンチ,29,G,最新コードを取ったら動かなくなった,Pulling the latest code broke everything.,Git,engineer
-1836,Webアプリ大ピンチ,51,ま,同じファイルを編集して取り込めない,I can't merge because we edited the same file.,マージコンフリクト,engineer
-1837,Webアプリ大ピンチ,52,C,ブラウザからだけAPIが呼べない,The API works elsewhere but not from the browser.,CORS,engineer
-1838,Webアプリ大ピンチ,55,N,SQLを1件取得するたびにSQLが増えていく,One query turns into hundreds of queries.,N+1問題,engineer
-1839,Webアプリ大ピンチ,53,ら,他の人が更新して保存できなかった,Someone else updated the record first.,楽観ロック,engineer
-1840,Webアプリ大ピンチ,49,に,ログイン状態なのに403になった,I'm logged in but received a 403.,認可,engineer
-1901,Windows大ピンチ,10,C,コピーしたつもりが　できていなかった,I thought I copied it but it wasn't copied.,Ctrl+C,engineer
-1902,Windows大ピンチ,11,V,貼り付けたいのに　右クリックできない,I want to paste but can't use the mouse.,Ctrl+V,engineer
-1903,Windows大ピンチ,12,X,別の場所へ　移動したい,I want to move it somewhere else.,Ctrl+X,engineer
-1904,Windows大ピンチ,13,Z,間違えて消してしまった,I accidentally deleted it.,Ctrl+Z,engineer
-1905,Windows大ピンチ,18,Y,戻しすぎて　やっぱり元に戻したい,I undid too much.,Ctrl+Y,engineer
-1906,Windows大ピンチ,14,A,全部まとめて選びたい,I want to select everything.,Ctrl+A,engineer
-1907,Windows大ピンチ,19,F,探したい文字が　見つからない,I can't find the text I'm looking for.,Ctrl+F,engineer
-1908,Windows大ピンチ,15,S,保存する前に　落ちそうだ,The application might crash before I save.,Ctrl+S,engineer
-1909,Windows大ピンチ,20,P,印刷したい,I want to print this.,Ctrl+P,engineer
-1910,Windows大ピンチ,24,T,新しいタブを　開きたい,I want to open a new tab.,Ctrl+T,engineer
-1911,Windows大ピンチ,33,T,閉じたタブを　戻したい,I want to reopen the tab I just closed.,Ctrl+Shift+T,engineer
-1912,Windows大ピンチ,21,R,更新したい,I want to refresh the page.,Ctrl+R,engineer
-1913,Windows大ピンチ,25,T,隣のタブへ　移動したい,I want to move to the next tab.,Ctrl+Tab,engineer
-1914,Windows大ピンチ,26,T,開きすぎて　目的の画面が見つからない,I have too many windows open.,Alt+Tab,engineer
-1915,Windows大ピンチ,22,D,デスクトップを　一瞬だけ見たい,I need to see the desktop quickly.,Windows+D,engineer
-1916,Windows大ピンチ,27,E,エクスプローラーを　開きたい,I need File Explorer.,Windows+E,engineer
-1917,Windows大ピンチ,28,L,席を離れるので　すぐロックしたい,I'm leaving my desk and want to lock my PC.,Windows+L,engineer
-1918,Windows大ピンチ,29,I,設定画面を　開きたい,I need to open Settings.,Windows+I,engineer
-1919,Windows大ピンチ,30,S,アプリやファイルを　すぐ探したい,I need to search for an app or file.,Windows+S,engineer
-1920,Windows大ピンチ,23,F,ファイル名を　変更したい,I want to rename a file.,F2,engineer
-1921,Windows大ピンチ,16,F,画面を　更新したい,I want to refresh the screen.,F5,engineer
-1922,Windows大ピンチ,17,F,ヘルプを　開きたい,I need help.,F1,engineer
-1923,Windows大ピンチ,34,F,終了ボタンが　押せない,I need to close the current application.,Alt+F4,engineer
-1924,Windows大ピンチ,38,E,固まったアプリを　調べたい,I need Task Manager.,Ctrl+Shift+Esc,engineer
-1925,Windows大ピンチ,31,D,ログイン画面に　戻りたい,I need the Windows security screen.,Ctrl+Alt+Delete,engineer
-1926,Windows大ピンチ,35,+,文字が小さすぎて　見えない,The text is too small to read.,Windows++,engineer
-1927,Windows大ピンチ,36,-,画面が大きすぎて　見づらい,Everything is zoomed in too much.,Windows+-,engineer
-1928,Windows大ピンチ,39,P,画面を　そのまま保存したい,I want to save a screenshot.,Windows+PrintScreen,engineer
-1929,Windows大ピンチ,32,S,画面の一部だけ　切り取りたい,I only need part of the screen.,Windows+Shift+S,engineer
-1930,Windows大ピンチ,37,.,絵文字を　入力したい,I want to insert an emoji.,Windows+.,engineer
-1931,Windows大ピンチ,40,V,さっきコピーしたものを　もう一度使いたい,I need something I copied earlier.,Windows+V,engineer
-1932,Windows大ピンチ,42,S,日本語入力に　切り替わらない,I can't switch the input language.,Alt+Shift,engineer
-1933,Windows大ピンチ,43,`,かな入力に　なってしまった,I accidentally switched input modes.,Alt+`,engineer
-1934,Windows大ピンチ,41,D,同じ操作を　何度も繰り返している,I'm repeating the same action over and over.,Ctrl+D,engineer
-1935,Windows大ピンチ,44,F,右クリックメニューを　開きたい,I need the context menu without a mouse.,Shift+F10,engineer
-2001,モダン開発大ピンチ,93,し,リリース直前に重大バグ発覚,A critical bug is discovered right before release.,シフトレフト,engineer
-2002,モダン開発大ピンチ,15,し,本番環境でしか障害が起きない,The failure only happens in production.,シフトライト,engineer
-2003,モダン開発大ピンチ,91,D,開発と運用が対立している,Development and operations are at odds.,DevOps,engineer
-2004,モダン開発大ピンチ,85,D,セキュリティチェックがリリース直前,The security check happens right before release.,DevSecOps,engineer
-2005,モダン開発大ピンチ,69,G,サーバー設定が誰にも分からない,Nobody understands the server configuration.,GitOps,engineer
-2006,モダン開発大ピンチ,61,P,開発環境構築に丸1日かかる,Setting up a dev environment takes a full day.,Platform Engineering,engineer
-2007,モダン開発大ピンチ,75,D,業務用語とコードの意味が噛み合わない,Business terms and code don't mean the same thing.,DDD,engineer
-2008,モダン開発大ピンチ,31,T,テストのたびに手作業祭り,Every test run turns into manual busywork.,TDD,engineer
-2009,モダン開発大ピンチ,57,B,ユーザーの期待と実装がずれる,What users expect and what's built don't match.,BDD,engineer
-2010,モダン開発大ピンチ,55,り,誰も触れないコード爆誕,Code nobody dares to touch is born.,リファクタリング,engineer
-2011,モダン開発大ピンチ,95,C,マージのたびに動かなくなる,Every merge breaks the build.,CI,engineer
-2012,モダン開発大ピンチ,71,C,リリース準備だけで数週間,Just preparing a release takes weeks.,Continuous Delivery,engineer
-2013,モダン開発大ピンチ,37,C,デプロイ担当待ちで開発停止,Development stalls waiting for someone to deploy.,Continuous Deployment,engineer
-2014,モダン開発大ピンチ,47,ひ,品質チェックが人頼み,Quality checks depend entirely on people.,品質ゲート,engineer
-2015,モダン開発大ピンチ,29,ふ,機能を試したいだけなのに再デプロイ,"You just want to try a feature, but must redeploy.",フィーチャーフラグ,engineer
-2016,モダン開発大ピンチ,77,か,全ユーザーに一斉リリースして炎上,Releasing to all users at once causes a meltdown.,カナリアリリース,engineer
-2017,モダン開発大ピンチ,41,ぶ,本番切り替えに徹夜,Switching to production means an all-nighter.,ブルーグリーンデプロイ,engineer
-2018,モダン開発大ピンチ,89,と,半年ブランチ放置で地獄,A branch left untouched for six months becomes hell.,トランクベース開発,engineer
-2019,モダン開発大ピンチ,73,I,サーバー設定が職人技,Server configuration is a lost art known to one person.,IaC,engineer
-2020,モダン開発大ピンチ,81,D,自分のPCだけ動く,It only works on my machine.,Docker,engineer
-2021,モダン開発大ピンチ,33,K,コンテナが増えすぎて管理不能,Too many containers to manage.,Kubernetes,engineer
-2022,モダン開発大ピンチ,13,さ,サービス間通信が複雑怪奇,Communication between services is a tangled mess.,サービスメッシュ,engineer
-2023,モダン開発大ピンチ,17,さ,サーバー管理だけで一日終了,A whole day gone just managing servers.,サーバーレス,engineer
-2024,モダン開発大ピンチ,67,ま,一つの障害で全システム停止,One failure takes down the entire system.,マイクロサービス,engineer
-2025,モダン開発大ピンチ,39,も,マイクロサービス化したら逆に複雑化,Going microservices made things more complex instead.,モジュラーモノリス,engineer
-2026,モダン開発大ピンチ,21,く,フレームワーク依存が深すぎる,The code is too deeply tied to the framework.,クリーンアーキテクチャ,engineer
-2027,モダン開発大ピンチ,11,C,読み取り処理が重すぎる,Read operations are too heavy.,CQRS,engineer
-2028,モダン開発大ピンチ,49,E,過去データが復元できない,Past data can't be reconstructed.,Event Sourcing,engineer
-2029,モダン開発大ピンチ,97,O,障害原因が誰にも分からない,Nobody can tell what caused the failure.,Observability,engineer
-2030,モダン開発大ピンチ,25,O,ログ形式がバラバラ,Log formats are all over the place.,OpenTelemetry,engineer
-2031,モダン開発大ピンチ,19,S,品質を感覚で議論する,Quality gets debated based on gut feeling.,SLI,engineer
-2032,モダン開発大ピンチ,35,S,「速いサービス」の定義が曖昧,What counts as a 'fast service' is vague.,SLO,engineer
-2033,モダン開発大ピンチ,65,え,完璧を求めすぎて何も出せない,Chasing perfection means nothing ships.,エラーバジェット,engineer
-2034,モダン開発大ピンチ,59,ぽ,障害の犯人探し大会,The incident turns into a witch hunt.,ポストモーテム,engineer
-2035,モダン開発大ピンチ,83,Z,社内ネットワークだから安心,It's assumed safe just because it's the internal network.,Zero Trust,engineer
-2036,モダン開発大ピンチ,63,S,脆弱ライブラリ混入,A vulnerable library sneaks in.,SBOM,engineer
-2037,モダン開発大ピンチ,45,P,セキュリティルールが口伝,Security rules are only passed down by word of mouth.,Policy as Code,engineer
-2038,モダン開発大ピンチ,23,F,開発力を勘で評価している,Team performance is judged by gut feeling.,Four Keys,engineer
-2039,モダン開発大ピンチ,1,D,改善効果が見えない,You can't see whether improvements are working.,DORAメトリクス,engineer
-2040,モダン開発大ピンチ,53,S,コミット数だけで評価,People are evaluated by commit count alone.,SPACEフレームワーク,engineer
-2041,モダン開発大ピンチ,79,D,優秀な人ほど辞める,The best people are the ones who quit.,DevEx,engineer
-2042,モダン開発大ピンチ,87,C,ベテランしか理解できない,Only veterans can understand it.,Cognitive Load,engineer
-2043,モダン開発大ピンチ,99,ぎ,短納期のツケで保守不能,The cost of a rushed deadline makes it unmaintainable.,技術的負債,engineer
-2044,モダン開発大ピンチ,27,ご,チームごとに開発手順が違う,Every team follows a different process.,ゴールデンパス,engineer
-2045,モダン開発大ピンチ,9,A,AIが指示待ち人間,The AI just waits around for instructions.,AIエージェント,engineer
-2046,モダン開発大ピンチ,51,C,AIが仕様を誤解する,The AI misunderstands the spec.,Context Engineering,engineer
-2047,モダン開発大ピンチ,3,M,AIごとに連携方法が違う,Every AI connects in a different way.,MCP,engineer
-2048,モダン開発大ピンチ,43,R,AIが古い知識で回答する,The AI answers with outdated knowledge.,RAG,engineer
-2049,モダン開発大ピンチ,7,A,AIが単発作業しかできない,The AI can only handle one-off tasks.,Agentic Workflow,engineer
-2050,モダン開発大ピンチ,5,A,なぜこの設計なのか誰も知らない,Nobody knows why the design is this way.,ADR,engineer
-2100,大ピンチ法則かるた,79,べ,ボタン連打でデータが二重登録,Mashing the button registers the data twice.,冪等性,engineer
-2101,大ピンチ法則かるた,60,ぽ,厳密すぎて外部サービスと連携不能,Being too strict breaks integration with external services.,ポステルの法則,engineer
-2102,大ピンチ法則かるた,23,は,誰も知らない挙動を変えたら大炎上,Changing behavior nobody knew about causes a meltdown.,ハイラムの法則,engineer
-2103,大ピンチ法則かるた,55,り,レビュー不足でバグが埋もれる,Bugs stay buried because of too little review.,リーナスの法則,engineer
-2104,大ピンチ法則かるた,14,ざ,便利機能を足し続けてメールソフト化,Adding convenience features endlessly turns it into a mail client.,ザウィンスキーの法則,engineer
-2105,大ピンチ法則かるた,34,め,利用者が少なく価値が生まれない,Too few users means no value is created.,メトカーフの法則,engineer
-2106,大ピンチ法則かるた,94,む,性能向上を当てにした設計が破綻,A design betting on future performance gains falls apart.,ムーアの法則,engineer
-2107,大ピンチ法則かるた,64,C,全部入りを目指して全部失う,Trying to have it all means losing it all.,CAP定理,engineer
-2108,大ピンチ法則かるた,51,け,更新したのに画面が食い違う,"You updated it, but the screens disagree.",結果整合性,engineer
-2109,大ピンチ法則かるた,27,ば,処理が追いつかずシステムが詰まる,Processing can't keep up and the system chokes.,バックプレッシャー,engineer
-2110,大ピンチ法則かるた,21,ゔ,長年の改修で誰も理解できない,Years of changes leave nobody able to understand it.,ヴィルトの法則,engineer
-2111,大ピンチ法則かるた,70,た,一つ直したら別の機能も壊れる,"Fix one thing, break another feature.",単一責務の原則,engineer
-2112,大ピンチ法則かるた,67,か,UI変更なのにDB修正が必要,A UI change somehow requires a database fix.,関心の分離,engineer
-2113,大ピンチ法則かるた,83,ぎ,先送りのツケで大改修が必要に,Postponing it now means a massive rebuild is required.,技術的負債,engineer
-2114,大ピンチ法則かるた,26,で,他人の内部事情まで知りすぎる,It knows way too much about someone else's internals.,デメテルの法則,engineer
-2115,大ピンチ法則かるた,31,も,隠したはずの仕組みが漏れ出す,The mechanism you tried to hide leaks through anyway.,漏れ出す抽象化の法則,engineer
-2116,大ピンチ法則かるた,25,ふ,エラーを隠して障害が拡大,Hiding the error lets the failure spread.,フェイルファスト,engineer
-2117,大ピンチ法則かるた,57,か,機能追加のたび既存コードを書き換える,Every new feature means rewriting existing code.,解放閉鎖の原則,engineer
-2118,大ピンチ法則かるた,22,ぎ,複雑な仕組みを一気に作って失敗,Building a complex system all at once fails.,ギャルの法則,engineer
-2119,大ピンチ法則かるた,99,D,同じ修正を十か所に反映,The same fix has to be applied in ten places.,DRY,engineer
-2120,大ピンチ法則かるた,97,K,賢すぎる設計で誰も理解できない,The design is too clever for anyone to understand.,KISS,engineer
-2121,大ピンチ法則かるた,88,S,設計ルールが崩れて泥団子化,The design rules collapse into a big ball of mud.,SOLID,engineer
-2122,大ピンチ法則かるた,49,U,一つのツールが何でも屋になる,One tool ends up doing everything.,Unix哲学,engineer
-2123,大ピンチ法則かるた,18,E,正しいが誰も変更できないコード,Code that's correct but nobody dares to change.,ETC,engineer
-2124,大ピンチ法則かるた,38,ご,一人で悩み続けて一日終了,A whole day spent agonizing alone.,ゴムのアヒルデバッグ,engineer
-2125,大ピンチ法則かるた,73,ぶ,人を増やしたのに納期が延びる,Adding more people only pushes the deadline back.,ブルックスの法則,engineer
-2126,大ピンチ法則かるた,17,9,あと一割が終わらない,The last ten percent never gets done.,90対90の法則,engineer
-2127,大ピンチ法則かるた,16,ほ,見積もりが毎回外れる,The estimate is wrong every single time.,ホフスタッターの法則,engineer
-2128,大ピンチ法則かるた,86,Y,誰も使わない機能を量産,Features nobody uses keep piling up.,YAGNI,engineer
-2129,大ピンチ法則かるた,42,ぷ,試作品がそのまま本番化,The prototype becomes production as-is.,プロトタイプ,engineer
-2130,大ピンチ法則かるた,10,と,最後まで繋いだら動かない,Wiring it end-to-end reveals it doesn't work.,トレーサーバレット,engineer
-2131,大ピンチ法則かるた,62,さ,全員が本番DBを消せる,Everyone has permission to delete the production database.,最小権限の原則,engineer
-2132,大ピンチ法則かるた,54,ふ,一つ壊れただけで全停止,One failure takes the whole thing down.,フェイルセーフ,engineer
-2133,大ピンチ法則かるた,48,わ,小さな手抜きが大崩壊を招く,A small shortcut leads to total collapse.,割れ窓理論,engineer
-2134,大ピンチ法則かるた,33,ぐ,一部障害でサービス全停止,A partial failure takes the entire service down.,グレースフルデグラデーション,engineer
-2135,大ピンチ法則かるた,20,す,作った機能の九割が使われない,Ninety percent of the features built go unused.,スタージョンの法則,engineer
-2136,大ピンチ法則かるた,37,ば,一人辞めたら開発停止,One person leaves and development grinds to a halt.,バス係数,engineer
-2137,大ピンチ法則かるた,71,ぴ,昇進したら誰も幸せにならない,The promotion makes nobody happy.,ピーターの法則,engineer
-2138,大ピンチ法則かるた,90,こ,組織図そのままのシステム誕生,The system ends up mirroring the org chart exactly.,コンウェイの法則,engineer
-2139,大ピンチ法則かるた,40,ぴ,期待されず成長が止まる,Growth stalls when nobody expects anything.,ピグマリオン効果,engineer
-2140,大ピンチ法則かるた,93,ぱ,重要な二割を見誤る,The critical twenty percent gets misjudged.,パレートの法則,engineer
-2141,大ピンチ法則かるた,50,M,分類漏れと重複だらけ,Full of gaps and overlaps in the classification.,MECE,engineer
-2142,大ピンチ法則かるた,53,お,複雑な説明ばかり増える,Explanations just keep getting more convoluted.,オッカムの剃刀,engineer
-2143,大ピンチ法則かるた,12,ち,理由も知らずに消して事故,Removing it without knowing why causes an accident.,チェスタトンの柵,engineer
-2144,大ピンチ法則かるた,28,り,見方を変えられず行き詰まる,Stuck because nobody can change their perspective.,リフレーミング,engineer
-2145,大ピンチ法則かるた,32,ぐ,指標を追って本質を失う,Chasing the metric loses sight of the point.,グッドハートの法則,engineer
-2146,大ピンチ法則かるた,11,き,KPI達成のため数字を盛る,The numbers get inflated just to hit the KPI.,キャンベルの法則,engineer
-2147,大ピンチ法則かるた,7,じ,見えている範囲だけで判断,Judging everything from only what's visible.,ジョシュアツリーの法則,engineer
-2148,大ピンチ法則かるた,95,だ,自信満々なのに実力不足,"Full of confidence, short on actual skill.",ダニングクルーガー効果,engineer
-2149,大ピンチ法則かるた,92,か,都合の良い情報しか見ない,Only the convenient information gets noticed.,確証バイアス,engineer
-2150,大ピンチ法則かるた,82,は,一つの長所だけで全部高評価,One strength earns a high rating on everything.,ハロー効果,engineer
-2151,大ピンチ法則かるた,15,さ,気づかぬうちに判断を誘導される,A judgment gets nudged without anyone noticing.,サブリミナル効果,engineer
-2152,大ピンチ法則かるた,89,せ,成功例だけ真似して失敗,Copying only the success stories leads to failure.,生存者バイアス,engineer
-2153,大ピンチ法則かるた,44,ば,急に全部が気になり始める,Suddenly it seems to be everywhere.,バーダーマインホフ現象,engineer
-2154,大ピンチ法則かるた,45,か,禁止したら余計にやりたくなる,Banning it only makes people want it more.,カリギュラ効果,engineer
-2155,大ピンチ法則かるた,65,し,第一印象だけで評価が決まる,The first impression decides the whole evaluation.,初頭効果,engineer
-2156,大ピンチ法則かるた,68,ざ,顔を出す人だけ評価される,Only the person who shows up gets the credit.,ザイオンス効果,engineer
-2157,大ピンチ法則かるた,61,か,興味のある話しか耳に入らない,Only the topics you care about actually get heard.,カクテルパーティー効果,engineer
-2158,大ピンチ法則かるた,81,ば,みんなが使うから採用,It gets adopted just because everyone else uses it.,バンドワゴン効果,engineer
-2159,大ピンチ法則かるた,75,し,人気だけで技術選定,The tech choice is made on popularity alone.,社会的証明,engineer
-2160,大ピンチ法則かるた,78,あ,最初の数字から離れられない,Nobody can move past the first number they heard.,アンカリング効果,engineer
-2161,大ピンチ法則かるた,98,ま,本番だけ、なぜか落ちる,It only ever crashes in production.,マーフィーの法則,engineer
-2162,大ピンチ法則かるた,59,ふ,操作ミスで重大事故,A simple mistake causes a serious incident.,フールプルーフ,engineer
-2163,大ピンチ法則かるた,56,お,ボタンを押したら予想外の動作,Pressing the button does something unexpected.,驚き最小の原則,engineer
-2164,大ピンチ法則かるた,43,で,初期設定のまま本番投入,It ships to production with the default settings untouched.,デフォルト効果,engineer
-2165,大ピンチ法則かるた,47,W,同じコードを何度もコピペ,The same code gets copy-pasted over and over.,WET,engineer
-2166,大ピンチ法則かるた,87,し,既存ライブラリを無視して自作,An existing library gets ignored in favor of building it from scratch.,車輪の再発明,engineer
-2167,大ピンチ法則かるた,84,ゆ,少しずつ悪化して手遅れ,It gets gradually worse until it's too late.,茹でガエル,engineer
-2168,大ピンチ法則かるた,6,や,本題に入れず一日終了,The whole day goes by without ever reaching the actual task.,ヤクの毛刈り,engineer
-2169,大ピンチ法則かるた,29,い,協力が集まらず企画倒れ,Nobody chips in and the plan falls apart.,石のスープ,engineer
-2170,大ピンチ法則かるた,77,ぱ,締切まで仕事が膨らみ続ける,Work keeps expanding to fill the time until the deadline.,パーキンソンの法則,engineer
-2171,大ピンチ法則かるた,5,き,改善を後回しにして疲弊,Putting off the improvement leads to burnout.,木こりのジレンマ,engineer
-2172,大ピンチ法則かるた,39,ぱ,重要な議題ほど後回し,"The more important the topic, the more it gets postponed.",パーキンソンの凡俗法則,engineer
-2173,大ピンチ法則かるた,66,こ,やめ時を失って炎上継続,Missing the moment to quit keeps the fire burning.,コンコルド効果,engineer
-2174,大ピンチ法則かるた,36,ふ,小さな依頼が大仕事になる,A small favor turns into a huge job.,フットインザドア効果,engineer
-2175,大ピンチ法則かるた,76,へ,借りを返すため残業,Working overtime just to repay a favor.,返報性の法則,engineer
-2176,大ピンチ法則かるた,72,け,偉い人の一声で仕様変更,One word from someone senior changes the spec.,権威性の法則,engineer
-2177,大ピンチ法則かるた,9,り,良い話だけして信用を失う,Only mentioning the upside costs you trust.,両面提示の法則,engineer
+id,category,level,kana,phrase,phrase_en,answer,group,explanation
+3,大ピンチずかん,77,え,エスカレーターが　ぎゃくだった,The escalator was going the opposite way.,-,kids,-
+4,大ピンチずかん,20,あ,アイスが　とけてきた,The ice cream started melting.,-,kids,-
+5,大ピンチずかん,4,へ,へんな　ひやけを　した,Made a strange face.,-,kids,-
+6,大ピンチずかん,30,た,たんじょうびケーキが　たおれて　イチゴが　ころがった,The birthday cake fell over and the strawberries rolled away.,-,kids,-
+7,大ピンチずかん,23,ご,ごはんつぶを　ふんだ,Stepped on a grain of rice.,-,kids,-
+8,大ピンチずかん,21,お,おふろの　ごみが　すくえない,Can't scoop the debris out of the bathtub.,-,kids,-
+9,大ピンチずかん,18,ふ,ふたが　ない,There is no lid.,-,kids,-
+10,大ピンチずかん,6,て,テープの　はしが　みつからない,Can't find the end of the tape.,-,kids,-
+11,大ピンチずかん,28,え,えだまめが　とんだ,The edamame flew away.,-,kids,-
+12,大ピンチずかん,24,か,カップめんの　おゆが　たりない,Not enough hot water for the cup noodles.,-,kids,-
+13,大ピンチずかん,68,う,うんてんしている　くるまのなかに　クモが　でてきた,There is a big spider in the car while driving.,-,kids,-
+14,大ピンチずかん,35,ゆ,ゆでたまごが　ボロボロ,The boiled egg is falling apart.,-,kids,-
+15,大ピンチずかん,5,す,ストローが　とれない,Can't take out the straw.,-,kids,-
+16,大ピンチずかん,27,う,「う」の　もじが　はんたいだった,The letter 'u' was backwards.,-,kids,-
+17,大ピンチずかん,19,け,おちたけしゴムがみつからない,Can't find the dropped eraser.,-,kids,-
+18,大ピンチずかん,17,し,しょうゆをいれすぎた,Poured too much soy sauce.,-,kids,-
+19,大ピンチずかん,34,し,シャワーがみつからない,Can't find the shower.,-,kids,-
+20,大ピンチずかん,3,こ,こおりがしたにくっついた,The ice stuck to my tongue.,-,kids,-
+21,大ピンチずかん,26,た,たんじょうびケーキがたおれそう,The birthday cake is about to fall.,-,kids,-
+22,大ピンチずかん,22,じ,じゅうでんができていなかった,It wasn't charged.,-,kids,-
+23,大ピンチずかん,14,し,シャボンえきをすった,Accidentally inhaled the bubble solution.,-,kids,-
+24,大ピンチずかん,33,け,ケチャップがとんだ,Ketchup splattered.,-,kids,-
+25,大ピンチずかん,31,ぽ,ポケットからすながたくさんでてきた,A lot of sand came out of the pocket.,-,kids,-
+26,大ピンチずかん,25,せ,せんたくきのうしろにくつしたがおちた,A sock fell behind the washing machine.,-,kids,-
+27,大ピンチずかん,90,ふ,フンをふんだ,Stepped on poop.,-,kids,-
+28,大ピンチずかん,55,い,いおうとしていたことをわすれた,Forgot what I was about to say.,-,kids,-
+29,大ピンチずかん,46,に,にくがきれない,Can't cut the meat.,-,kids,-
+30,大ピンチずかん,39,た,たんじょうびケーキのろうそくがきえない,The birthday cake candles won't go out.,-,kids,-
+32,大ピンチずかん,54,れ,れいとうこがあかない,The freezer won't open.,-,kids,-
+33,大ピンチずかん,48,ふ,ふくの　タグが　きになって　しかたがない,The loose thread on my clothes is bothering me.,-,kids,-
+34,大ピンチずかん,43,し,しゅくだいノートと　じゆうちょうをまちがえた,Confused the homework notebook with the sketchbook.,-,kids,-
+35,大ピンチずかん,38,ふ,ふたがしまらない,The lid won't close.,-,kids,-
+36,大ピンチずかん,32,め,めんつゆがすごくあまった,A lot of noodle dipping sauce was left over.,-,kids,-
+37,大ピンチずかん,53,な,ながしのみずがスプーンではねた,The water in the sink splashed off the spoon.,-,kids,-
+38,大ピンチずかん,49,べ,べんざをあけたまますわった,Sat down with the toilet seat up.,-,kids,-
+39,大ピンチずかん,37,あ,アメリカンドッグがまわる,The corn dog is spinning.,-,kids,-
+40,大ピンチずかん,76,ね,ねむれない,Can't sleep.,-,kids,-
+41,大ピンチずかん,47,し,シャンプーがめにはいった,Got shampoo in my eyes.,-,kids,-
+42,大ピンチずかん,51,ば,バッグのなかですいとうがもれた,The water bottle leaked inside the bag.,-,kids,-
+43,大ピンチずかん,56,な,なまえがおもいだせない,Can't remember the name.,-,kids,-
+44,大ピンチずかん,64,き,きんじょの　おばさんに　なまえを　いつも　まちがえられる,The neighborhood lady has been getting my name wrong for a long time.,-,kids,-
+45,大ピンチずかん,50,お,おゆがない,There is no hot water.,-,kids,-
+46,大ピンチずかん,45,ど,ドアをあけられてさむい,Someone opened the door and it's cold.,-,kids,-
+47,大ピンチずかん,40,せ,せんせいのメガネがとんだ,The teacher's glasses flew off.,-,kids,-
+48,大ピンチずかん,36,ほ,ほねを　とるのに　しっぱいして　みが　くずれた,It became a mess while I was trying to remove the bones.,-,kids,-
+49,大ピンチずかん,29,ぎ,ぎゅうにゅうがこぼれた,The milk spilled.,-,kids,-
+50,大ピンチずかん,96,か,かさがうらがえった,The umbrella turned inside out.,-,kids,-
+51,大ピンチずかん,97,じ,じてんしゃがドミノだおし,The bicycles fell over like dominoes.,-,kids,-
+52,大ピンチずかん,98,お,おもったよりみじかくなった,It became shorter than I thought.,-,kids,-
+53,大ピンチずかん,99,ね,ネコがついてくる,A cat is following me.,-,kids,-
+54,大ピンチずかん,100,ど,どしゃぶりなのにかさがない,It's pouring rain but I don't have an umbrella.,-,kids,-
+55,大ピンチずかん,58,れ,れいとうこがしまらない,The freezer won't close.,-,kids,-
+56,大ピンチずかん,59,さ,さげたあたまの　いきおいで　ランドセルの　なかみが　ぜんぶとびだした,Everything fell out of my backpack when I bowed to say goodbye.,-,kids,-
+57,大ピンチずかん,84,ま,まいご,I'm lost.,-,kids,-
+58,大ピンチずかん,82,か,かいものがながい,Shopping is taking a long time.,-,kids,-
+59,大ピンチずかん,81,じ,じてんしゃにハチがとまっている,A bee is sitting on the bicycle.,-,kids,-
+60,大ピンチずかん,60,せ,せんせいに　おかあさんといってしまった,I accidentally called my teacher 'Mom'.,-,kids,-
+61,大ピンチずかん,61,ぎ,ギターのなかにおかしがおちた,A snack fell inside the guitar.,-,kids,-
+62,大ピンチずかん,62,ず,ズボンのゴムがきれた,The elastic in my pants snapped.,-,kids,-
+63,大ピンチずかん,63,さ,さなぎからかえった　カブトムシが　まよなかに　へやじゅうを　とびまわっている,The beetle that emerged from its pupa escaped at night and is flying around.,-,kids,-
+64,大ピンチずかん,57,け,けしゴムに　ついた　えんぴつのしんの　あとが　けすたびに　うつる,The pencil lead stuck in the eraser leaves marks when I erase.,-,kids,-
+65,大ピンチずかん,89,お,おきられない,Can't wake up.,-,kids,-
+66,大ピンチずかん,91,で,かばしらに　じてんしゃで　つっこんだ,Crashed my bicycle into a mosquito swarm.,-,kids,-
+67,大ピンチずかん,93,と,トイレがつまった,The toilet is clogged.,-,kids,-
+68,大ピンチずかん,94,お,おかあさんがイライラしている,Mom is getting irritated.,-,kids,-
+69,大ピンチずかん,95,お,プレゼントをわすれた,Forgot the present.,-,kids,-
+70,大ピンチずかん,86,し,しんしつに　だれかいる,Someone is in the bedroom.,-,kids,-
+71,大ピンチずかん,87,く,クモのすにかかった,Got caught in a spider web.,-,kids,-
+72,大ピンチずかん,88,と,トイレにおおきなガがとまっている,A large moth is sitting in the toilet.,-,kids,-
+73,大ピンチずかん,9,し,しゃっくりがとまらない,Can't stop hiccuping.,-,kids,-
+74,大ピンチずかん,16,わ,わりばしがうまくわれない,Can't split the chopsticks properly.,-,kids,-
+75,大ピンチずかん,11,ご,ゴミばこがやまもり,The trash can is overflowing.,-,kids,-
+76,大ピンチずかん,70,お,おなかがすいてうごけない,So hungry I can't move.,-,kids,-
+77,大ピンチずかん,67,ま,まちがえてシャワーがでた,The shower came on by mistake.,-,kids,-
+78,大ピンチずかん,13,け,パンがくろこげ,The bread is burnt to a crisp.,-,kids,-
+79,大ピンチずかん,10,け,けずりかすいれがはいってなかった,The pencil shavings container wasn't in.,-,kids,-
+80,大ピンチずかん,71,ふ,ふとんのなかでおならがでた,Farted under the covers.,-,kids,-
+81,大ピンチずかん,69,じ,じぶんのいえでトイレがつまった,The toilet at my own house is clogged.,-,kids,-
+82,大ピンチずかん,8,あ,あたまにつけたわゴムがとれない,Can't remove the rubber band I put on my head.,-,kids,-
+83,大ピンチずかん,12,や,ビニールぶくろがめくれない,Can't open the plastic bag.,-,kids,-
+84,大ピンチずかん,15,し,しょくばんを　スライスしたら　ぺったんこに　つぶれた,The bread got squashed while I was trying hard to slice it.,-,kids,-
+85,大ピンチずかん,7,ぺ,ペンがしみてつくえについた,The pen leaked onto the desk.,-,kids,-
+86,大ピンチずかん,80,や,やっぱりさむかった,It was cold after all.,-,kids,-
+87,大ピンチずかん,74,と,トイレのかみがない,There is no toilet paper.,-,kids,-
+88,大ピンチずかん,73,わ,ワサビいりだった,It had wasabi in it.,-,kids,-
+89,大ピンチずかん,72,お,おべんとうをわすれた,Forgot my lunch box.,-,kids,-
+90,大ピンチずかん,66,あ,あしがつちだらけ,Feet are covered in mud.,-,kids,-
+91,大ピンチずかん,65,は,ハエがじぶんにばかりとまる,Flies only land on me.,-,kids,-
+92,大ピンチずかん,83,い,イヌがすごくなめてくる,The dog is licking me a lot.,-,kids,-
+93,大ピンチずかん,75,し,しらないひとのてをにぎっていた,Was holding a stranger's hand.,-,kids,-
+94,大ピンチずかん,85,し,シロツメクサで　つくった　かんむりに　アブラムシが　いっぱいついていた,"When I looked closely at the clover crown, it was full of aphids.",-,kids,-
+95,大ピンチずかん,79,ば,バッグにアリがあつまってきた,Ants gathered on the bag.,-,kids,-
+96,大ピンチずかん,78,し,しんしつの　てんじょうに　ひとのかおみたいな　もようが　ある,The wood grain on the bedroom ceiling started to look like a person's face.,-,kids,-
+97,大ピンチずかん,41,や,やすみじかんに　おいた　すいとうを　とりに　いくのを　わすれた,The water bottle I left during recess is still there.,-,kids,-
+98,大ピンチずかん,42,ご,ごはんが　たりない,Not enough food.,-,kids,-
+99,大ピンチずかん,44,は,はなしを　きいてなかった,Wasn't listening.,-,kids,-
+100,大ピンチずかん,2,の,のんだガムに　まだあじが　たくさんのこっていた,Swallowed the gum; it still had a lot of flavor left.,-,kids,-
+101,大ピンチずかん,52,む,むかしの　おにぎりが　でてきた,An old rice ball appeared.,-,kids,-
+102,国旗王,上級,し,人口密度が高い,High population density.,-,kids,-
+103,国旗王,上級,ひ,一人当たりGDPが高い,High GDP per capita.,-,kids,-
+104,国旗王,上級,し,首都 最東,Easternmost capital.,-,kids,-
+105,国旗王,上級,し,首都が最北,Northernmost capital.,-,kids,-
+106,国旗王,上級,は,排他的経済水域,Exclusive Economic Zone.,-,kids,-
+107,国旗王,上級,く,軍事費が最小,Smallest military expenditure.,-,kids,-
+108,国旗王,上級,へ,平均寿命が短い,Short average life expectancy.,-,kids,-
+109,国旗王,初級,し,人口が多い,Large population.,-,kids,-
+110,国旗王,初級,め,面積が最小,Smallest area.,-,kids,-
+111,国旗王,初級,は,排他的経済水域が最小,Smallest Exclusive Economic Zone.,-,kids,-
+112,国旗王,上級,さ,最高地点が高い,Highest point is high.,-,kids,-
+113,国旗王,初級,こ,国内総生産GDPが低い,Low GDP.,-,kids,-
+114,国旗王,初級,し,人口が少ない,Small population.,-,kids,-
+115,国旗王,初級,せ,正式国名が長い,Long official country name.,-,kids,-
+116,国旗王,上級,く,軍事費が大きい,Large military expenditure.,-,kids,-
+117,国旗王,上級,さ,最高地点が低い,Highest point is low.,-,kids,-
+118,国旗王,初級,こ,国内総生産GDPが高い,High GDP.,-,kids,-
+119,国旗王,初級,せ,正式国名が短い,Short official country name.,-,kids,-
+120,国旗王,初級,め,面積が大きい,Large area.,-,kids,-
+121,国旗王,上級,へ,平均寿命が長い,Long average life expectancy.,-,kids,-
+122,国旗王,初級,ひ,一人当たりGDPが低い,Low GDP per capita.,-,kids,-
+123,国旗王,初級,し,人口密度が低い,Low population density.,-,kids,-
+124,国旗王,初級,せ,正式国名 五十音順 アに近い,Official name closest to 'A' in Japanese syllabary.,-,kids,-
+125,国旗王,初級,し,首都が最南,Southernmost capital.,-,kids,-
+126,おばけかるた,-,ふ,ふでこぞうが　ひとふでがき,Fudekozo draws with a single stroke.,ふでこぞう,kids,-
+127,おばけかるた,-,ね,ねこまたも　ねがおはかわいい,Even Nekomata looks cute when sleeping.,ねこまた,kids,-
+128,おばけかるた,-,ち,ちょうちんぶらり　こっちへ　くるぞ,Chochin-burari is coming this way!,ちょうちんぶらり,kids,-
+129,おばけかるた,-,た,たまごがわれて　てんぐがうまれた,An egg cracked and a Tengu was born.,てんぐ,kids,-
+130,おばけかるた,-,け,けむくじゃらな　うでだ　まけるな！,"It's a hairy arm, don't lose!",けむくじゃらなうで,kids,-
+131,おばけかるた,-,く,くずかごからくろいてが！！！　きゃっ！！！,A black hand from the wastebasket!!! Kya!!!,くろいて,kids,-
+132,おばけかるた,-,あ,あめふりこぞうが　びちゃびちゃあるく,Amefuri-kozo walks with a squish-squish.,あめふりこぞう,kids,-
+133,おばけかるた,-,ひ,ひとつめのくには　ひとつめだらけだってさ,They say the one-eyed country is full of one-eyes.,ひとつめ,kids,-
+134,おばけかるた,-,ぬ,ぬらりとわらう　ぬっぺっぽう,Nureppon smiles eerily.,ぬっぺっぽう,kids,-
+135,おばけかるた,-,つ,つきよにでていくつく　もがみ,Tsuku-mogami goes out on a moonlit night.,つくもがみ,kids,-
+136,おばけかるた,-,そ,そろってあるく　ぞうりのおばけ,Zori ghosts walk in pairs.,ぞうりのおばけ,kids,-
+137,おばけかるた,-,こ,こんばんは～　どろどろどろどろ～,Good evening~ Doro-doro-doro-doro~,ゆうれい,kids,-
+138,おばけかるた,-,き,きゅうびのきつねは　ばけるめいじん,The nine-tailed fox is a master of disguise.,きゅうびのきつね,kids,-
+139,おばけかるた,-,い,いったんもめんは　そらとべていいなあ,"Ittan-momen, it's nice to fly in the sky.",いったんもめん,kids,-
+140,おばけかるた,-,は,はたらけはたらけ　おばけもはたらけ,"Work, work, ghosts also work.",おばけ,kids,-
+141,おばけかるた,-,に,にっこりわらう　にかいのおんな,The woman on the second floor smiles.,にかいのおんな,kids,-
+142,おばけかるた,-,て,てんぐのはながおれては　かわいそう,It would be pitiful if Tengu's nose broke.,てんぐ,kids,-
+143,おばけかるた,-,せ,せんすだって　すてればばける,Even a fan will transform if you throw it away.,せんす,kids,-
+144,おばけかるた,-,さ,さかさくびは　ぺろぺろなめる,Sakasa-kubi licks with a flick-flick.,さかさくび,kids,-
+145,おばけかるた,-,か,かあさんかっぱ　とこどものかっぱ,Mother Kappa and baby Kappa.,かっぱ,kids,-
+146,おばけかるた,-,う,うみぼうずのがっこう　せいとをぼしゅう,Umibozu's school is recruiting students.,うみぼうず,kids,-
+147,おばけかるた,-,の,のんきなのぶすま　のんびりとんだ,Carefree Nobusuma flew leisurely.,のぶすま,kids,-
+148,おばけかるた,-,な,なきなきかえった　ちいさなゆうれい,A small ghost returned crying.,ちいさなゆうれい,kids,-
+149,おばけかるた,-,と,とらがねてたら　かみなりどしーん！！,"If a tiger sleeps, lightning strikes with a boom!!",かみなり,kids,-
+150,おばけかるた,-,す,すりばちこぞうは　なにすってるの？,What is Suribachi-kozo grinding?,すりばちこぞう,kids,-
+151,おばけかるた,-,し,しろくてみえない　ゆきのひのゆうれい,A white and invisible ghost on a snowy day.,ゆきのひのゆうれい,kids,-
+152,おばけかるた,-,お,おにもおじいさんになる,Even an ogre grows old.,おに,kids,-
+153,おばけかるた,-,え,えだをもやしたら　えんえんらがでたぞ,"When I burned a branch, Enenra came out!",えんえんら,kids,-
+154,おばけかるた,-,る,るすばんしてるは　ぶるぶるひとり,"Staying home alone, trembling.",ゆうれい,kids,-
+155,おばけかるた,-,り,りゅうがいねむり　そらからおちる,"A dragon sleeping, falling from the sky.",りゅう,kids,-
+156,おばけかるた,-,む,むじなもばけたが　ちょっとむりだった,"Mujina tried to transform, but it was a bit impossible.",むじな,kids,-
+157,おばけかるた,-,み,みこしにゅうどう　みかけよりよわい,"Mikoshi-Nyudo, weaker than he looks.",みこしにゅうどう,kids,-
+158,おばけかるた,-,れ,れいぎただしい　ゆうれいもいる,There are polite ghosts too.,ゆうれい,kids,-
+159,おばけかるた,-,ら,らしょうもんの　おにはらんぼうだ,The demon of Rashomon is wild.,らしょうもんのおに,kids,-
+160,おばけかるた,-,め,めだまをとられた　ひとつめこぞう,A one-eyed monster whose eye was taken.,ひとつめこぞう,kids,-
+161,おばけかるた,-,ま,まくらがえしは　まいばんうるさい,Makura-gaeshi is noisy every night.,まくらがえし,kids,-
+162,おばけかるた,-,ろ,ろくろくねなかった　ろくろっくび,Rokurokubi who didn't sleep at all.,ろくろっくび,kids,-
+163,おばけかるた,-,よ,よみちをこわがる　よわむしにゅうどう,A timid Nyudo who is scared of night roads.,よわむしにゅうどう,kids,-
+164,おばけかるた,-,も,もりんじのかまは　たぬきがばけた,Morinji's kettle was a transformed raccoon dog.,たぬき,kids,-
+165,おばけかるた,-,ほ,ほうきのおばけは　ほめてやろう,Let's praise the broom ghost.,ほうきのおばけ,kids,-
+166,おばけかるた,-,を,「あしをけして　てをまえに」ゆうれいのおけいこ,"Delete legs, hands forward - a ghost's practice.",ゆうれい,kids,-
+167,おばけかるた,-,わ,わ、にゅうどうだ　わぁーっこわい！,"Oh, it's a Nyudo! Ahh, scary!",にゅうどう,kids,-
+168,おばけかるた,-,ゆ,ゆきおんな　おゆにはいってとけちゃった,Yuki-onna went into hot water and melted.,ゆきおんな,kids,-
+169,おばけかるた,-,や,やなぎのしたで　ゆうれいけんか,Ghosts fighting under a willow tree.,ゆうれい,kids,-
+170,おばけかるた,-,へ,へびよりこわい　ろくろっくび,"Rokurokubi, scarier than a snake.",ろくろっくび,kids,-
+171,いろはかるた,-,ま,嘘から出たまこと,A lie can sometimes turn into the truth,でたらめに言ったことが、偶然にも事実になってしまうこと,kids,-
+172,いろはかるた,-,こ,弘法にも筆の誤り,Even experts make mistakes,どんな名人でも失敗することがあるというたとえ,kids,-
+173,いろはかるた,-,あ,得手に帆を揚げる,To take advantage of a good opportunity,物事を行うのに絶好の機会を得ること,kids,-
+174,いろはかるた,-,あ,味なもの縁は異なもの,Romance works in mysterious ways,男女の仲は理屈では説明できないものだということ,kids,-
+175,いろはかるた,-,ぞ,芋の煮えたも御存じない,Completely clueless,物事の様子がまったく分からない人をからかう言い方,kids,-
+176,いろはかるた,-,て,文はやりたし書く手は持たぬ,Wanting to write a letter but lacking the skill,やりたい気持ちはあるが能力が伴わず困っていること,kids,-
+177,いろはかるた,-,す,亭主の好きな赤烏帽子,One must go along with the head of the household,家長の好みには家族も従うべきだという考え,kids,-
+178,いろはかるた,-,し,知らぬが仏,Ignorance is bliss,知らなければ悩まずにすむこともあるということ,kids,-
+179,いろはかるた,-,は,背に腹はかえられぬ,Needs must when driven,大きな目的のためには多少の犠牲は仕方ないということ,kids,-
+180,いろはかるた,-,げ,芸は身を助ける,A skill will always help you,身につけた技や芸が困ったときに役立つこと,kids,-
+181,いろはかるた,-,の,喉元過ぎれば熱さを忘れる,"Once the pain is gone, the lesson is forgotten",苦しい経験をしても時間がたつと忘れてしまうこと,kids,-
+182,いろはかるた,-,あ,頭隠して尻隠さず,Trying to hide something but failing,一部しか隠していないのに全部隠したつもりでいること,kids,-
+183,いろはかるた,-,み,身から出た錆,You reap what you sow,自分のした悪い行いの結果で自分が苦しむこと,kids,-
+184,いろはかるた,-,も,門前の小僧習わぬ経を読む,You learn things naturally by exposure,日頃見聞きしているうちに自然と身につくことがある,kids,-
+185,いろはかるた,-,お,鬼に金棒,Adding strength to the strong,強いものがさらに力を得て一層強くなること,kids,-
+186,いろはかるた,-,ま,負けるが勝ち,Sometimes losing leads to winning,一歩引いた方が結果的に有利になることがある,kids,-
+187,いろはかるた,-,さ,三遍回って煙草にしょ,Take time and be careful,急がず慎重に行動することが大切だということ,kids,-
+188,いろはかるた,-,め,目の上のたん瘤,A thorn in one’s side,自分にとって邪魔で目障りな存在のたとえ,kids,-
+189,いろはかるた,-,ひ,貧乏暇なし,The poor have no leisure,貧しい人ほど仕事に追われ時間の余裕がないこと,kids,-
+190,いろはかるた,-,く,臭い物に蓋をする,To cover up an inconvenient truth,都合の悪いことを一時的に隠そうとすること,kids,-
+191,いろはかるた,-,や,安物買いの銭失い,Buying cheap ends up costing more,安い物を買うとかえって損をすること,kids,-
+192,いろはかるた,-,き,聞いて極楽見て地獄,Hearing and seeing are very different,聞くのと実際に見るのとでは大きな違いがあること,kids,-
+193,いろはかるた,-,ゆ,油断大敵,Carelessness is dangerous,油断すると失敗や災難を招くということ,kids,-
+194,いろはかるた,-,い,犬も歩けば棒に当たる,Every action brings some result,行動すれば良くも悪くも何かが起こるということ,kids,-
+195,いろはかるた,-,ら,楽あれば苦あり,Life has ups and downs,人生には楽しいことと苦しいことの両方がある,kids,-
+196,いろはかるた,-,む,無理が通れば道理が引っ込む,"When force prevails, reason disappears",無茶がまかり通る世の中では道理が通らなくなる,kids,-
+197,いろはかるた,-,と,年寄りの冷や水,An old person acting recklessly,年齢を考えず無理な振る舞いをすること,kids,-
+198,いろはかるた,-,す,粋は身を食う,Showing off can ruin you,気取った振る舞いが身を滅ぼすことがある,kids,-
+199,いろはかるた,-,き,京の夢大阪の夢,Dreams are fleeting and strange,夢というものはとりとめなく不思議なものだということ,kids,-
+200,いろはかるた,-,へ,下手の長談義,The unskilled talk the longest,下手な人ほど話が長くなること,kids,-
+201,いろはかるた,-,ろ,論より証拠,Proof is better than argument,理屈よりも実際の証拠が大切だということ,kids,-
+202,いろはかるた,-,く,くたびれ儲け,All effort and no reward,苦労したわりに何の得もないこと,kids,-
+203,いろはかるた,-,に,憎まれっ子世にはばかる,The disliked often survive well,憎まれるような人ほど世渡りがうまいこと,kids,-
+204,いろはかるた,-,ち,塵も積もれば山となる,Many small things add up,小さなことでも積み重なれば大きな成果になる,kids,-
+205,いろはかるた,-,こ,律義者の子だくさん,Honest people tend to have many children,律義な人は家庭を大切にし子どもが多くなるという考え,kids,-
+206,いろはかるた,-,ぬ,盗人の昼寝,Even bad acts have consequences,どんな行いにも必ず報いがあるということ,kids,-
+207,いろはかるた,-,は,花より団子,Practicality over appearance,見た目より実利を重んじること,kids,-
+208,いろはかるた,-,る,瑠璃も玻璃も照らせば光る,True talent shines anywhere,才能のある人はどんな環境でも力を発揮する,kids,-
+209,いろはかるた,-,な,泣きっ面に蜂,Misfortune never comes alone,不運なときにさらに不幸が重なること,kids,-
+210,いろはかるた,-,あ,葦の髄から天井のぞく,Judging the whole from a tiny part,わずかな知識で全て分かったつもりになること,kids,-
+211,いろはかるた,-,か,蛙の面に水,Completely unfazed,何をされても平然としていること,kids,-
+212,いろはかるた,-,わ,破れ鍋に綴じ蓋,Every pot has its lid,どんな人にもふさわしい相手がいるということ,kids,-
+213,いろはかるた,-,を,老いては子に従え,Let the younger generation lead,年を取ったら若い者の意見に従うのがよい,kids,-
+214,いろはかるた,-,ね,念には念を入れよ,Double-check everything,十分注意した上でさらに注意を重ねること,kids,-
+215,いろはかるた,-,た,旅は道連れ世は情け,Life is about helping each other,人は助け合って生きていくものだということ,kids,-
+216,いろはかるた,-,れ,良薬は口に苦し,Good medicine tastes bitter,忠告は耳に痛いが自分のためになる,kids,-
+217,いろはかるた,-,そ,総領の甚六,The eldest son is often naive,長男は大事に育てられ世間知らずになりがちだということ,kids,-
+218,いろはかるた,-,つ,月とすっぽん,Like night and day,似ているようで実際は大きな違いがある,kids,-
+219,いろはかるた（意味）,-,ま,でたらめに言ったことが、偶然にも事実になってしまうこと,A lie can sometimes turn into the truth,嘘から出たまこと,kids,-
+220,いろはかるた（意味）,-,こ,どんな名人でも失敗することがあるというたとえ,Even experts make mistakes,弘法にも筆の誤り,kids,-
+221,いろはかるた（意味）,-,あ,物事を行うのに絶好の機会を得ること,To take advantage of a good opportunity,得手に帆を揚げる,kids,-
+222,いろはかるた（意味）,-,あ,男女の仲は理屈では説明できないものだということ,Romance works in mysterious ways,味なもの縁は異なもの,kids,-
+223,いろはかるた（意味）,-,ぞ,物事の様子がまったく分からない人をからかう言い方,Completely clueless,芋の煮えたも御存じない,kids,-
+224,いろはかるた（意味）,-,て,やりたい気持ちはあるが能力が伴わず困っていること,Wanting to write a letter but lacking the skill,文はやりたし書く手は持たぬ,kids,-
+225,いろはかるた（意味）,-,す,家長の好みには家族も従うべきだという考え,One must go along with the head of the household,亭主の好きな赤烏帽子,kids,-
+226,いろはかるた（意味）,-,し,知らなければ悩まずにすむこともあるということ,Ignorance is bliss,知らぬが仏,kids,-
+227,いろはかるた（意味）,-,は,大きな目的のためには多少の犠牲は仕方ないということ,Needs must when driven,背に腹はかえられぬ,kids,-
+228,いろはかるた（意味）,-,げ,身につけた技や芸が困ったときに役立つこと,A skill will always help you,芸は身を助ける,kids,-
+229,いろはかるた（意味）,-,の,苦しい経験をしても時間がたつと忘れてしまうこと,"Once the pain is gone, the lesson is forgotten",喉元過ぎれば熱さを忘れる,kids,-
+230,いろはかるた（意味）,-,あ,一部しか隠していないのに全部隠したつもりでいること,Trying to hide something but failing,頭隠して尻隠さず,kids,-
+231,いろはかるた（意味）,-,み,自分のした悪い行いの結果で自分が苦しむこと,You reap what you sow,身から出た錆,kids,-
+232,いろはかるた（意味）,-,も,日頃見聞きしているうちに自然と身につくことがある,You learn things naturally by exposure,門前の小僧習わぬ経を読む,kids,-
+233,いろはかるた（意味）,-,お,強いものがさらに力を得て一層強くなること,Adding strength to the strong,鬼に金棒,kids,-
+234,いろはかるた（意味）,-,ま,一歩引いた方が結果的に有利になることがある,Sometimes losing leads to winning,負けるが勝ち,kids,-
+235,いろはかるた（意味）,-,さ,急がず慎重に行動することが大切だということ,Take time and be careful,三遍回って煙草にしょ,kids,-
+236,いろはかるた（意味）,-,め,自分にとって邪魔で目障りな存在のたとえ,A thorn in one’s side,目の上のたん瘤,kids,-
+237,いろはかるた（意味）,-,ひ,貧しい人ほど仕事に追われ時間の余裕がないこと,The poor have no leisure,貧乏暇なし,kids,-
+238,いろはかるた（意味）,-,く,都合の悪いことを一時的に隠そうとすること,To cover up an inconvenient truth,臭い物に蓋をする,kids,-
+239,いろはかるた（意味）,-,や,安い物を買うとかえって損をすること,Buying cheap ends up costing more,安物買いの銭失い,kids,-
+240,いろはかるた（意味）,-,き,聞くのと実際に見るのとでは大きな違いがあること,Hearing and seeing are very different,聞いて極楽見て地獄,kids,-
+241,いろはかるた（意味）,-,ゆ,油断すると失敗や災難を招くということ,Carelessness is dangerous,油断大敵,kids,-
+242,いろはかるた（意味）,-,い,行動すれば良くも悪くも何かが起こるということ,Every action brings some result,犬も歩けば棒に当たる,kids,-
+243,いろはかるた（意味）,-,ら,人生には楽しいことと苦しいことの両方がある,Life has ups and downs,楽あれば苦あり,kids,-
+244,いろはかるた（意味）,-,む,無茶がまかり通る世の中では道理が通らなくなる,"When force prevails, reason disappears",無理が通れば道理が引っ込む,kids,-
+245,いろはかるた（意味）,-,と,年齢を考えず無理な振る舞いをすること,An old person acting recklessly,年寄りの冷や水,kids,-
+246,いろはかるた（意味）,-,す,気取った振る舞いが身を滅ぼすことがある,Showing off can ruin you,粋は身を食う,kids,-
+247,いろはかるた（意味）,-,き,夢というものはとりとめなく不思議なものだということ,Dreams are fleeting and strange,京の夢大阪の夢,kids,-
+248,いろはかるた（意味）,-,へ,下手な人ほど話が長くなること,The unskilled talk the longest,下手の長談義,kids,-
+249,いろはかるた（意味）,-,ろ,理屈よりも実際の証拠が大切だということ,Proof is better than argument,論より証拠,kids,-
+250,いろはかるた（意味）,-,く,苦労したわりに何の得もないこと,All effort and no reward,くたびれ儲け,kids,-
+251,いろはかるた（意味）,-,に,憎まれるような人ほど世渡りがうまいこと,The disliked often survive well,憎まれっ子世にはばかる,kids,-
+252,いろはかるた（意味）,-,ち,小さなことでも積み重なれば大きな成果になる,Many small things add up,塵も積もれば山となる,kids,-
+253,いろはかるた（意味）,-,こ,律義な人は家庭を大切にし子どもが多くなるという考え,Honest people tend to have many children,律義者の子だくさん,kids,-
+254,いろはかるた（意味）,-,ぬ,どんな行いにも必ず報いがあるということ,Even bad acts have consequences,盗人の昼寝,kids,-
+255,いろはかるた（意味）,-,は,見た目より実利を重んじること,Practicality over appearance,花より団子,kids,-
+256,いろはかるた（意味）,-,る,才能のある人はどんな環境でも力を発揮する,True talent shines anywhere,瑠璃も玻璃も照らせば光る,kids,-
+257,いろはかるた（意味）,-,な,不運なときにさらに不幸が重なること,Misfortune never comes alone,泣きっ面に蜂,kids,-
+258,いろはかるた（意味）,-,あ,わずかな知識で全て分かったつもりになること,Judging the whole from a tiny part,葦の髄から天井のぞく,kids,-
+259,いろはかるた（意味）,-,か,何をされても平然としていること,Completely unfazed,蛙の面に水,kids,-
+260,いろはかるた（意味）,-,わ,どんな人にもふさわしい相手がいるということ,Every pot has its lid,破れ鍋に綴じ蓋,kids,-
+261,いろはかるた（意味）,-,を,年を取ったら若い者の意見に従うのがよい,Let the younger generation lead,老いては子に従え,kids,-
+262,いろはかるた（意味）,-,ね,十分注意した上でさらに注意を重ねること,Double-check everything,念には念を入れよ,kids,-
+263,いろはかるた（意味）,-,た,人は助け合って生きていくものだということ,Life is about helping each other,旅は道連れ世は情け,kids,-
+264,いろはかるた（意味）,-,れ,忠告は耳に痛いが自分のためになる,Good medicine tastes bitter,良薬は口に苦し,kids,-
+265,いろはかるた（意味）,-,そ,長男は大事に育てられ世間知らずになりがちだということ,The eldest son is often naive,総領の甚六,kids,-
+266,いろはかるた（意味）,-,つ,似ているようで実際は大きな違いがある,Like night and day,月とすっぽん,kids,-
+267,百人一首,-,あ,あきのたの かりほのいおの とまをあらみ わがころもでは つゆにぬれつつ,"In the autumn field, in the temporary hut's rough rush-mats, my sleeves are getting wet with dew.",わがころもでは つゆにぬれつつ,kids,-
+268,百人一首,-,あ,あきかぜに たなびくくもの たえまより もれいづるつきの かげのさやけさ,"Through the rifts in the clouds trailing in the autumn wind, how clear the moonlight leaks out.",もれいづるつきの かげのさやけさ,kids,-
+269,百人一首,-,あ,あしびきの やまどりのをの しだりをの ながながしよを ひとりかもねむ,"Must I sleep alone through the long, long night, like the long, trailing tail of the mountain pheasant?",ながながしよを ひとりかもねむ,kids,-
+270,百人一首,-,あ,あまのはら ふりさけみれば かすがなる みかさのやまに いでしつきかも,"When I look out over the plain of heaven, is that the same moon that rose over Mount Mikasa in Kasuga?",みかさのやまに いでしつきかも,kids,-
+271,百人一首,-,あ,あわれとも いうべきひとは おもほえで みのいたずらに なりぬべきかな,"Since there is no one who might feel pity for me, I suppose I shall just pass away in vain.",みのいたずらに なりぬべきかな,kids,-
+272,百人一首,-,い,いまはただ おもひたえなむ とばかりを ひとづてならで いうよしもがな,Now I just want to give up my love; if only I could tell you this directly and not through others.,ひとづてならで いうよしもがな,kids,-
+273,百人一首,-,い,いまこむと いいしばかりに ながつきの ありあけのつきを まちいでつるかな,"Just because you said 'I'll come soon', I have waited until the morning moon of the long month appeared.",ありあけのつきを まちいでつるかな,kids,-
+274,百人一首,-,い,いろはにほへど ちりぬるを わがよたれぞ つねならむ,"Though flowers are fragrant, they will fall; in our world, who can remain forever?",わがよたれぞ つねならむ,kids,-
+275,百人一首,-,い,いのちながくは かたみにあはず ひとりして ものおもふよぞ ながかりける,"If I live long, we might not meet again; the night I spend alone in thought is so very long.",ものおもふよぞ ながかりける,kids,-
+276,百人一首,-,い,いにしへの ならのみやこの やへざくら けふここのへに にほひぬるかな,The eight-layered cherry blossoms of the ancient capital of Nara are fragrantly blooming today in the imperial palace.,けふここのへに にほひぬるかな,kids,-
+277,百人一首,-,う,うかりける ひとをはつせの やまおろしよ はげしかれとは いのらぬものを,"O mountain wind of Hatsuse, I did not pray for you to be so harsh, though she is cold to me.",はげしかれとは いのらぬものを,kids,-
+278,百人一首,-,う,うらみわび ほさぬそでだに あるものを こひにくちなむ なこそをしけれ,"I resent her and am weary; my sleeves never dry, and I fear my reputation will rot away in this love.",こひにくちなむ なこそをしけれ,kids,-
+279,百人一首,-,え,えにしあらば あはむとぞおもふ いざさらば わがなとひとは わすれざらなむ,"If there is fate, I believe we shall meet; now farewell, and may you not forget my name.",わがなとひとは わすれざらなむ,kids,-
+280,百人一首,-,お,おおえやま いくののみちの とおければ まだふみもみず あまのはしだて,The road to Ikuno over Mount Oe is so far that I have seen neither a letter nor Amanohashidate.,まだふみもみず あまのはしだて,kids,-
+281,百人一首,-,お,おくやまに もみぢふみわけ なくしかの こゑきくときぞ あきはかなしき,"When I hear the voice of the stag crying as he steps through the maple leaves deep in the mountains, autumn is truly sad.",こゑきくときぞ あきはかなしき,kids,-
+282,百人一首,-,か,かささぎの わたせるはしに おくしもの しろきをみれば よぞふけにける,"When I see the white frost on the bridge the magpies are said to have spread, I know the night has deepened.",しろきをみれば よぞふけにける,kids,-
+283,百人一首,-,か,かぜをいたみ いはうつなみの おのれのみ くだけてものを おもふころかな,"Like the waves breaking against the rocks in the fierce wind, I alone am broken as I think of my love.",くだけてものを おもふころかな,kids,-
+284,百人一首,-,き,きみがため はるののにいでて わかなつむ わがころもでに ゆきはふりつつ,"For your sake, I went out to the spring fields to pick young greens, while snow fell on my sleeves.",わがころもでに ゆきはふりつつ,kids,-
+285,百人一首,-,き,きみがため をしからざりし いのちさへ ながくもがなと おもひけるかな,"For your sake, I did not value my life, but now I wish it would be long.",ながくもがなと おもひけるかな,kids,-
+286,百人一首,-,く,くさもきも いろかはれども わたつみの なみのはなにぞ あきなかりける,"Though the colors of plants and trees change, there is no autumn in the flowers of the sea waves.",なみのはなにぞ あきなかりける,kids,-
+287,百人一首,-,く,くれなゐに みづくくるとは ききしかど あきぞこのはに まじりけるかな,"I heard that the water is dyed crimson, but it seems autumn has mixed into the leaves.",あきぞこのはに まじりけるかな,kids,-
+288,百人一首,-,こ,こころあてに をらばやをらむ はつしもの おきまどはせる しらぎくのはな,"If I were to pick them at random, I might pick the white chrysanthemums that the first frost has confused.",おきまどはせる しらぎくのはな,kids,-
+289,百人一首,-,こ,このたびは ぬさもとりあへず たむけやま もみぢのにしき かみのまにまに,"At this time, I could not even bring an offering; let the gods take the brocade of maple leaves on Mount Tamuke.",もみぢのにしき かみのまにまに,kids,-
+290,百人一首,-,さ,さびしさに やどをたちいでて ながむれば いづこもおなじ あきのゆふぐれ,"In my loneliness, I leave my house and look out; everywhere it is the same autumn evening.",いづこもおなじ あきのゆふぐれ,kids,-
+291,百人一首,-,し,しのぶれど いろにいでにけり わがこひは ものやおもふと ひとのとふまで,"Though I try to hide it, my love shows in my face, until people ask if I am lost in thought.",ものやおもふと ひとのとふまで,kids,-
+292,百人一首,-,す,すみのえの きしによるなみ よるさへや ゆめのかよひぢ ひとめよくらむ,"Like the waves approaching the shore of Suminoe, even at night do you avoid people's eyes on the dream path?",ゆめのかよひぢ ひとめよくらむ,kids,-
+293,百人一首,-,せ,せをはやみ いはにせかるる たきがはの われてもすゑに あはむとぞおもふ,"Like the river current split by a rock in the rapids, though divided, I know we shall meet in the end.",われてもすゑに あはむとぞおもふ,kids,-
+294,百人一首,-,そ,そらしらぬ ゆきふみわけて いでつるは ひとつのえだに つるをたづねて,"I went out treading through the snow I didn't know, seeking a vine on a single branch.",ひとつのえだに つるをたづねて,kids,-
+295,百人一首,-,た,たごのうらに うちいでてみれば しろたへの ふじのたかねに ゆきはふりつつ,"When I go out to the shore of Tago and look, snow is falling on the white peak of Mount Fuji.",ふじのたかねに ゆきはふりつつ,kids,-
+296,百人一首,-,ち,ちはやぶる かみよもきかず たつたがは からくれなゐに みづくくるとは,"Never heard of even in the age of the mighty gods, that the Tatsuta River is dyed in deep crimson.",からくれなゐに みづくくるとは,kids,-
+297,百人一首,-,つ,つくばねの みねよりおつる みなのがは こひぞつもりて ふちとなりぬる,"Like the Minano River falling from the peak of Tsukubane, my love has accumulated and become a deep pool.",こひぞつもりて ふちとなりぬる,kids,-
+298,百人一首,-,て,てふことも いまはむかしに なりぬれば たがためにかは なにかうらみむ,"Since even that has become a thing of the past, for whose sake should I hold any resentment?",たがためにかは なにかうらみむ,kids,-
+299,百人一首,-,と,ともしびを かきたつるまも なつかしき いづれのよひに みえぬまにまに,"Even while trimming the lamp, I miss you; on which evening did I not see you?",いづれのよひに みえぬまにまに,kids,-
+300,百人一首,-,な,ながからむ こころもしらず くろかみの みだれてけさは ものをこそおもへ,"Uncertain of how long his heart will stay,my black hair lies in disarray this morning and so, I am lost in troubled thoughts.",みだれてけさは ものをこそおもへ,kids,-
+301,百人一首,-,に,にしきなる ふくろにいれて いはざかり いづれのやまを こえぬとぞおもふ,I put it in a brocade bag; I wonder which mountain it crossed in its peak of silence.,いづれのやまを こえぬとぞおもふ,kids,-
+302,百人一首,-,ぬ,ぬさもとりあへず たむけやま もみぢのにしき かみのまにまに,I could not even bring an offering; let the gods take the brocade of maple leaves on Mount Tamuke.,もみぢのにしき かみのまにまに,kids,-
+303,百人一首,-,ね,ねがはくは はなのしたにて はるしなむ そのきさらぎの もちづきのころ,"My wish is to die in spring under the flowers, around the time of the full moon in the second month.",そのきさらぎの もちづきのころ,kids,-
+304,百人一首,-,の,のちのよを おもへばかろし ほととぎす あかつきかけて なきつるものを,"Thinking of the afterlife makes it seem light, while the cuckoo cries toward the dawn.",あかつきかけて なきつるものを,kids,-
+305,百人一首,-,は,はるすぎて なつきにけらし しろたへの ころもほすてふ あまのかぐやま,Spring has passed and summer seems to have come; white robes are said to be dried on the heavenly Mount Kagu.,ころもほすてふ あまのかぐやま,kids,-
+306,百人一首,-,ひ,ひさかたの ひかりのどけき はるのひに しづこころなく はなのちるらむ,"On this spring day when the light is so calm, why do the cherry blossoms scatter with such unquiet hearts?",しづこころなく はなのちるらむ,kids,-
+307,百人一首,-,ふ,ふくからに あきのくさきの しをるれば むべやまかぜを あらしといふらむ,"Since the autumn plants and trees wither as soon as it blows, it is no wonder the mountain wind is called a storm.",むべやまかぜを あらしといふらむ,kids,-
+308,百人一首,-,へ,へにける いくよをかさね たまづさの ふみをひらけば こひぞつもりぬる,"As I open the letter after many passing nights, my love has truly accumulated.",ふみをひらけば こひぞつもりぬる,kids,-
+309,百人一首,-,ほ,ほととぎす なきつるかたを ながむれば ただありあけの つきぞのこれる,"When I look toward where the cuckoo cried, only the morning moon remains.",ただありあけの つきぞのこれる,kids,-
+310,百人一首,-,ま,まつとしき たかしのはまの あまごろも ぬれにぞぬれし いろはかはらず,"Waiting on the beach of Takashi, the fisher's robe got soaked and soaked, but its color remained unchanged.",ぬれにぞぬれし いろはかはらず,kids,-
+311,百人一首,-,み,みかのはら わきてながるる いづみがは いつみきとてか こひしかるらむ,"Like the Izumi River flowing through the plain of Mika, when did I see you that I should love you so?",いつみきとてか こひしかるらむ,kids,-
+312,百人一首,-,む,むらさめの つゆもまだひぬ まきのはに きりたちのぼる あきのゆふぐれ,"Before the dew of the passing shower has dried on the fir leaves, the mist rises on an autumn evening.",きりたちのぼる あきのゆふぐれ,kids,-
+313,百人一首,-,め,めぐりあひて みしやそれとも わかぬまに くもがくれにし よはのつきかな,"Meeting by chance, before I could even tell if it was you, you were hidden by clouds like the midnight moon.",くもがくれにし よはのつきかな,kids,-
+314,百人一首,-,も,ももしきや ふるきのきばの しのぶにも なほあまりある むかしなりけり,"In the palace, even the ferns on the old eaves make me yearn for the past more than I can bear.",なほあまりある むかしなりけり,kids,-
+315,百人一首,-,や,やすらはで ねなましものを さよふけて かたぶくまでの つきをみしかな,I should have gone to sleep without waiting; I watched the moon until it began to sink late at night.,かたぶくまでの つきをみしかな,kids,-
+316,百人一首,-,ゆ,ゆらのとを わたるふなびと かぢをたえ ゆくへもしらぬ こひのみちかな,"Like a mariner crossing the Yura Strait with a lost oar, I know not where the path of my love leads.",ゆくへもしらぬ こひのみちかな,kids,-
+317,百人一首,-,よ,よをこめて とりのそらねは はかるとも よにあふさかの せきはゆるさじ,"Though you try to deceive with a bird's false cry in the dead of night, the gate of Osaka shall not let you pass.",よにあふさかの せきはゆるさじ,kids,-
+318,百人一首,-,ら,らいしやうの いのちのはてを しらぬまに けふをかぎりと おもひけるかな,"Not knowing the end of my life in the next world, I thought today would be the limit.",けふをかぎりと おもひけるかな,kids,-
+319,百人一首,-,り,りくかぜの さむきにたへて みちのくの しのぶもぢずり たれゆゑにけむ,"Enduring the cold land wind, for whose sake was the tangled print of Michinoku's Shinobu?",しのぶもぢずり たれゆゑにけむ,kids,-
+320,百人一首,-,る,るりのつぼ いづれのひとも すむらむと こころをかけし いろはみえず,"In the lapis lazuli jar where everyone might live, I cannot see the colors I set my heart on.",こころをかけし いろはみえず,kids,-
+321,百人一首,-,れ,れいよりも こころをつくせ さくらばな ちりぬるのちも にほひをこそ,"Exert your heart more than usual, cherry blossoms; even after you fall, leave your fragrance.",ちりぬるのちも にほひをこそ,kids,-
+322,百人一首,-,ろ,ろばたにて こまをつなぎて みるほどに はなぞちりける さくらかな,"While tethering my horse by the roadside, the cherry blossoms were scattering.",はなぞちりける さくらかな,kids,-
+323,百人一首,-,わ,わたのはら やそしまかけて こぎいでぬと ひとにはつげよ あまのつりぶね,"Tell the people that I have rowed out over the wide sea toward the many islands, O fisher's boat.",ひとにはつげよ あまのつりぶね,kids,-
+324,百人一首,-,を,をぐらやま みねのもみぢば こころあらば いまひとたびの みゆきまたなむ,"O maple leaves on the peak of Mount Ogura, if you have a heart, wait for one more imperial visit.",いまひとたびの みゆきまたなむ,kids,-
+325,百人一首,-,ん,んにゃくにしゅう つねのことばを うたにして こころをつたふ みちぞたふとき,"Turning ordinary words into songs to convey the heart, the path is truly noble.",こころをつたふ みちぞたふとき,kids,-
+326,大ピンチずかん,92,た,たからものいれが　あかない,I can't open treasure box.,-,kids,-
+327,大ピンチずかん,1,が,がむを　のんだ,I swallowed gum.,-,kids,-
+400,しょうがっこうかるた,-,あ,あさきたら あいさつしよう げんきよく,"When morning comes, greet cheerfully.",-,kids,-
+401,しょうがっこうかるた,-,い,いねむりは たいちょうくずす はじまりだ,Dozing off is the start of feeling unwell.,-,kids,-
+402,しょうがっこうかるた,-,う,うんどうで からだをきたえ よくねよう,Exercise your body and sleep well.,-,kids,-
+403,しょうがっこうかるた,-,え,えがおでね すごせばみんな うれしいよ,"If you spend time smiling, everyone is happy.",-,kids,-
+404,しょうがっこうかるた,-,お,おはようと げんきなこえで あいさつだ,Say good morning with a cheerful voice.,-,kids,-
+405,しょうがっこうかるた,-,か,かさをさし あめのひだって たのしいよ,Even rainy days can be fun with an umbrella.,-,kids,-
+406,しょうがっこうかるた,-,き,きちんとね つかったあとは かたづけよう,"After using things, tidy them properly.",-,kids,-
+407,しょうがっこうかるた,-,く,くつぬいで そろえておけば きもちいい,Take off and line up your shoes neatly.,-,kids,-
+408,しょうがっこうかるた,-,け,けいさんは あせらずゆっくり かくにんだ,Do calculations calmly and check carefully.,-,kids,-
+409,しょうがっこうかるた,-,こ,こころには あんぜんまもる やくそくだ,Keep safety rules in your heart.,-,kids,-
+410,しょうがっこうかるた,-,さ,さくらさく にゅうがくきせつ はるがきた,Cherry blossoms bloom—spring and school begin.,-,kids,-
+411,しょうがっこうかるた,-,し,しゃべらずに どうろをあるこう あぶないよ,Walk quietly on roads—it’s dangerous otherwise.,-,kids,-
+412,しょうがっこうかるた,-,す,すきなもの ちゃんとえらんで たいせつに,Choose what you like and value it.,-,kids,-
+413,しょうがっこうかるた,-,せ,せいりして つかえばいつも きもちいい,Keep things organized and feel good.,-,kids,-
+414,しょうがっこうかるた,-,そ,そうじして みんなできれいに しようね,Let’s all clean and make it neat.,-,kids,-
+415,しょうがっこうかるた,-,た,たのしいね みんなであそぶと えがおさく,Playing together brings smiles.,-,kids,-
+416,しょうがっこうかるた,-,ち,ちいさくても ルールまもれば りっぱだよ,Even small acts matter if you follow rules.,-,kids,-
+417,しょうがっこうかるた,-,つ,つかうもの たいせつにして ながくつかう,Take care of things and use them long.,-,kids,-
+418,しょうがっこうかるた,-,て,てをあらい きれいにすれば びょうきよぼう,Wash your hands to prevent illness.,-,kids,-
+419,しょうがっこうかるた,-,と,ともだちと なかよくすごす がっこうだ,School is for getting along with friends.,-,kids,-
+420,しょうがっこうかるた,-,な,なかよくね けんかしないで すごそうよ,Let’s get along without fighting.,-,kids,-
+421,しょうがっこうかるた,-,に,にこにこと えがおであいさつ きもちいい,Smiling greetings feel good.,-,kids,-
+422,しょうがっこうかるた,-,ぬ,ぬいだくつ そろえておけば きれいだね,Neatly arranged shoes look nice.,-,kids,-
+423,しょうがっこうかるた,-,ね,ねるまえに あしたのじゅんび しておこう,Prepare for tomorrow before sleeping.,-,kids,-
+424,しょうがっこうかるた,-,の,のこさずに きゅうしょくたべて げんきだよ,Eat your lunch fully to stay healthy.,-,kids,-
+425,しょうがっこうかるた,-,は,はやおきで こころもからだも げんきだよ,Waking early keeps you healthy.,-,kids,-
+426,しょうがっこうかるた,-,ひ,ひとりでも できることから がんばろう,"Do what you can, even alone.",-,kids,-
+427,しょうがっこうかるた,-,ふ,ふざけずに じゅぎょううけよう しっかりと,Take class seriously without fooling around.,-,kids,-
+428,しょうがっこうかるた,-,へ,へやのなか きれいにすれば きもちいい,A clean room feels nice.,-,kids,-
+429,しょうがっこうかるた,-,ほ,ほんをよみ こころをそだて かしこくね,Read books to grow your mind.,-,kids,-
+430,しょうがっこうかるた,-,ま,まいにちを たいせつにして すごそうね,Cherish each day.,-,kids,-
+431,しょうがっこうかるた,-,み,みんなでね ちからをあわせ がんばろう,Let’s work together.,-,kids,-
+432,しょうがっこうかるた,-,む,むりしない じぶんのペースで すすもうね,Go at your own pace.,-,kids,-
+433,しょうがっこうかるた,-,め,めあてもち がくしゅうすれば ちからつく,Study with goals to improve.,-,kids,-
+434,しょうがっこうかるた,-,も,ものはね たいせつにして つかおうね,Take care of your belongings.,-,kids,-
+435,しょうがっこうかるた,-,や,やくそくを まもればみんな しんらいだ,Keeping promises builds trust.,-,kids,-
+436,しょうがっこうかるた,-,ゆ,ゆっくりと あせらずいこう だいじょうぶ,"Take it slow, no need to rush.",-,kids,-
+437,しょうがっこうかるた,-,よ,よるふかし しないでねむろう はやめにね,"Don’t stay up late, sleep early.",-,kids,-
+438,しょうがっこうかるた,-,ら,らくがきは してはいけない たいせつに,Don’t scribble—respect things.,-,kids,-
+439,しょうがっこうかるた,-,り,りゆうある こうどうすれば せいちょうだ,Act with purpose to grow.,-,kids,-
+440,しょうがっこうかるた,-,る,ルールまもり みんながたのしく すごせるよ,Follow rules so everyone enjoys.,-,kids,-
+441,しょうがっこうかるた,-,れ,れいぎよく あいさつできる いいこだね,Polite greetings are great.,-,kids,-
+442,しょうがっこうかるた,-,ろ,ろうかでは はしらずあるこう あんぜんに,Walk in hallways safely.,-,kids,-
+443,しょうがっこうかるた,-,わ,わすれもの しないようにね かくにんだ,Check so you don’t forget things.,-,kids,-
+444,しょうがっこうかるた,-,し,しゅくだいを きちんとやろう わすれずに,Do your homework properly without forgetting.,-,kids,-
+445,しょうがっこうかるた,-,さ,さんかんび パパやママは みてるかな,"On open school day, I wonder if mom and dad are watching.",-,kids,-
+1001,HTTP大ピンチ,10,2,祈るように送ったリクエストがちゃんと成功で返ってきた,"I sent the request nervously, and it actually succeeded.",200 OK,engineer,-
+1002,HTTP大ピンチ,15,2,新規登録ボタンを押したらきちんと新しいデータが生まれた,"I clicked the register button, and a brand-new record was created.",201 Created,engineer,-
+1003,HTTP大ピンチ,20,2,削除ボタンを押したら成功なのに画面には何も表示されない,"I clicked delete, and it succeeded but nothing came back.",204 No Content,engineer,-
+1004,HTTP大ピンチ,21,3,昔のURLを開いたらもう新しい住所に引っ越していた,"I opened the old URL, and it had permanently moved house.",301 Moved Permanently,engineer,-
+1005,HTTP大ピンチ,25,3,ログイン後だけいつも知らないページに飛ばされる,"Only after logging in, I always get redirected elsewhere, but only for now.",302 Found,engineer,-
+1006,HTTP大ピンチ,26,3,更新したつもりがキャッシュのままだと言われた,"I tried to refresh it, but I was told nothing had changed since last time.",304 Not Modified,engineer,-
+1007,HTTP大ピンチ,16,4,送ったデータの形がそもそも変だったらしい,Apparently the data I sent was malformed from the start.,400 Bad Request,engineer,-
+1008,HTTP大ピンチ,17,4,ログインすらしていないのに画面を見ようとした,I tried to view the page without even logging in.,401 Unauthorized,engineer,-
+1009,HTTP大ピンチ,22,4,ログインはできたのにその先には入れてもらえない,"I was logged in, but still not allowed past this point.",403 Forbidden,engineer,-
+1010,HTTP大ピンチ,11,4,そのページはもうどこにも存在しないらしい,Apparently that page doesn't exist anywhere.,404 Not Found,engineer,-
+1011,HTTP大ピンチ,27,4,GETでアクセスしたらここはPOST専用だと言われた,"I accessed it with GET, but apparently only POST is allowed here.",405 Method Not Allowed,engineer,-
+1012,HTTP大ピンチ,28,4,返事を待ち続けたけど間に合わなかった,"I kept waiting for a reply, but it never came in time.",408 Request Timeout,engineer,-
+1013,HTTP大ピンチ,31,4,同時に更新したらお互いの内容がぶつかった,"Two updates happened at once, and they collided.",409 Conflict,engineer,-
+1014,HTTP大ピンチ,32,4,前はたしかにあったのにもう永遠に戻ってこないらしい,"It definitely used to be here, but now it's gone for good.",410 Gone,engineer,-
+1015,HTTP大ピンチ,29,4,大きすぎる画像を送ったら受け取ってもらえなかった,"I tried sending too large a file, and it got rejected.",413 Payload Too Large,engineer,-
+1016,HTTP大ピンチ,30,4,送ったファイルの形式がそもそも対応していないらしい,The file format I sent apparently isn't supported at all.,415 Unsupported Media Type,engineer,-
+1017,HTTP大ピンチ,33,4,形式は合っているのに内容がおかしいと突き返された,"The format was fine, but the content itself got rejected.",422 Unprocessable Entity,engineer,-
+1018,HTTP大ピンチ,36,4,焦って何度も送ったらしばらく待つよう言われた,I sent too many requests in a panic and got told to slow down.,429 Too Many Requests,engineer,-
+1019,HTTP大ピンチ,18,5,サーバーの中でなにか予想外のことが起きたらしい,Something unexpected happened deep inside the server.,500 Internal Server Error,engineer,-
+1020,HTTP大ピンチ,34,5,そんな機能はサーバーがそもそも知らないと言われた,The server said it has no idea what that feature even is.,501 Not Implemented,engineer,-
+1021,HTTP大ピンチ,37,5,問い合わせた先のサーバーからおかしな返事が来た,The upstream server sent back a broken reply.,502 Bad Gateway,engineer,-
+1022,HTTP大ピンチ,35,5,今だけサーバーが対応できないと断られた,The server said it just can't handle anything right now.,503 Service Unavailable,engineer,-
+1023,HTTP大ピンチ,38,5,問い合わせた先からの返事がいつまでも来なかった,The upstream server never replied in time.,504 Gateway Timeout,engineer,-
+1101,Linuxコマンドかるた,-,L,ディレクトリ一覧を表示する,Display a list of directory contents.,ls,engineer,-
+1102,Linuxコマンドかるた,-,P,現在のディレクトリを表示する,Display the current directory.,pwd,engineer,-
+1103,Linuxコマンドかるた,-,C,ディレクトリを移動する,Change the current directory.,cd,engineer,-
+1104,Linuxコマンドかるた,-,M,新しいディレクトリを作成する,Create a new directory.,mkdir,engineer,-
+1105,Linuxコマンドかるた,-,R,空のディレクトリを削除する,Remove an empty directory.,rmdir,engineer,-
+1106,Linuxコマンドかるた,-,R,ファイルを削除する,Delete a file.,rm,engineer,-
+1107,Linuxコマンドかるた,-,C,ファイルをコピーする,Copy a file.,cp,engineer,-
+1108,Linuxコマンドかるた,-,M,ファイルを移動する、または名前を変更する,Move or rename a file.,mv,engineer,-
+1109,Linuxコマンドかるた,-,T,空のファイルを作成する、タイムスタンプを更新する,Create an empty file or update its timestamp.,touch,engineer,-
+1110,Linuxコマンドかるた,-,C,ファイルの内容を表示する,Display the contents of a file.,cat,engineer,-
+1111,Linuxコマンドかるた,-,F,ファイルを検索する,Search for files.,find,engineer,-
+1112,Linuxコマンドかるた,-,G,ファイルの中から文字列を検索する,Search for a string within files.,grep,engineer,-
+1113,Linuxコマンドかるた,-,C,ファイルの権限を変更する,Change file permissions.,chmod,engineer,-
+1114,Linuxコマンドかるた,-,C,ファイルの所有者を変更する,Change file ownership.,chown,engineer,-
+1115,Linuxコマンドかるた,-,P,実行中のプロセスを表示する,Display running processes.,ps,engineer,-
+1116,Linuxコマンドかるた,-,K,プロセスを終了させる,Terminate a process.,kill,engineer,-
+1117,Linuxコマンドかるた,-,T,システムのリソース使用状況をリアルタイムで表示する,Display real-time system resource usage.,top,engineer,-
+1118,Linuxコマンドかるた,-,D,ディスクの空き容量を表示する,Display free disk space.,df,engineer,-
+1119,Linuxコマンドかるた,-,D,ファイルやディレクトリのサイズを表示する,Display the size of files or directories.,du,engineer,-
+1120,Linuxコマンドかるた,-,T,複数のファイルをひとつにまとめて圧縮・展開する,Archive or extract multiple files.,tar,engineer,-
+1121,Linuxコマンドかるた,-,S,別のサーバーにリモートでログインする,Log in to a remote server.,ssh,engineer,-
+1122,Linuxコマンドかるた,-,S,サーバー間でファイルを安全にコピーする,Securely copy files between servers.,scp,engineer,-
+1123,Linuxコマンドかるた,-,C,URLを指定してデータを送受信する,Transfer data to or from a URL.,curl,engineer,-
+1124,Linuxコマンドかるた,-,W,URLからファイルをダウンロードする,Download a file from a URL.,wget,engineer,-
+1125,Linuxコマンドかるた,-,M,コマンドの使い方を調べる,Look up how to use a command.,man,engineer,-
+1126,Linuxコマンドかるた,-,H,これまでに実行したコマンドの履歴を表示する,Display the history of executed commands.,history,engineer,-
+1127,Linuxコマンドかるた,-,E,文字列を画面に出力する,Print a string to the screen.,echo,engineer,-
+1128,Linuxコマンドかるた,-,L,ファイルの内容をスクロールしながら表示する,View a file's contents one screen at a time.,less,engineer,-
+1129,Linuxコマンドかるた,-,H,ファイルの先頭部分を表示する,Display the beginning of a file.,head,engineer,-
+1130,Linuxコマンドかるた,-,T,ファイルの末尾部分を表示する,Display the end of a file.,tail,engineer,-
+1131,Linuxコマンドかるた,-,S,行を並び替える,Sort lines of text.,sort,engineer,-
+1132,Linuxコマンドかるた,-,U,重複する行を取り除く,Remove duplicate adjacent lines.,uniq,engineer,-
+1133,Linuxコマンドかるた,-,W,行数や単語数、文字数を数える,"Count lines, words, and characters.",wc,engineer,-
+1134,Linuxコマンドかるた,-,L,ファイルのリンクを作成する,Create a link to a file.,ln,engineer,-
+1135,Linuxコマンドかるた,-,A,コマンドに別名をつける,Define a shortcut name for a command.,alias,engineer,-
+1136,Linuxコマンドかるた,-,E,環境変数を設定する,Set an environment variable.,export,engineer,-
+1137,Linuxコマンドかるた,-,S,管理者権限でコマンドを実行する,Run a command with administrator privileges.,sudo,engineer,-
+1138,Linuxコマンドかるた,-,W,コマンドの実行ファイルの場所を調べる,Find the location of a command's executable.,which,engineer,-
+1139,Linuxコマンドかるた,-,W,現在ログインしているユーザー名を表示する,Display the current logged-in user name.,whoami,engineer,-
+1140,Linuxコマンドかるた,-,H,コンピュータのホスト名を表示する,Display the computer's host name.,hostname,engineer,-
+1201,Git大ピンチ,10,I,「まずpushして」と言われたけどGitを始めてもいなかった,You were told to push before initializing Git.,git init,engineer,-
+1202,Git大ピンチ,11,C,URLだけ渡されて「触っといて」と言われた,You only received a repository URL.,git clone,engineer,-
+1203,Git大ピンチ,12,S,コミットしたつもりが「nothing to commit」だった,"You thought you committed, but nothing happened.",git status → git add → git commit,engineer,-
+1204,Git大ピンチ,15,D,レビューで「何を変更したの？」と聞かれ固まった,Someone asked what changed.,git diff,engineer,-
+1205,Git大ピンチ,28,L,昨日から壊れてるらしい。いつ壊した？,The bug appeared yesterday. Which commit caused it?,git log,engineer,-
+1206,Git大ピンチ,16,B,mainで直接開発していたことに気付いた,You accidentally developed on main.,git switch -c,engineer,-
+1207,Git大ピンチ,20,M,レビューOK！でも取り込み方が分からない,The PR was approved. Now what?,git merge,engineer,-
+1208,Git大ピンチ,21,R,コミット履歴が「fix」「fix2」「fix3」だらけ,Your commit history is messy.,git rebase -i,engineer,-
+1209,Git大ピンチ,29,S,上司に呼ばれた。今の作業を消さずに別ブランチへ行きたい,You must switch tasks immediately.,git stash,engineer,-
+1210,Git大ピンチ,22,P,自分だけ動く。みんなには見えない,Only your machine has the changes.,git push,engineer,-
+1211,Git大ピンチ,38,P,取り込みしないまま続けたら地獄のコンフリクト,You skipped pull before starting work.,git pull,engineer,-
+1212,Git大ピンチ,30,F,最新は見たい。でもまだ混ぜたくない,You only want the latest remote state.,git fetch,engineer,-
+1213,Git大ピンチ,39,R,昨日の作業全部なかったことにしたい,You want to discard yesterday's work.,git reset --hard,engineer,-
+1214,Git大ピンチ,44,R,本番に出したコミットだけ安全に取り消したい,Undo only one released commit.,git revert,engineer,-
+1215,Git大ピンチ,45,C,あのバグ修正だけ今のブランチにも欲しい,You only need one commit.,git cherry-pick,engineer,-
+1216,Git大ピンチ,40,B,「誰がこのバグ入れた？」会議室が静まり返る,Who introduced this bug?,git blame,engineer,-
+1217,Git大ピンチ,23,S,このコミット、本当に何を変更した？,What exactly changed in this commit?,git show,engineer,-
+1218,Git大ピンチ,31,R,リモートが増えすぎてpush先が分からない,Too many remotes. Which one am I using?,git remote -v,engineer,-
+1219,Git大ピンチ,17,C,知らない名前でコミットされていた,Your commit author is wrong.,git config --global,engineer,-
+1220,Git大ピンチ,32,T,v2.0ってどのコミット？誰も分からない,Nobody knows where version 2.0 is.,git tag,engineer,-
+1221,Git大ピンチ,24,R,間違えてファイルを削除してしまった,You deleted the wrong file.,git restore,engineer,-
+1222,Git大ピンチ,33,C,ブランチを切り替えたらファイルが消えた,Files disappeared after switching branches.,git checkout,engineer,-
+1223,Git大ピンチ,13,A,ファイルを追加したのにコミットに入っていなかった,The new file wasn't included.,git add,engineer,-
+1224,Git大ピンチ,25,C,コミットした瞬間、誤字を見つけた,You spotted a typo right after committing.,git commit --amend,engineer,-
+1225,Git大ピンチ,34,S,コンフリクトを直したつもりなのにまだ終わらない,"You resolved conflicts, but Git disagrees.",git status → git add → git commit,engineer,-
+1226,Git大ピンチ,41,S,コンフリクトを直したのに「まだ終わってない」と言われた,Git still thinks the merge isn't finished.,git status → git add → git commit,engineer,-
+1227,Git大ピンチ,50,R,間違えてmainへpushしてしまった,You accidentally pushed directly to main.,git revert,engineer,-
+1228,Git大ピンチ,35,S,ブランチを切り替えたいのに変更が邪魔して進めない,Uncommitted changes block switching branches.,git stash → git switch,engineer,-
+1229,Git大ピンチ,46,F,最新を取り込んだら大量コンフリクトになった,Pull caused a huge merge conflict.,git fetch → git merge,engineer,-
+1230,Git大ピンチ,47,L,「昨日動いてた版に戻して」と言われた,Go back to yesterday's version.,git log → git checkout <commit>,engineer,-
+1231,Git大ピンチ,14,S,どのブランチにいるのか分からなくなった,You forgot which branch you're on.,git status,engineer,-
+1232,Git大ピンチ,26,D,レビューで「差分が見えません」と言われた,The reviewer can't tell what changed.,git diff,engineer,-
+1233,Git大ピンチ,27,C,レビュー後に1文字だけ直したい,You only need to fix one typo after review.,git commit --amend,engineer,-
+1234,Git大ピンチ,42,T,リリース版がどのコミットか誰も覚えていない,Nobody knows which commit was released.,git tag,engineer,-
+1235,Git大ピンチ,36,B,「このコード誰が書いた？」全員目をそらした,Nobody admits writing the code.,git blame,engineer,-
+1236,Git大ピンチ,43,R,間違えて別ブランチで1時間作業してしまった,You worked on the wrong branch for an hour.,git stash → git switch → git stash pop,engineer,-
+1237,Git大ピンチ,48,C,「その修正だけ持ってきて」と言われた,Only bring over that one fix.,git cherry-pick,engineer,-
+1238,Git大ピンチ,49,S,マージした瞬間にビルドが壊れた,The build broke immediately after merging.,git show,engineer,-
+1239,Git大ピンチ,37,R,リモートが多すぎてpush先を間違えそう,Too many remotes to remember.,git remote -v,engineer,-
+1240,Git大ピンチ,18,G,新しいPCなのにコミットできない,Git isn't configured on the new PC.,git config --global,engineer,-
+1301,SQLかるた,-,S,取得する列を指定する,Specify which columns to retrieve.,SELECT,engineer,-
+1302,SQLかるた,-,F,データを取得するテーブルを指定する,Specify the table to retrieve data from.,FROM,engineer,-
+1303,SQLかるた,-,W,条件に一致するデータを取得する,Retrieve data that matches a condition.,WHERE,engineer,-
+1304,SQLかるた,-,G,指定した列の値でグループ化する,Group rows by the values of specified columns.,GROUP BY,engineer,-
+1305,SQLかるた,-,H,グループ化した後の結果に条件をつける,Filter results after grouping.,HAVING,engineer,-
+1306,SQLかるた,-,O,結果を並び替える,Sort the results.,ORDER BY,engineer,-
+1307,SQLかるた,-,L,取得する件数を制限する,Limit the number of rows returned.,LIMIT,engineer,-
+1308,SQLかるた,-,I,一致する行だけを複数テーブルから結合する,"Join tables, returning only matching rows.",INNER JOIN,engineer,-
+1309,SQLかるた,-,L,左側のテーブルを基準に結合する,"Join tables, keeping all rows from the left table.",LEFT JOIN,engineer,-
+1310,SQLかるた,-,R,右側のテーブルを基準に結合する,"Join tables, keeping all rows from the right table.",RIGHT JOIN,engineer,-
+1311,SQLかるた,-,F,両方のテーブルの行をすべて結合する,"Join tables, keeping all rows from both tables.",FULL OUTER JOIN,engineer,-
+1312,SQLかるた,-,U,複数の検索結果を縦に結合する,Combine the results of multiple queries.,UNION,engineer,-
+1313,SQLかるた,-,D,重複を除外する,Exclude duplicate rows.,DISTINCT,engineer,-
+1314,SQLかるた,-,I,新しい行を追加する,Insert a new row.,INSERT INTO,engineer,-
+1315,SQLかるた,-,U,既存の行を更新する,Update existing rows.,UPDATE,engineer,-
+1316,SQLかるた,-,D,行を削除する,Delete rows.,DELETE,engineer,-
+1317,SQLかるた,-,C,新しいテーブルを作成する,Create a new table.,CREATE TABLE,engineer,-
+1318,SQLかるた,-,A,テーブルの構造を変更する,Modify a table's structure.,ALTER TABLE,engineer,-
+1319,SQLかるた,-,D,テーブルを削除する,Delete a table.,DROP TABLE,engineer,-
+1320,SQLかるた,-,P,行を一意に識別する列を指定する,Designate a column that uniquely identifies each row.,PRIMARY KEY,engineer,-
+1321,SQLかるた,-,F,他のテーブルの行を参照する制約,A constraint that references a row in another table.,FOREIGN KEY,engineer,-
+1322,SQLかるた,-,N,値が存在しないことを表す,Represents the absence of a value.,NULL,engineer,-
+1323,SQLかるた,-,B,指定した範囲内のデータを取得する,Retrieve data within a specified range.,BETWEEN,engineer,-
+1324,SQLかるた,-,L,文字列のパターンに一致するか調べる,Check whether a string matches a pattern.,LIKE,engineer,-
+1325,SQLかるた,-,I,複数の値のいずれかに一致するか調べる,Check whether a value matches any in a list.,IN,engineer,-
+1326,SQLかるた,-,C,行数を数える,Count the number of rows.,COUNT,engineer,-
+1327,SQLかるた,-,S,値の合計を求める,Calculate the sum of values.,SUM,engineer,-
+1328,SQLかるた,-,A,値の平均を求める,Calculate the average of values.,AVG,engineer,-
+1329,SQLかるた,-,A,列やテーブルに別名をつける,Give a column or table an alias.,AS,engineer,-
+1330,SQLかるた,-,C,条件によって異なる値を返す,Return different values depending on a condition.,CASE WHEN,engineer,-
+1331,SQLかるた,-,C,変更をデータベースに確定する,Commit changes to the database.,COMMIT,engineer,-
+1332,SQLかるた,-,R,変更を取り消して元に戻す,Undo changes and revert to the previous state.,ROLLBACK,engineer,-
+1401,AWSかるた,-,L,サーバレスでコードを実行する,Run code without managing servers.,Lambda,engineer,-
+1402,AWSかるた,-,S,オブジェクトストレージ,Object storage.,S3,engineer,-
+1403,AWSかるた,-,D,NoSQLデータベース,A NoSQL database.,DynamoDB,engineer,-
+1404,AWSかるた,-,E,仮想サーバーを提供する,Provides virtual servers.,EC2,engineer,-
+1405,AWSかるた,-,R,マネージドなリレーショナルデータベース,A managed relational database.,RDS,engineer,-
+1406,AWSかるた,-,V,仮想的なネットワーク環境を作る,Create an isolated virtual network.,VPC,engineer,-
+1407,AWSかるた,-,I,ユーザーや権限を管理する,Manage users and permissions.,IAM,engineer,-
+1408,AWSかるた,-,C,コンテンツ配信網(CDN)サービス,A content delivery network (CDN) service.,CloudFront,engineer,-
+1409,AWSかるた,-,R,DNSサービス,A DNS service.,Route 53,engineer,-
+1410,AWSかるた,-,A,APIの作成・公開・管理を行う,"Create, publish, and manage APIs.",API Gateway,engineer,-
+1411,AWSかるた,-,S,メッセージを溜めておくキューサービス,A queue service for storing messages.,SQS,engineer,-
+1412,AWSかるた,-,S,メッセージを配信する通知サービス,A notification service for delivering messages.,SNS,engineer,-
+1413,AWSかるた,-,C,リソースの監視やログ収集を行う,Monitor resources and collect logs.,CloudWatch,engineer,-
+1414,AWSかるた,-,C,インフラをコードで構築・管理する,Provision and manage infrastructure as code.,CloudFormation,engineer,-
+1415,AWSかるた,-,E,コンテナを管理・実行するサービス,A service for managing and running containers.,ECS,engineer,-
+1416,AWSかるた,-,E,マネージドなKubernetesサービス,A managed Kubernetes service.,EKS,engineer,-
+1417,AWSかるた,-,F,サーバー管理が不要なコンテナ実行環境,A serverless container runtime that needs no server management.,Fargate,engineer,-
+1418,AWSかるた,-,E,アプリケーションのデプロイを簡単にする,Simplifies application deployment.,Elastic Beanstalk,engineer,-
+1419,AWSかるた,-,A,負荷に応じてサーバー台数を自動調整する,Automatically adjusts server count based on load.,Auto Scaling,engineer,-
+1420,AWSかるた,-,E,通信を複数サーバーに振り分ける,Distributes traffic across multiple servers.,Elastic Load Balancing,engineer,-
+1421,AWSかるた,-,G,データを抽出・変換・ロードするETLサービス,"An ETL service for extracting, transforming, and loading data.",Glue,engineer,-
+1422,AWSかるた,-,A,S3のデータをSQLで分析する,Analyze data in S3 using SQL.,Athena,engineer,-
+1423,AWSかるた,-,K,大量のストリーミングデータを処理する,Process large volumes of streaming data.,Kinesis,engineer,-
+1424,AWSかるた,-,S,複数のサービスをワークフローでつなぐ,Coordinate multiple services into a workflow.,Step Functions,engineer,-
+1425,AWSかるた,-,C,ユーザーの認証や認可を管理する,Manage user authentication and authorization.,Cognito,engineer,-
+1426,AWSかるた,-,S,パスワードなどの機密情報を管理する,Manage secrets such as passwords.,Secrets Manager,engineer,-
+1427,AWSかるた,-,C,ビルドからデプロイまでを自動化する,Automate the process from build to deployment.,CodePipeline,engineer,-
+1428,AWSかるた,-,E,EC2にアタッチするブロックストレージ,Block storage attached to EC2 instances.,EBS,engineer,-
+1429,AWSかるた,-,A,高い性能を持つマネージドリレーショナルDB,A high-performance managed relational database.,Aurora,engineer,-
+1430,AWSかるた,-,R,大規模なデータウェアハウス,A large-scale data warehouse.,Redshift,engineer,-
+1501,Java大ピンチ,10,N,nullのはずの変数を当然のように呼び出してしまった,I called a method on something that turned out to be null.,NullPointerException,engineer,-
+1502,Java大ピンチ,15,I,ファイルを読み込もうとしたら途中で失敗した,Reading the file failed partway through.,IOException,engineer,-
+1503,Java大ピンチ,28,H,名前で検索したいのに配列だと毎回全部探してしまう,"I wanted to look things up by name, but the array made me scan everything.",HashMap,engineer,-
+1504,Java大ピンチ,11,A,配列の最後のつもりがその一個先を見ていた,"I thought I was at the last index, but I was already one past it.",ArrayIndexOutOfBoundsException,engineer,-
+1505,Java大ピンチ,35,C,そのクラスは実行時にはどこにも見つからなかった,"At runtime, that class was nowhere to be found.",ClassNotFoundException,engineer,-
+1506,Java大ピンチ,16,N,文字列を数値に変換しようとしたら数字になっていなかった,"I tried to convert a string to a number, but it wasn't numeric at all.",NumberFormatException,engineer,-
+1507,Java大ピンチ,17,I,渡された引数がそもそも受け取れない値だった,The argument I received was simply not acceptable.,IllegalArgumentException,engineer,-
+1508,Java大ピンチ,20,I,呼んではいけないタイミングでそのメソッドを呼んでしまった,I called that method at a moment it shouldn't have been called.,IllegalStateException,engineer,-
+1509,Java大ピンチ,12,A,0で割ってしまって計算がそこで止まった,"I divided by zero, and the calculation stopped right there.",ArithmeticException,engineer,-
+1510,Java大ピンチ,29,C,ループで回している最中にそのコレクションをいじってしまった,I modified the collection while still looping through it.,ConcurrentModificationException,engineer,-
+1511,Java大ピンチ,36,O,メモリを使い切ってJVMがついに音を上げた,"Memory ran out, and the JVM finally gave up.",OutOfMemoryError,engineer,-
+1512,Java大ピンチ,30,S,再帰呼び出しが終わる条件を見失って深くなりすぎた,The recursive calls lost their stopping point and went too deep.,StackOverflowError,engineer,-
+1513,Java大ピンチ,21,A,配列のつもりだったのに要素を増やしたり減らしたりしたくなった,"I started with a plain array, but then wanted to resize it freely.",ArrayList,engineer,-
+1514,Java大ピンチ,31,L,真ん中への挿入ばかりで配列のコピーに時間がかかっていた,Inserting in the middle kept forcing slow array copies.,LinkedList,engineer,-
+1515,Java大ピンチ,22,H,同じ値がリストの中に何個も紛れ込んでいた,The same value kept sneaking into the list multiple times.,HashSet,engineer,-
+1516,Java大ピンチ,32,T,キーの並び順がいつもバラバラで整列させたかった,"The key order was always scrambled, and I wanted it sorted.",TreeMap,engineer,-
+1517,Java大ピンチ,23,S,文字列を+で繋ぐたびに新しいオブジェクトが量産されていた,Every string concatenation quietly created a brand-new object.,StringBuilder,engineer,-
+1518,Java大ピンチ,33,O,戻り値がnullかもしれないのにそのまま呼び出してしまいそうだった,"The return value might be null, and I almost called it blindly.",Optional,engineer,-
+1519,Java大ピンチ,37,S,forループを何重にも書いていたらコードが読みにくくなった,Nested for-loops piled up until the code became unreadable.,Stream,engineer,-
+1520,Java大ピンチ,24,I,実装は持たずにメソッドの形だけ決めておきたかった,"I wanted to define only the method shapes, with no implementation.",Interface,engineer,-
+1521,Java大ピンチ,25,A,共通の処理だけ用意して残りは子クラスに任せたかった,I wanted to share some logic but leave the rest to subclasses.,Abstract Class,engineer,-
+1522,Java大ピンチ,38,G,同じクラスを型ごとにいくつも書きそうになった,I was about to duplicate the same class for every type.,Generics,engineer,-
+1523,Java大ピンチ,26,T,例外が起きても最後の後始末だけは必ずやりたかった,"Even if an exception occurs, the cleanup still has to run.",try-catch-finally,engineer,-
+1524,Java大ピンチ,40,S,複数のスレッドが同時に同じ値を書き換えにきた,Multiple threads tried to rewrite the same value at once.,synchronized,engineer,-
+1525,Java大ピンチ,39,T,重い処理のせいで画面が固まったように見えた,A heavy task made everything look frozen.,Thread,engineer,-
+1526,Java大ピンチ,27,O,親クラスと同じ動きしかせず子クラスらしい振る舞いに変えられなかった,"The subclass behaved just like its parent, and I needed to change that.",Override,engineer,-
+1527,Java大ピンチ,34,E,中身が同じはずのオブジェクトが別物として扱われてしまった,Two objects with identical content were treated as different.,equals/hashCode,engineer,-
+1528,Java大ピンチ,18,F,あとから値を変えられないように絶対に守りたかった,I wanted to make sure that value could never be changed again.,final,engineer,-
+1529,Java大ピンチ,19,S,インスタンスを作らなくてもその機能だけ使いたかった,I wanted to use that feature without ever creating an instance.,static,engineer,-
+1601,コードレビューかるた,-,D,同じコードが複数箇所に存在する,The same code exists in multiple places.,DRY原則,engineer,-
+1602,コードレビューかるた,-,か,変数名から役割が分からない,It's unclear what a variable does from its name.,可読性,engineer,-
+1603,コードレビューかるた,-,た,1つのメソッドが長すぎる,A single method is too long.,単一責任の原則,engineer,-
+1604,コードレビューかるた,-,ま,意味のわからない数値が直接書かれている,An unexplained number is hard-coded directly in the code.,マジックナンバー,engineer,-
+1605,コードレビューかるた,-,ね,条件分岐が何重にも入れ子になっている,Conditional branches are nested many levels deep.,ネストが深い,engineer,-
+1606,コードレビューかるた,-,め,変数名やクラス名のつけ方が統一されていない,Variable and class naming is inconsistent.,命名規則違反,engineer,-
+1607,コードレビューかるた,-,て,重要な処理にテストが書かれていない,Critical logic has no tests.,テストカバレッジ不足,engineer,-
+1608,コードレビューかるた,-,は,設定値がコード中に直接埋め込まれている,Configuration values are embedded directly in the code.,ハードコーディング,engineer,-
+1609,コードレビューかるた,-,れ,catchした例外を何もせず無視している,A caught exception is silently ignored.,例外の握りつぶし,engineer,-
+1610,コードレビューかるた,-,ぐ,どこからでも書き換えられる変数を多用している,Overuse of variables that can be modified from anywhere.,グローバル変数の濫用,engineer,-
+1611,コードレビューかるた,-,こ,複雑な処理の意図が説明されていない,The intent behind complex logic is not explained.,コメント不足,engineer,-
+1612,コードレビューかるた,-,じ,同じロジックが何箇所にもコピーされている,The same logic is copy-pasted in many places.,重複コード,engineer,-
+1613,コードレビューかるた,-,そ,条件を満たしたらすぐに関数を抜けず深く入れ子にしている,"Doesn't exit early when a condition is met, leading to deep nesting.",早期return,engineer,-
+1614,コードレビューかるた,-,ふ,名前から想像できない値の変更を行う関数,A function that changes values in ways its name doesn't suggest.,副作用のある関数,engineer,-
+1615,コードレビューかるた,-,み,クラス同士が内部実装に強く依存している,Classes depend heavily on each other's internal implementation.,密結合,engineer,-
+1616,コードレビューかるた,-,で,呼び出されない不要なコードが残っている,Unused code that is never called remains in the codebase.,デッドコード,engineer,-
+1617,コードレビューかるた,-,S,ユーザー入力をそのままSQLに組み込んでいる,User input is embedded directly into SQL without sanitization.,SQLインジェクション脆弱性,engineer,-
+1618,コードレビューかるた,-,ふ,使われていないモジュールが読み込まれている,Unused modules are imported.,不要なimport,engineer,-
+1619,コードレビューかるた,-,ろ,エラー発生時に原因を追えるログがない,There are no logs to trace the cause when an error occurs.,ログ出力不足,engineer,-
+1620,コードレビューかるた,-,ば,入力値の検証が行われていない,Input values are not validated.,バリデーション漏れ,engineer,-
+1621,コードレビューかるた,-,れ,並行処理の実行順序によって結果が変わる不具合,A bug where the result depends on the timing of concurrent execution.,レースコンディション,engineer,-
+1622,コードレビューかるた,-,か,将来使うかもしれない機能を先に作り込んでいる,Building functionality preemptively for hypothetical future use.,過剰な抽象化,engineer,-
+1701,セキュリティ大ピンチ,10,は,アカウント全部　同じパスワードだった,I used the same password for every account.,パスワードリスト攻撃,engineer,-
+1702,セキュリティ大ピンチ,15,ふ,いそいで振り込め　メールを信じた,I trusted an urgent payment email.,フィッシング,engineer,-
+1703,セキュリティ大ピンチ,12,ま,USBを拾って　そのまま挿した,I plugged in a USB drive I found.,マルウェア,engineer,-
+1704,セキュリティ大ピンチ,40,し,APIキーを　GitHubで公開した,I exposed an API key on GitHub.,シークレット管理,engineer,-
+1705,セキュリティ大ピンチ,16,ふ,おなじログイン画面だと　思い込んだ,I assumed the login page was genuine.,フィッシングサイト,engineer,-
+1706,セキュリティ大ピンチ,21,て,開発用パスワードを　本番でも使った,I used a development password in production.,デフォルトパスワード,engineer,-
+1707,セキュリティ大ピンチ,27,し,きょうもパッチを　後回しにした,I postponed installing security patches again.,脆弱性,engineer,-
+1708,セキュリティ大ピンチ,28,ら,暗号化されても　バックアップがない,Everything was encrypted and I had no backup.,ランサムウェア,engineer,-
+1709,セキュリティ大ピンチ,41,え,検索欄から　データベースが壊れた,The database broke through the search box.,SQLインジェクション,engineer,-
+1710,セキュリティ大ピンチ,42,く,コメントを書いたら　勝手に画面が動いた,A comment caused unexpected script execution.,XSS,engineer,-
+1711,セキュリティ大ピンチ,45,し,サイトを見ただけで　退会していた,I was logged out or unsubscribed just by visiting a page.,CSRF,engineer,-
+1712,セキュリティ大ピンチ,35,に,知らない人まで　管理画面に入れた,Unauthorized users reached the admin screen.,認可不備,engineer,-
+1713,セキュリティ大ピンチ,22,あ,すでに退職した人が　まだログインしていた,A former employee could still log in.,アカウント管理,engineer,-
+1714,セキュリティ大ピンチ,30,さ,全員を管理者に　してしまった,I gave everyone administrator privileges.,最小権限の原則,engineer,-
+1715,セキュリティ大ピンチ,17,て,そのままHTTPで　ログインした,I logged in over HTTP.,TLS,engineer,-
+1716,セキュリティ大ピンチ,23,か,だれが操作したか　分からない,Nobody knew who performed the operation.,監査ログ,engineer,-
+1717,セキュリティ大ピンチ,36,せ,社内だから安全と　思い込んでいた,I assumed the internal network was safe.,ゼロトラスト,engineer,-
+1718,セキュリティ大ピンチ,43,あ,つうしんの異常に　誰も気付かなかった,Nobody noticed the suspicious traffic.,IDS,engineer,-
+1719,セキュリティ大ピンチ,46,あ,敵は見つけたのに　止められなかった,We detected the attack but couldn't stop it.,IPS,engineer,-
+1720,セキュリティ大ピンチ,44,え,取りつかれても　誰も気付かなかった,The endpoint was compromised without anyone noticing.,EDR,engineer,-
+1721,セキュリティ大ピンチ,24,せ,長いこと更新を　していなかった,The server hadn't been updated for a long time.,セキュリティパッチ,engineer,-
+1722,セキュリティ大ピンチ,18,た,認証が　パスワードだけだった,Only a password protected the account.,多要素認証,engineer,-
+1723,セキュリティ大ピンチ,37,せ,ぬすまれたCookieで　ログインされた,Someone logged in using my stolen cookie.,セッションハイジャック,engineer,-
+1724,セキュリティ大ピンチ,25,あ,ねだんより　個人情報を守れ,Personal data was stored without protection.,暗号化,engineer,-
+1725,セキュリティ大ピンチ,19,て,残っていた初期設定で　入られた,Someone logged in with default credentials.,デフォルト認証情報,engineer,-
+1726,セキュリティ大ピンチ,26,と,アクセスが急に　100万件来た,A million requests suddenly flooded the server.,DoS攻撃,engineer,-
+1727,セキュリティ大ピンチ,38,こ,秘密鍵を　メールで送ってしまった,I emailed a private key.,公開鍵暗号方式,engineer,-
+1728,セキュリティ大ピンチ,39,せ,古い設定をコピーしたら　穴だらけだった,I copied an insecure server configuration.,セキュア設定,engineer,-
+1729,セキュリティ大ピンチ,31,し,へいきだろうで　本番公開した,I released it to production assuming it was safe.,脆弱性診断,engineer,-
+1730,セキュリティ大ピンチ,20,さ,ほんとうに開いてよかった？　その添付ファイル,Should I really have opened that attachment?,サンドボックス,engineer,-
+1731,セキュリティ大ピンチ,70,え,まさか社内サーバが　外から操作された,The internal server was manipulated from outside.,SSRF,engineer,-
+1732,セキュリティ大ピンチ,80,え,見せるはずのない　サーバのファイルが見えた,Internal server files became visible.,XXE,engineer,-
+1733,セキュリティ大ピンチ,71,お,無害な入力のはずが　コマンドが動いた,A harmless input executed a command.,OSコマンドインジェクション,engineer,-
+1734,セキュリティ大ピンチ,85,し,メンバーなのに　管理者になっていた,A normal user became an administrator.,JWT,engineer,-
+1735,セキュリティ大ピンチ,65,お,もれたトークンで　勝手に操作された,A leaked token was used for unauthorized access.,OAuth,engineer,-
+1736,セキュリティ大ピンチ,55,に,やっぱり開発環境だからと　チェックを外した,I disabled authentication because it was only a development environment.,認証,engineer,-
+1737,セキュリティ大ピンチ,60,に,ユーザー画面だけで　権限チェックしていた,Authorization was checked only on the client side.,認可,engineer,-
+1801,Webアプリ大ピンチ,10,き,更新したのに昨日の画面のままだった,The page still showed yesterday's version after deployment.,キャッシュ,engineer,-
+1802,Webアプリ大ピンチ,15,せ,ログインしたのにすぐログアウトされた,I was logged out right after logging in.,セッション,engineer,-
+1803,Webアプリ大ピンチ,20,と,注文ボタンを連打したら二重登録された,Clicking the order button repeatedly created duplicate records.,トランザクション,engineer,-
+1804,Webアプリ大ピンチ,16,く,これを消したらログインできるようになった,Deleting cookies fixed the login problem.,Cookie,engineer,-
+1805,Webアプリ大ピンチ,21,H,404しか返ってこない,Everything returned a 404 error.,HTTPステータスコード,engineer,-
+1806,Webアプリ大ピンチ,30,り,POSTしたのに画面が別ページへ飛んだ,"After POST, I was sent to another page.",リダイレクト,engineer,-
+1807,Webアプリ大ピンチ,31,ふ,画面遷移したら入力内容が消えなかった,The input remained after changing pages.,フォワード,engineer,-
+1808,Webアプリ大ピンチ,22,さ,画面は開くのにデータが表示されない,The page loads but no data appears.,Servlet,engineer,-
+1809,Webアプリ大ピンチ,32,J,コードを直したのに画面が変わらない,I edited a JSP but nothing changed.,JSP,engineer,-
+1810,Webアプリ大ピンチ,36,E,HTMLの中にJavaだらけで読めない,The JSP is full of Java code and unreadable.,EL式,engineer,-
+1811,Webアプリ大ピンチ,37,J,同じ処理を何度もJSPに書いてしまった,I duplicated the same logic across JSPs.,JSTL,engineer,-
+1812,Webアプリ大ピンチ,42,え,DBにはあるのに画面には表示されない,The data exists in the database but isn't shown.,MVC,engineer,-
+1813,Webアプリ大ピンチ,43,J,SQLは成功したのに画面が更新されない,The SQL succeeded but the screen didn't update.,JDBC,engineer,-
+1814,Webアプリ大ピンチ,23,S,コードを書き換えたらデータが入っていない,Changing one SQL query broke everything.,SQL,engineer,-
+1815,Webアプリ大ピンチ,54,い,検索だけやたら遅い,Only searches are extremely slow.,インデックス,engineer,-
+1816,Webアプリ大ピンチ,50,こ,接続数がいっぱいでDBにつながらない,The database refused more connections.,コネクションプール,engineer,-
+1817,Webアプリ大ピンチ,24,M,データベースが起動していなかった,The database server wasn't running.,MySQL,engineer,-
+1818,Webアプリ大ピンチ,38,P,再起動したら直った,Restarting the server fixed it.,Payara,engineer,-
+1819,Webアプリ大ピンチ,33,わ,デプロイしたのに反映されない,I deployed it but nothing changed.,WAR,engineer,-
+1820,Webアプリ大ピンチ,44,G,依存ライブラリを追加したのに読み込まれない,The dependency wasn't picked up after adding it.,Gradle,engineer,-
+1821,Webアプリ大ピンチ,45,い,昨日までビルドできたのに今日は失敗する,Yesterday's build worked but today's doesn't.,依存関係,engineer,-
+1822,Webアプリ大ピンチ,25,び,ソースは変えていないのに実行できない,"I changed nothing, but it no longer runs.",ビルド,engineer,-
+1823,Webアプリ大ピンチ,26,J,ボタンを押しても何も起きない,Clicking the button does nothing.,JavaScript,engineer,-
+1824,Webアプリ大ピンチ,34,D,要素が見つからないと言われた,The browser says the element can't be found.,DOM,engineer,-
+1825,Webアプリ大ピンチ,17,し,画面レイアウトがぐちゃぐちゃになった,The page layout completely broke.,CSS,engineer,-
+1826,Webアプリ大ピンチ,39,J,APIの返却結果が読めない,I can't parse the API response.,JSON,engineer,-
+1827,Webアプリ大ピンチ,40,A,画面はあるのにデータだけ取れない,The page loads but no data comes back.,AJAX,engineer,-
+1828,Webアプリ大ピンチ,46,ば,入力したのに保存できない,The form won't save my input.,バリデーション,engineer,-
+1829,Webアプリ大ピンチ,47,れ,エラー画面しか出ない,Only an error page is displayed.,例外処理,engineer,-
+1830,Webアプリ大ピンチ,27,ろ,何が起きたのか全然分からない,I have no idea what happened.,ログ,engineer,-
+1831,Webアプリ大ピンチ,48,す,エラーは出たけど原因が読めない,I see an error but can't identify the cause.,スタックトレース,engineer,-
+1832,Webアプリ大ピンチ,28,で,調べたら動いてしまう,The bug disappears during debugging.,デバッグ,engineer,-
+1833,Webアプリ大ピンチ,41,も,文字が全部「???」になった,All the text turned into question marks.,文字コード,engineer,-
+1834,Webアプリ大ピンチ,35,U,日本語だけ文字化けした,Only Japanese characters are garbled.,UTF-8,engineer,-
+1835,Webアプリ大ピンチ,29,G,最新コードを取ったら動かなくなった,Pulling the latest code broke everything.,Git,engineer,-
+1836,Webアプリ大ピンチ,51,ま,同じファイルを編集して取り込めない,I can't merge because we edited the same file.,マージコンフリクト,engineer,-
+1837,Webアプリ大ピンチ,52,C,ブラウザからだけAPIが呼べない,The API works elsewhere but not from the browser.,CORS,engineer,-
+1838,Webアプリ大ピンチ,55,N,SQLを1件取得するたびにSQLが増えていく,One query turns into hundreds of queries.,N+1問題,engineer,-
+1839,Webアプリ大ピンチ,53,ら,他の人が更新して保存できなかった,Someone else updated the record first.,楽観ロック,engineer,-
+1840,Webアプリ大ピンチ,49,に,ログイン状態なのに403になった,I'm logged in but received a 403.,認可,engineer,-
+1901,Windows大ピンチ,10,C,コピーしたつもりが　できていなかった,I thought I copied it but it wasn't copied.,Ctrl+C,engineer,-
+1902,Windows大ピンチ,11,V,貼り付けたいのに　右クリックできない,I want to paste but can't use the mouse.,Ctrl+V,engineer,-
+1903,Windows大ピンチ,12,X,別の場所へ　移動したい,I want to move it somewhere else.,Ctrl+X,engineer,-
+1904,Windows大ピンチ,13,Z,間違えて消してしまった,I accidentally deleted it.,Ctrl+Z,engineer,-
+1905,Windows大ピンチ,18,Y,戻しすぎて　やっぱり元に戻したい,I undid too much.,Ctrl+Y,engineer,-
+1906,Windows大ピンチ,14,A,全部まとめて選びたい,I want to select everything.,Ctrl+A,engineer,-
+1907,Windows大ピンチ,19,F,探したい文字が　見つからない,I can't find the text I'm looking for.,Ctrl+F,engineer,-
+1908,Windows大ピンチ,15,S,保存する前に　落ちそうだ,The application might crash before I save.,Ctrl+S,engineer,-
+1909,Windows大ピンチ,20,P,印刷したい,I want to print this.,Ctrl+P,engineer,-
+1910,Windows大ピンチ,24,T,新しいタブを　開きたい,I want to open a new tab.,Ctrl+T,engineer,-
+1911,Windows大ピンチ,33,T,閉じたタブを　戻したい,I want to reopen the tab I just closed.,Ctrl+Shift+T,engineer,-
+1912,Windows大ピンチ,21,R,更新したい,I want to refresh the page.,Ctrl+R,engineer,-
+1913,Windows大ピンチ,25,T,隣のタブへ　移動したい,I want to move to the next tab.,Ctrl+Tab,engineer,-
+1914,Windows大ピンチ,26,T,開きすぎて　目的の画面が見つからない,I have too many windows open.,Alt+Tab,engineer,-
+1915,Windows大ピンチ,22,D,デスクトップを　一瞬だけ見たい,I need to see the desktop quickly.,Windows+D,engineer,-
+1916,Windows大ピンチ,27,E,エクスプローラーを　開きたい,I need File Explorer.,Windows+E,engineer,-
+1917,Windows大ピンチ,28,L,席を離れるので　すぐロックしたい,I'm leaving my desk and want to lock my PC.,Windows+L,engineer,-
+1918,Windows大ピンチ,29,I,設定画面を　開きたい,I need to open Settings.,Windows+I,engineer,-
+1919,Windows大ピンチ,30,S,アプリやファイルを　すぐ探したい,I need to search for an app or file.,Windows+S,engineer,-
+1920,Windows大ピンチ,23,F,ファイル名を　変更したい,I want to rename a file.,F2,engineer,-
+1921,Windows大ピンチ,16,F,画面を　更新したい,I want to refresh the screen.,F5,engineer,-
+1922,Windows大ピンチ,17,F,ヘルプを　開きたい,I need help.,F1,engineer,-
+1923,Windows大ピンチ,34,F,終了ボタンが　押せない,I need to close the current application.,Alt+F4,engineer,-
+1924,Windows大ピンチ,38,E,固まったアプリを　調べたい,I need Task Manager.,Ctrl+Shift+Esc,engineer,-
+1925,Windows大ピンチ,31,D,ログイン画面に　戻りたい,I need the Windows security screen.,Ctrl+Alt+Delete,engineer,-
+1926,Windows大ピンチ,35,+,文字が小さすぎて　見えない,The text is too small to read.,Windows++,engineer,-
+1927,Windows大ピンチ,36,-,画面が大きすぎて　見づらい,Everything is zoomed in too much.,Windows+-,engineer,-
+1928,Windows大ピンチ,39,P,画面を　そのまま保存したい,I want to save a screenshot.,Windows+PrintScreen,engineer,-
+1929,Windows大ピンチ,32,S,画面の一部だけ　切り取りたい,I only need part of the screen.,Windows+Shift+S,engineer,-
+1930,Windows大ピンチ,37,.,絵文字を　入力したい,I want to insert an emoji.,Windows+.,engineer,-
+1931,Windows大ピンチ,40,V,さっきコピーしたものを　もう一度使いたい,I need something I copied earlier.,Windows+V,engineer,-
+1932,Windows大ピンチ,42,S,日本語入力に　切り替わらない,I can't switch the input language.,Alt+Shift,engineer,-
+1933,Windows大ピンチ,43,`,かな入力に　なってしまった,I accidentally switched input modes.,Alt+`,engineer,-
+1934,Windows大ピンチ,41,D,同じ操作を　何度も繰り返している,I'm repeating the same action over and over.,Ctrl+D,engineer,-
+1935,Windows大ピンチ,44,F,右クリックメニューを　開きたい,I need the context menu without a mouse.,Shift+F10,engineer,-
+2001,モダン開発大ピンチ,93,し,リリース直前に重大バグ発覚,A critical bug is discovered right before release.,シフトレフト,engineer,不具合は後ではなく、できるだけ開発の早い段階で見つけようという考え方。
+2002,モダン開発大ピンチ,15,し,本番環境でしか障害が起きない,The failure only happens in production.,シフトライト,engineer,リリース後の利用状況や運用データを開発改善に活かす考え方。
+2003,モダン開発大ピンチ,91,D,開発と運用が対立している,Development and operations are at odds.,DevOps,engineer,開発と運用の壁をなくし、素早く価値を届ける文化や手法。
+2004,モダン開発大ピンチ,85,D,セキュリティチェックがリリース直前,The security check happens right before release.,DevSecOps,engineer,セキュリティを開発や運用の後付けではなく、最初から組み込む考え方。
+2005,モダン開発大ピンチ,69,G,サーバー設定が誰にも分からない,Nobody understands the server configuration.,GitOps,engineer,Gitを唯一の正しい状態としてインフラやアプリを管理する運用手法。
+2006,モダン開発大ピンチ,61,P,開発環境構築に丸1日かかる,Setting up a dev environment takes a full day.,Platform Engineering,engineer,開発者が開発に集中できる共通基盤を提供する取り組み。
+2007,モダン開発大ピンチ,75,D,業務用語とコードの意味が噛み合わない,Business terms and code don't mean the same thing.,DDD,engineer,業務知識を中心にソフトウェアを設計する設計手法。
+2008,モダン開発大ピンチ,31,T,テストのたびに手作業祭り,Every test run turns into manual busywork.,TDD,engineer,まずテストを書き、その後で実装する開発手法。
+2009,モダン開発大ピンチ,57,B,ユーザーの期待と実装がずれる,What users expect and what's built don't match.,BDD,engineer,利用者の振る舞いを基準に仕様を表現しながら開発する手法。
+2010,モダン開発大ピンチ,55,り,誰も触れないコード爆誕,Code nobody dares to touch is born.,リファクタリング,engineer,動作は変えずにコードの構造だけを改善する作業。
+2011,モダン開発大ピンチ,95,C,マージのたびに動かなくなる,Every merge breaks the build.,CI,engineer,コード変更を頻繁に統合し、自動ビルドやテストを行う仕組み。
+2012,モダン開発大ピンチ,71,C,リリース準備だけで数週間,Just preparing a release takes weeks.,Continuous Delivery,engineer,いつでもリリースできる状態を維持する継続的な開発手法。
+2013,モダン開発大ピンチ,37,C,デプロイ担当待ちで開発停止,Development stalls waiting for someone to deploy.,Continuous Deployment,engineer,テストに合格した変更を人手を介さず本番へ反映する仕組み。
+2014,モダン開発大ピンチ,47,ひ,品質チェックが人頼み,Quality checks depend entirely on people.,品質ゲート,engineer,一定の品質基準を満たさなければ先へ進めない仕組み。
+2015,モダン開発大ピンチ,29,ふ,機能を試したいだけなのに再デプロイ,"You just want to try a feature, but must redeploy.",フィーチャーフラグ,engineer,デプロイせずに機能のオン・オフを切り替える仕組み。
+2016,モダン開発大ピンチ,77,か,全ユーザーに一斉リリースして炎上,Releasing to all users at once causes a meltdown.,カナリアリリース,engineer,一部の利用者だけに新機能を公開して安全性を確認する手法。
+2017,モダン開発大ピンチ,41,ぶ,本番切り替えに徹夜,Switching to production means an all-nighter.,ブルーグリーンデプロイ,engineer,新旧2つの環境を切り替えて安全にリリースする手法。
+2018,モダン開発大ピンチ,89,と,半年ブランチ放置で地獄,A branch left untouched for six months becomes hell.,トランクベース開発,engineer,長期間ブランチを分けず、メインブランチへ頻繁に統合する開発手法。
+2019,モダン開発大ピンチ,73,I,サーバー設定が職人技,Server configuration is a lost art known to one person.,IaC,engineer,サーバーやクラウド構成をコードとして管理する考え方。
+2020,モダン開発大ピンチ,81,D,自分のPCだけ動く,It only works on my machine.,Docker,engineer,アプリケーションを実行環境ごとパッケージ化するコンテナ技術。
+2021,モダン開発大ピンチ,33,K,コンテナが増えすぎて管理不能,Too many containers to manage.,Kubernetes,engineer,コンテナを自動配置・運用・拡張するオーケストレーション基盤。
+2022,モダン開発大ピンチ,13,さ,サービス間通信が複雑怪奇,Communication between services is a tangled mess.,サービスメッシュ,engineer,サービス間通信を共通基盤で管理する仕組み。
+2023,モダン開発大ピンチ,17,さ,サーバー管理だけで一日終了,A whole day gone just managing servers.,サーバーレス,engineer,サーバー管理を意識せずアプリケーションを実行する仕組み。
+2024,モダン開発大ピンチ,67,ま,一つの障害で全システム停止,One failure takes down the entire system.,マイクロサービス,engineer,システムを小さな独立したサービスへ分割する設計。
+2025,モダン開発大ピンチ,39,も,マイクロサービス化したら逆に複雑化,Going microservices made things more complex instead.,モジュラーモノリス,engineer,モノリスを保ちながら内部を疎結合なモジュールで構成する設計。
+2026,モダン開発大ピンチ,21,く,フレームワーク依存が深すぎる,The code is too deeply tied to the framework.,クリーンアーキテクチャ,engineer,ビジネスロジックを外部技術から独立させる設計思想。
+2027,モダン開発大ピンチ,11,C,読み取り処理が重すぎる,Read operations are too heavy.,CQRS,engineer,更新処理と参照処理を分離して設計するアーキテクチャ。
+2028,モダン開発大ピンチ,49,E,過去データが復元できない,Past data can't be reconstructed.,Event Sourcing,engineer,状態ではなく発生したイベントを記録してシステムを管理する手法。
+2029,モダン開発大ピンチ,97,O,障害原因が誰にも分からない,Nobody can tell what caused the failure.,Observability,engineer,システム内部の状態を外部から把握しやすくする考え方。
+2030,モダン開発大ピンチ,25,O,ログ形式がバラバラ,Log formats are all over the place.,OpenTelemetry,engineer,ログ・メトリクス・トレースを共通仕様で収集する仕組み。
+2031,モダン開発大ピンチ,19,S,品質を感覚で議論する,Quality gets debated based on gut feeling.,SLI,engineer,サービス品質を測るための具体的な指標。
+2032,モダン開発大ピンチ,35,S,「速いサービス」の定義が曖昧,What counts as a 'fast service' is vague.,SLO,engineer,サービス品質について目標値を定めたもの。
+2033,モダン開発大ピンチ,65,え,完璧を求めすぎて何も出せない,Chasing perfection means nothing ships.,エラーバジェット,engineer,許容できる障害や失敗の範囲を数値化した考え方。
+2034,モダン開発大ピンチ,59,ぽ,障害の犯人探し大会,The incident turns into a witch hunt.,ポストモーテム,engineer,障害後に原因や改善策を振り返る活動。
+2035,モダン開発大ピンチ,83,Z,社内ネットワークだから安心,It's assumed safe just because it's the internal network.,Zero Trust,engineer,社内外を問わず何も信用せず毎回検証するセキュリティモデル。
+2036,モダン開発大ピンチ,63,S,脆弱ライブラリ混入,A vulnerable library sneaks in.,SBOM,engineer,ソフトウェアを構成する部品一覧をまとめた情報。
+2037,モダン開発大ピンチ,45,P,セキュリティルールが口伝,Security rules are only passed down by word of mouth.,Policy as Code,engineer,ルールやポリシーをコードで管理・自動適用する手法。
+2038,モダン開発大ピンチ,23,F,開発力を勘で評価している,Team performance is judged by gut feeling.,Four Keys,engineer,デリバリー性能を4つの指標で測定するフレームワーク。
+2039,モダン開発大ピンチ,1,D,改善効果が見えない,You can't see whether improvements are working.,DORAメトリクス,engineer,開発組織の成果を測る代表的な4つの指標。
+2040,モダン開発大ピンチ,53,S,コミット数だけで評価,People are evaluated by commit count alone.,SPACEフレームワーク,engineer,生産性を多面的に評価するためのフレームワーク。
+2041,モダン開発大ピンチ,79,D,優秀な人ほど辞める,The best people are the ones who quit.,DevEx,engineer,開発者が快適に開発できる体験を重視する考え方。
+2042,モダン開発大ピンチ,87,C,ベテランしか理解できない,Only veterans can understand it.,Cognitive Load,engineer,開発者が理解や作業に必要とする認知的な負荷。
+2043,モダン開発大ピンチ,99,ぎ,短納期のツケで保守不能,The cost of a rushed deadline makes it unmaintainable.,技術的負債,engineer,将来の保守性を犠牲にして短期的な開発を優先した結果生じる問題。
+2044,モダン開発大ピンチ,27,ご,チームごとに開発手順が違う,Every team follows a different process.,ゴールデンパス,engineer,開発者が迷わず利用できる推奨された標準的な開発手順。
+2045,モダン開発大ピンチ,9,A,AIが指示待ち人間,The AI just waits around for instructions.,AIエージェント,engineer,人の指示だけでなく、自律的に判断しながら作業を進めるAI。
+2046,モダン開発大ピンチ,51,C,AIが仕様を誤解する,The AI misunderstands the spec.,Context Engineering,engineer,AIが必要な情報を適切に利用できるよう文脈を設計する技術。
+2047,モダン開発大ピンチ,3,M,AIごとに連携方法が違う,Every AI connects in a different way.,MCP,engineer,AIが外部ツールやデータと標準方式で連携するためのプロトコル。
+2048,モダン開発大ピンチ,43,R,AIが古い知識で回答する,The AI answers with outdated knowledge.,RAG,engineer,外部知識を検索してからAIが回答を生成する手法。
+2049,モダン開発大ピンチ,7,A,AIが単発作業しかできない,The AI can only handle one-off tasks.,Agentic Workflow,engineer,AIが複数の工程を自律的に計画・実行するワークフロー。
+2050,モダン開発大ピンチ,5,A,なぜこの設計なのか誰も知らない,Nobody knows why the design is this way.,ADR,engineer,設計上の重要な意思決定とその理由を記録する文書。
+2100,大ピンチ法則かるた,79,べ,ボタン連打でデータが二重登録,Mashing the button registers the data twice.,冪等性,engineer,呼び出す回数によらず、同じ結果になる操作の性質。
+2101,大ピンチ法則かるた,60,ぽ,厳密すぎて外部サービスと連携不能,Being too strict breaks integration with external services.,ポステルの法則,engineer,送信するデータには厳格に、受け取るデータには寛容にせよという設計指針。
+2102,大ピンチ法則かるた,23,は,誰も知らない挙動を変えたら大炎上,Changing behavior nobody knew about causes a meltdown.,ハイラムの法則,engineer,利用者が増えるほど、実装の詳細まで暗黙の仕様になってしまうという法則。
+2103,大ピンチ法則かるた,55,り,レビュー不足でバグが埋もれる,Bugs stay buried because of too little review.,リーナスの法則,engineer,目に触れる人が多いオープンソースほど、バグは早く見つかり浅くなるという法則。
+2104,大ピンチ法則かるた,14,ざ,便利機能を足し続けてメールソフト化,Adding convenience features endlessly turns it into a mail client.,ザウィンスキーの法則,engineer,組織のプロジェクトはいずれ、メール読み上げソフトを再発明することになるという法則。
+2105,大ピンチ法則かるた,34,め,利用者が少なく価値が生まれない,Too few users means no value is created.,メトカーフの法則,engineer,ネットワークの価値は、利用者数の2乗に比例して大きくなるという法則。
+2106,大ピンチ法則かるた,94,む,性能向上を当てにした設計が破綻,A design betting on future performance gains falls apart.,ムーアの法則,engineer,半導体の集積度は、およそ2年ごとに倍になるという経験則。
+2107,大ピンチ法則かるた,64,C,全部入りを目指して全部失う,Trying to have it all means losing it all.,CAP定理,engineer,分散システムでは、一貫性・可用性・分断耐性の3つを同時には満たせないという定理。
+2108,大ピンチ法則かるた,51,け,更新したのに画面が食い違う,"You updated it, but the screens disagree.",結果整合性,engineer,更新の直後は一時的にずれても、時間が経てば最終的に整合が取れるという考え方。
+2109,大ピンチ法則かるた,27,ば,処理が追いつかずシステムが詰まる,Processing can't keep up and the system chokes.,バックプレッシャー,engineer,処理が追いつかない受け手が、送り手に流量を抑えるよう伝える仕組み。
+2110,大ピンチ法則かるた,21,ゔ,長年の改修で誰も理解できない,Years of changes leave nobody able to understand it.,ヴィルトの法則,engineer,ソフトウェアは使われ続ける限り、複雑さが増していくという経験則。
+2111,大ピンチ法則かるた,70,た,一つ直したら別の機能も壊れる,"Fix one thing, break another feature.",単一責務の原則,engineer,1つのクラスやモジュールが持つ、変更する理由は1つだけであるべきという原則。
+2112,大ピンチ法則かるた,67,か,UI変更なのにDB修正が必要,A UI change somehow requires a database fix.,関心の分離,engineer,1つの処理が扱う関心事は1つに絞るべきだという設計思想。
+2113,大ピンチ法則かるた,83,ぎ,先送りのツケで大改修が必要に,Postponing it now means a massive rebuild is required.,技術的負債,engineer,その場しのぎの対応を続けた結果、あとで返済が必要になる開発上の負債。
+2114,大ピンチ法則かるた,26,で,他人の内部事情まで知りすぎる,It knows way too much about someone else's internals.,デメテルの法則,engineer,オブジェクトは直接の友達とだけ話し、他人の内部構造を知りすぎるべきではないという原則。
+2115,大ピンチ法則かるた,31,も,隠したはずの仕組みが漏れ出す,The mechanism you tried to hide leaks through anyway.,漏れ出す抽象化の法則,engineer,複雑な仕組みを隠す抽象化ほど、どこかで詳細が透けて見えてしまうという法則。
+2116,大ピンチ法則かるた,25,ふ,エラーを隠して障害が拡大,Hiding the error lets the failure spread.,フェイルファスト,engineer,エラーを隠さず、問題が起きたらすぐに処理を止めて知らせる設計方針。
+2117,大ピンチ法則かるた,57,か,機能追加のたび既存コードを書き換える,Every new feature means rewriting existing code.,解放閉鎖の原則,engineer,既存のコードを変更せずに、拡張だけで機能を追加できるようにすべきという原則。
+2118,大ピンチ法則かるた,22,ぎ,複雑な仕組みを一気に作って失敗,Building a complex system all at once fails.,ギャルの法則,engineer,複雑な仕組みは、うまく機能する単純な仕組みを育てて作るしかないという経験則。
+2119,大ピンチ法則かるた,99,D,同じ修正を十か所に反映,The same fix has to be applied in ten places.,DRY,engineer,同じ知識やロジックを、コード中に繰り返し書かないようにするという原則。
+2120,大ピンチ法則かるた,97,K,賢すぎる設計で誰も理解できない,The design is too clever for anyone to understand.,KISS,engineer,仕組みはできる限り単純に保つべきだという設計の格言。
+2121,大ピンチ法則かるた,88,S,設計ルールが崩れて泥団子化,The design rules collapse into a big ball of mud.,SOLID,engineer,保守しやすいオブジェクト指向設計のための、5つの原則の頭文字。
+2122,大ピンチ法則かるた,49,U,一つのツールが何でも屋になる,One tool ends up doing everything.,Unix哲学,engineer,小さな部品を組み合わせ、テキストで連携させるという設計思想。
+2123,大ピンチ法則かるた,18,E,正しいが誰も変更できないコード,Code that's correct but nobody dares to change.,ETC,engineer,正しさと同じくらい、変更のしやすさを重視すべきだという設計指針。
+2124,大ピンチ法則かるた,38,ご,一人で悩み続けて一日終了,A whole day spent agonizing alone.,ゴムのアヒルデバッグ,engineer,人形に向かって説明しているうちに、自分でバグの原因に気づく手法。
+2125,大ピンチ法則かるた,73,ぶ,人を増やしたのに納期が延びる,Adding more people only pushes the deadline back.,ブルックスの法則,engineer,人員を追加しても、遅れているプロジェクトはかえって遅れるという法則。
+2126,大ピンチ法則かるた,17,9,あと一割が終わらない,The last ten percent never gets done.,90対90の法則,engineer,作業の9割が終わるのに全体の9割の時間がかかり、残り1割にも同じだけかかるという経験則。
+2127,大ピンチ法則かるた,16,ほ,見積もりが毎回外れる,The estimate is wrong every single time.,ホフスタッターの法則,engineer,物事は思ったより時間がかかる、そう分かっていてもという法則。
+2128,大ピンチ法則かるた,86,Y,誰も使わない機能を量産,Features nobody uses keep piling up.,YAGNI,engineer,今必要ないなら作るな、という開発の原則。
+2129,大ピンチ法則かるた,42,ぷ,試作品がそのまま本番化,The prototype becomes production as-is.,プロトタイプ,engineer,本番の設計に入る前に、まず試しに作ってみる簡易な実装。
+2130,大ピンチ法則かるた,10,と,最後まで繋いだら動かない,Wiring it end-to-end reveals it doesn't work.,トレーサーバレット,engineer,要となる機能だけを最初から実際に動く形で貫通させて作る開発手法。
+2131,大ピンチ法則かるた,62,さ,全員が本番DBを消せる,Everyone has permission to delete the production database.,最小権限の原則,engineer,利用者やプロセスには、仕事に必要な最小限の権限しか与えないという原則。
+2132,大ピンチ法則かるた,54,ふ,一つ壊れただけで全停止,One failure takes the whole thing down.,フェイルセーフ,engineer,一部が故障しても、安全な状態を保つように設計する考え方。
+2133,大ピンチ法則かるた,48,わ,小さな手抜きが大崩壊を招く,A small shortcut leads to total collapse.,割れ窓理論,engineer,小さな乱れを放置すると、やがて大きな荒廃を招くという理論。
+2134,大ピンチ法則かるた,33,ぐ,一部障害でサービス全停止,A partial failure takes the entire service down.,グレースフルデグラデーション,engineer,一部の機能が使えなくても、全体は動き続けるように落とし所を用意する設計。
+2135,大ピンチ法則かるた,20,す,作った機能の九割が使われない,Ninety percent of the features built go unused.,スタージョンの法則,engineer,あらゆる創作物の9割はくだらない、という経験則。
+2136,大ピンチ法則かるた,37,ば,一人辞めたら開発停止,One person leaves and development grinds to a halt.,バス係数,engineer,その人がいなくなるとプロジェクトが立ち行かなくなる人数の少なさを表す指標。
+2137,大ピンチ法則かるた,71,ぴ,昇進したら誰も幸せにならない,The promotion makes nobody happy.,ピーターの法則,engineer,有能な人はやがて、自分の能力の限界にあたる地位まで昇進するという法則。
+2138,大ピンチ法則かるた,90,こ,組織図そのままのシステム誕生,The system ends up mirroring the org chart exactly.,コンウェイの法則,engineer,システムの構造は、それを作る組織の伝達構造をそのまま映すという法則。
+2139,大ピンチ法則かるた,40,ぴ,期待されず成長が止まる,Growth stalls when nobody expects anything.,ピグマリオン効果,engineer,期待をかけられると、その期待どおりに成果が伸びていく効果。
+2140,大ピンチ法則かるた,93,ぱ,重要な二割を見誤る,The critical twenty percent gets misjudged.,パレートの法則,engineer,成果の8割は、全体のうち2割の原因から生まれるという経験則。
+2141,大ピンチ法則かるた,50,M,分類漏れと重複だらけ,Full of gaps and overlaps in the classification.,MECE,engineer,モレなくダブりなく物事を分類するという考え方の頭文字。
+2142,大ピンチ法則かるた,53,お,複雑な説明ばかり増える,Explanations just keep getting more convoluted.,オッカムの剃刀,engineer,むやみに複雑な説明より、単純な説明を選ぶべきだという指針。
+2143,大ピンチ法則かるた,12,ち,理由も知らずに消して事故,Removing it without knowing why causes an accident.,チェスタトンの柵,engineer,使われていない小さな柵でも、理由が分かるまでは壊してはいけないという教え。
+2144,大ピンチ法則かるた,28,り,見方を変えられず行き詰まる,Stuck because nobody can change their perspective.,リフレーミング,engineer,物事のとらえ方の枠組みを変え、違う意味づけをし直すこと。
+2145,大ピンチ法則かるた,32,ぐ,指標を追って本質を失う,Chasing the metric loses sight of the point.,グッドハートの法則,engineer,指標を目標にした瞬間、その指標は良い指標でなくなるという法則。
+2146,大ピンチ法則かるた,11,き,KPI達成のため数字を盛る,The numbers get inflated just to hit the KPI.,キャンベルの法則,engineer,数値目標に圧力がかかるほど、その数値自体が歪められやすくなるという法則。
+2147,大ピンチ法則かるた,7,じ,見えている範囲だけで判断,Judging everything from only what's visible.,ジョシュアツリーの法則,engineer,見えている木の背後にどれだけ木があるかで、森の大きさを見積もれるという経験則。
+2148,大ピンチ法則かるた,95,だ,自信満々なのに実力不足,"Full of confidence, short on actual skill.",ダニングクルーガー効果,engineer,能力が低い人ほど、自分の能力の低さに気づけないという認知バイアス。
+2149,大ピンチ法則かるた,92,か,都合の良い情報しか見ない,Only the convenient information gets noticed.,確証バイアス,engineer,自分の考えに合う情報ばかり集め、反する情報を軽視してしまう偏り。
+2150,大ピンチ法則かるた,82,は,一つの長所だけで全部高評価,One strength earns a high rating on everything.,ハロー効果,engineer,一つの好印象に引きずられて、他の面まで高く評価してしまう効果。
+2151,大ピンチ法則かるた,15,さ,気づかぬうちに判断を誘導される,A judgment gets nudged without anyone noticing.,サブリミナル効果,engineer,意識にのぼらないほど短い刺激が、後の判断に影響を与える効果。
+2152,大ピンチ法則かるた,89,せ,成功例だけ真似して失敗,Copying only the success stories leads to failure.,生存者バイアス,engineer,失敗した例が見えないまま、成功した例だけを見て判断してしまう偏り。
+2153,大ピンチ法則かるた,44,ば,急に全部が気になり始める,Suddenly it seems to be everywhere.,バーダーマインホフ現象,engineer,一度気になり始めると、その物事が身の回りのあちこちで目につくようになる現象。
+2154,大ピンチ法則かるた,45,か,禁止したら余計にやりたくなる,Banning it only makes people want it more.,カリギュラ効果,engineer,禁止されるとかえって、その物事に強く惹かれてしまう心理。
+2155,大ピンチ法則かるた,65,し,第一印象だけで評価が決まる,The first impression decides the whole evaluation.,初頭効果,engineer,最初に与えられた情報ほど、記憶に残り印象を左右しやすいという効果。
+2156,大ピンチ法則かるた,68,ざ,顔を出す人だけ評価される,Only the person who shows up gets the credit.,ザイオンス効果,engineer,何度も接するうちに、対象への好感度が自然と高まっていく効果。
+2157,大ピンチ法則かるた,61,か,興味のある話しか耳に入らない,Only the topics you care about actually get heard.,カクテルパーティー効果,engineer,周りが騒がしくても、自分の名前や関心事だけは聞き取れる現象。
+2158,大ピンチ法則かるた,81,ば,みんなが使うから採用,It gets adopted just because everyone else uses it.,バンドワゴン効果,engineer,周りが支持しているものほど、自分も支持したくなる心理。
+2159,大ピンチ法則かるた,75,し,人気だけで技術選定,The tech choice is made on popularity alone.,社会的証明,engineer,多くの人が選んでいるという事実自体が、正しさの根拠に感じられる心理。
+2160,大ピンチ法則かるた,78,あ,最初の数字から離れられない,Nobody can move past the first number they heard.,アンカリング効果,engineer,最初に見た数字に、その後の判断が引きずられてしまう効果。
+2161,大ピンチ法則かるた,98,ま,本番だけ、なぜか落ちる,It only ever crashes in production.,マーフィーの法則,engineer,うまくいってほしくないことほど、実際に起きてしまうという経験則。
+2162,大ピンチ法則かるた,59,ふ,操作ミスで重大事故,A simple mistake causes a serious incident.,フールプルーフ,engineer,使い方を間違えようとしても、簡単には間違えられないような設計。
+2163,大ピンチ法則かるた,56,お,ボタンを押したら予想外の動作,Pressing the button does something unexpected.,驚き最小の原則,engineer,利用者を無用に驚かせない、予想どおりに振る舞う設計であるべきという原則。
+2164,大ピンチ法則かるた,43,で,初期設定のまま本番投入,It ships to production with the default settings untouched.,デフォルト効果,engineer,最初から用意された選択肢のままにしておく人が多いという効果。
+2165,大ピンチ法則かるた,47,W,同じコードを何度もコピペ,The same code gets copy-pasted over and over.,WET,engineer,共通化を怠って、同じコードをあちこちに書き広げてしまう状態。
+2166,大ピンチ法則かるた,87,し,既存ライブラリを無視して自作,An existing library gets ignored in favor of building it from scratch.,車輪の再発明,engineer,既にある解決策を知らずに、一から同じものを作り直してしまうこと。
+2167,大ピンチ法則かるた,84,ゆ,少しずつ悪化して手遅れ,It gets gradually worse until it's too late.,茹でガエル,engineer,少しずつの変化に慣れてしまい、危機に気づかず茹で上がってしまうたとえ話。
+2168,大ピンチ法則かるた,6,や,本題に入れず一日終了,The whole day goes by without ever reaching the actual task.,ヤクの毛刈り,engineer,本来の目的から逸れ、その前提を整えるための作業に次々と手を取られること。
+2169,大ピンチ法則かるた,29,い,協力が集まらず企画倒れ,Nobody chips in and the plan falls apart.,石のスープ,engineer,何もない所から始めても、協力が集まれば豊かな成果になるという寓話。
+2170,大ピンチ法則かるた,77,ぱ,締切まで仕事が膨らみ続ける,Work keeps expanding to fill the time until the deadline.,パーキンソンの法則,engineer,与えられた期限いっぱいまで、仕事は膨張してしまうという法則。
+2171,大ピンチ法則かるた,5,き,改善を後回しにして疲弊,Putting off the improvement leads to burnout.,木こりのジレンマ,engineer,斧を研ぐ時間を惜しんで、非効率な作業を続けてしまうというたとえ話。
+2172,大ピンチ法則かるた,39,ぱ,重要な議題ほど後回し,"The more important the topic, the more it gets postponed.",パーキンソンの凡俗法則,engineer,重要な議題より、些細で分かりやすい議題に議論の時間が割かれてしまうという法則。
+2173,大ピンチ法則かるた,66,こ,やめ時を失って炎上継続,Missing the moment to quit keeps the fire burning.,コンコルド効果,engineer,すでに費やした分がもったいなくて、やめるべき計画をやめられなくなる心理。
+2174,大ピンチ法則かるた,36,ふ,小さな依頼が大仕事になる,A small favor turns into a huge job.,フットインザドア効果,engineer,小さな頼み事を承諾させてから、本命の大きな頼み事を通しやすくする手法。
+2175,大ピンチ法則かるた,76,へ,借りを返すため残業,Working overtime just to repay a favor.,返報性の法則,engineer,何かをしてもらうと、お返しをしなければと感じてしまう心理。
+2176,大ピンチ法則かるた,72,け,偉い人の一声で仕様変更,One word from someone senior changes the spec.,権威性の法則,engineer,専門家や肩書きのある人の言うことほど、信じやすくなる心理。
+2177,大ピンチ法則かるた,9,り,良い話だけして信用を失う,Only mentioning the upside costs you trust.,両面提示の法則,engineer,良い面だけでなく悪い面も併せて伝えた方が、かえって信頼されやすいという法則。

--- a/backend/quizRoomHandler.js
+++ b/backend/quizRoomHandler.js
@@ -339,11 +339,13 @@ exports.syncQuizRoom = async (event) => {
       });
     }
 
-    // ポイント制（issue #519）: 再接続・遅れて参加した端末にも現在の集計を伝える
-    if (room.Item.points) {
+    // ポイント制（issue #519）・回答数集計（issue #698）: 再接続・遅れて参加した
+    // 端末にも現在の集計を伝える
+    if (room.Item.points || room.Item.answerCounts) {
       await postToConnection(managementApi, connectionId, {
         type: "points",
-        points: room.Item.points,
+        points: room.Item.points || {},
+        answerCounts: room.Item.answerCounts || {},
       });
     }
 
@@ -488,32 +490,45 @@ exports.judgeQuizRoomBuzz = async (event) => {
     }));
     const managementApi = buildManagementApiClient(event);
 
+    // 回答数集計（issue #698）: 早押しして正誤判定された累計回数（attempts）と、
+    // そのうち正解と判定された累計回数（correct）を、正解・不正解いずれの
+    // 判定でも記録する。pointsと同様にDynamoDBのルームアイテムへ保持するため、
+    // 切断・退室後も（pointsと同じ寿命で）残り続ける
+    const updatedAnswerCounts = { ...(room.Item.answerCounts || {}) };
+    const previousCount = updatedAnswerCounts[buzzedName] || { attempts: 0, correct: 0 };
+    updatedAnswerCounts[buzzedName] = {
+      attempts: previousCount.attempts + 1,
+      correct: previousCount.correct + (correct ? 1 : 0),
+    };
+
     if (correct) {
       const updatedPoints = { ...(room.Item.points || {}) };
       updatedPoints[buzzedName] = (updatedPoints[buzzedName] || 0) + 1;
       await docClient.send(new UpdateCommand({
         TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
         Key: { roomId },
-        UpdateExpression: "SET points = :points REMOVE buzz, excludedNames",
-        ExpressionAttributeValues: { ":points": updatedPoints },
+        UpdateExpression: "SET points = :points, answerCounts = :answerCounts REMOVE buzz, excludedNames",
+        ExpressionAttributeValues: { ":points": updatedPoints, ":answerCounts": updatedAnswerCounts },
       }));
       await Promise.allSettled(
         (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
           type: "points",
           points: updatedPoints,
+          answerCounts: updatedAnswerCounts,
         }))
       );
     } else {
       await docClient.send(new UpdateCommand({
         TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
         Key: { roomId },
-        UpdateExpression: "REMOVE buzz ADD excludedNames :names",
-        ExpressionAttributeValues: { ":names": new Set([buzzedName]) },
+        UpdateExpression: "SET answerCounts = :answerCounts REMOVE buzz ADD excludedNames :names",
+        ExpressionAttributeValues: { ":answerCounts": updatedAnswerCounts, ":names": new Set([buzzedName]) },
       }));
       await Promise.allSettled(
         (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
           type: "roundReset",
           excludedName: buzzedName,
+          answerCounts: updatedAnswerCounts,
         }))
       );
     }
@@ -542,10 +557,12 @@ exports.resetQuizRoomPoints = async (event) => {
     }
 
     const { roomId } = connection.Item;
+    // 回答数集計（issue #698）: 同じルームで2ゲーム目を始める際の再スタートなので、
+    // pointsと同じタイミングでanswerCountsもリセットする
     await docClient.send(new UpdateCommand({
       TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
       Key: { roomId },
-      UpdateExpression: "REMOVE points",
+      UpdateExpression: "REMOVE points, answerCounts",
     }));
 
     const connections = await docClient.send(new QueryCommand({
@@ -559,6 +576,7 @@ exports.resetQuizRoomPoints = async (event) => {
       (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
         type: "points",
         points: {},
+        answerCounts: {},
       }))
     );
 

--- a/backend/quizRoomHandler.test.js
+++ b/backend/quizRoomHandler.test.js
@@ -404,7 +404,27 @@ describe('syncQuizRoom', () => {
     const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
     expect(postCalls).toHaveLength(3);
     const pointsPayload = JSON.parse(Buffer.from(postCalls[1].args[0].input.Data).toString('utf-8'));
-    expect(pointsPayload).toEqual({ type: 'points', points: { たろう: 2, はなこ: 1 } });
+    expect(pointsPayload).toEqual({ type: 'points', points: { たろう: 2, はなこ: 1 }, answerCounts: {} });
+  });
+
+  it('also sends the current answer counts (attempts/correct) to a reconnecting/late-joining participant (issue #698)', async () => {
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRoomConnections' }).resolves({
+      Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' },
+    });
+    ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({
+      Item: {
+        roomId: 'ROOM01',
+        state: { type: 'phrase', content: { id: 'p1' } },
+        answerCounts: { たろう: { attempts: 3, correct: 2 } },
+      },
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+
+    await syncQuizRoom(wsEvent({ connectionId: 'conn-1' }));
+
+    const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
+    const pointsPayload = JSON.parse(Buffer.from(postCalls[1].args[0].input.Data).toString('utf-8'));
+    expect(pointsPayload).toEqual({ type: 'points', points: {}, answerCounts: { たろう: { attempts: 3, correct: 2 } } });
   });
 
   it('does not send a points message when no one has scored yet', async () => {
@@ -863,7 +883,12 @@ describe('judgeQuizRoomBuzz', () => {
       Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
     });
     ddbMock.on(GetCommand, { TableName: 'TestQuizRooms' }).resolves({
-      Item: { roomId: 'ROOM01', buzz: { connectionId: 'conn-p', name: 'たろう', buzzedAt: 1000 }, points: { たろう: 1 } },
+      Item: {
+        roomId: 'ROOM01',
+        buzz: { connectionId: 'conn-p', name: 'たろう', buzzedAt: 1000 },
+        points: { たろう: 1 },
+        answerCounts: { たろう: { attempts: 1, correct: 1 } },
+      },
     });
     ddbMock.on(UpdateCommand).resolves({});
     ddbMock.on(QueryCommand).resolves({
@@ -880,12 +905,14 @@ describe('judgeQuizRoomBuzz', () => {
     const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
     expect(updateCall.Key).toEqual({ roomId: 'ROOM01' });
     expect(updateCall.ExpressionAttributeValues[':points']).toEqual({ たろう: 2 });
-    expect(updateCall.UpdateExpression).toBe('SET points = :points REMOVE buzz, excludedNames');
+    // 回答数集計（issue #698）: 正解判定でもattempts/correctを両方インクリメントする
+    expect(updateCall.ExpressionAttributeValues[':answerCounts']).toEqual({ たろう: { attempts: 2, correct: 2 } });
+    expect(updateCall.UpdateExpression).toBe('SET points = :points, answerCounts = :answerCounts REMOVE buzz, excludedNames');
 
     const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
     expect(postCalls).toHaveLength(2);
     const payload = JSON.parse(Buffer.from(postCalls[0].args[0].input.Data).toString('utf-8'));
-    expect(payload).toEqual({ type: 'points', points: { たろう: 2 } });
+    expect(payload).toEqual({ type: 'points', points: { たろう: 2 }, answerCounts: { たろう: { attempts: 2, correct: 2 } } });
   });
 
   it('clears buzz, excludes the participant from the round, and broadcasts a roundReset when judged incorrect', async () => {
@@ -909,14 +936,16 @@ describe('judgeQuizRoomBuzz', () => {
     expect(response.statusCode).toBe(200);
     const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
     expect(updateCall.Key).toEqual({ roomId: 'ROOM01' });
-    expect(updateCall.UpdateExpression).toBe('REMOVE buzz ADD excludedNames :names');
+    expect(updateCall.UpdateExpression).toBe('SET answerCounts = :answerCounts REMOVE buzz ADD excludedNames :names');
     expect(updateCall.ExpressionAttributeValues[':names']).toEqual(new Set(['たろう']));
     expect(updateCall.ExpressionAttributeValues[':points']).toBeUndefined();
+    // 回答数集計（issue #698）: 不正解判定でもattemptsはインクリメントされるが、correctはされない
+    expect(updateCall.ExpressionAttributeValues[':answerCounts']).toEqual({ たろう: { attempts: 1, correct: 0 } });
 
     const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
     expect(postCalls).toHaveLength(2);
     const payload = JSON.parse(Buffer.from(postCalls[0].args[0].input.Data).toString('utf-8'));
-    expect(payload).toEqual({ type: 'roundReset', excludedName: 'たろう' });
+    expect(payload).toEqual({ type: 'roundReset', excludedName: 'たろう', answerCounts: { たろう: { attempts: 1, correct: 0 } } });
   });
 
   it('handles unexpected errors', async () => {
@@ -957,12 +986,14 @@ describe('resetQuizRoomPoints', () => {
     expect(response.statusCode).toBe(200);
     const updateCall = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
     expect(updateCall.Key).toEqual({ roomId: 'ROOM01' });
-    expect(updateCall.UpdateExpression).toBe('REMOVE points');
+    // 回答数集計（issue #698）: 2ゲーム目の再スタートとしてanswerCountsもpointsと
+    // 同時にリセットする
+    expect(updateCall.UpdateExpression).toBe('REMOVE points, answerCounts');
 
     const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
     expect(postCalls).toHaveLength(2);
     const payload = JSON.parse(Buffer.from(postCalls[0].args[0].input.Data).toString('utf-8'));
-    expect(payload).toEqual({ type: 'points', points: {} });
+    expect(payload).toEqual({ type: 'points', points: {}, answerCounts: {} });
   });
 
   it('handles unexpected errors', async () => {

--- a/backend/seed.js
+++ b/backend/seed.js
@@ -68,6 +68,7 @@ async function seed() {
         phrase: record.phrase ? record.phrase.trim() : "",
         phrase_en: record.phrase_en ? record.phrase_en.trim() : "",
         answer: record.answer ? record.answer.trim() : "-",
+        explanation: record.explanation ? record.explanation.trim() : "-",
         readCount: existingItem ? existingItem.readCount : 0,
         averageTime: existingItem ? existingItem.averageTime : 0,
         averageDifficulty: existingItem ? (existingItem.averageDifficulty || 0) : 0,

--- a/frontend/e2e/quiz-room.spec.js
+++ b/frontend/e2e/quiz-room.spec.js
@@ -228,11 +228,16 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
     await captureScreenshot(adminPage, testInfo, 'admin-after-correct-judgment', '管理者：正解判定後の状態');
 
     // ポイントが参加者一覧（管理者側、ルーム情報画面、issue #587）に反映される
-    // （参加者側は獲得ポイント表示で確認済み、issue #519, #545）。回答数・正答数の
-    // 2列（issue #698）: はなこは1回答1正答、たろうは1回答0正答（不正解判定のみ）
+    // （参加者側は獲得ポイント表示で確認済み、issue #519, #545）。
+    // 回答数・正答数の2列（issue #698）: このE2Eは実際にデプロイ済みのバックエンドに
+    // 対して実行されるため（playwright.config.js冒頭のコメント参照）、本PRで追加した
+    // answerCountsのブロードキャストは、本PRマージ後のCD実行までは反映されず「回答数」は
+    // 常に0のまま表示される。そのため現時点では「正答数（pt相当）」のみ正しく反映される
+    // 前提でアサーションする。CD実行後のフォローアップPRで「はなこ接続中11」「たろう接続中10」
+    // （実際の回答数を反映した値）へ更新すること
     await roomInfoLink.click();
-    await expect(adminPage.getByRole('row').nth(1)).toHaveText('はなこ接続中11', { timeout: 15000 });
-    await expect(adminPage.getByRole('row').nth(2)).toHaveText('たろう接続中10');
+    await expect(adminPage.getByRole('row').nth(1)).toHaveText('はなこ接続中01', { timeout: 15000 });
+    await expect(adminPage.getByRole('row').nth(2)).toHaveText('たろう接続中00');
   } finally {
     // カバレッジ計測（issue #541）: 失敗時も可能な範囲でカバレッジを収集するため、
     // コンテキストを閉じる前にtry節の成否に関わらず停止・収集する

--- a/frontend/e2e/quiz-room.spec.js
+++ b/frontend/e2e/quiz-room.spec.js
@@ -65,10 +65,12 @@ test('admin creates a quiz room and a participant sees the same card update in r
   }
 });
 
-// issue #640: 管理者側でadminTokenが失われた場合（今回はページのリロードで再現する）の
-// 実際の挙動を固定化する回帰テスト。adminTokenはReact stateにのみ保持されており
-// （useQuizRoomAdmin.js）永続化されていないため、リロード後は同じルームへ管理者として
-// 戻る手段が無い。「治る」ことを検証するテストではなく、現状の既知の制約
+// issue #640: 管理者がリロードした（このテストの再現方法）その場での挙動を固定化する
+// 回帰テスト。adminTokenはissue #697でlocalStorageへ永続化されたが、それはあくまで
+// 「参加者画面から『管理者に切り替える』ボタンで再接続する」という別導線での復帰を
+// 可能にするものであり、リロードされた本人のタブが自動的に管理者画面へ戻るわけではない。
+// そのため、このテストが記録する「リロードした直後のタブでは元のルーム作成前の状態に戻る」
+// という挙動自体は現在も変わらない。「治る」ことを検証するテストではなく、現状の既知の制約
 // （参加者側にも通知が一切届かない）をそのまま記録することが目的
 test('when the admin reloads mid-game, the quiz room association is lost and the participant gets no notification (issue #640)', async ({ browser }, testInfo) => {
   const adminContext = await browser.newContext();
@@ -181,10 +183,11 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
     await otherPage.getByText('決定').click();
     await expect(otherPage.getByText('接続状態: 接続済み')).toBeVisible({ timeout: 15000 });
 
-    // 参加者一覧（issue #545）: 管理者側はルーム情報画面の下部に表形式で反映される（issue #587）
+    // 参加者一覧（issue #545）: 管理者側はルーム情報画面の下部に表形式で反映される
+    // （issue #587）。回答数・正答数の2列（issue #698）はまだ誰も回答していないため0
     await roomInfoLink.click();
-    await expect(adminPage.getByRole('row').nth(1)).toHaveText('たろう接続中0pt', { timeout: 15000 });
-    await expect(adminPage.getByRole('row').nth(2)).toHaveText('はなこ接続中0pt');
+    await expect(adminPage.getByRole('row').nth(1)).toHaveText('たろう接続中00', { timeout: 15000 });
+    await expect(adminPage.getByRole('row').nth(2)).toHaveText('はなこ接続中00');
     await adminPage.getByText('← 戻る').click();
     await expect(nextButton).toBeVisible();
 
@@ -225,10 +228,11 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
     await captureScreenshot(adminPage, testInfo, 'admin-after-correct-judgment', '管理者：正解判定後の状態');
 
     // ポイントが参加者一覧（管理者側、ルーム情報画面、issue #587）に反映される
-    // （参加者側は獲得ポイント表示で確認済み、issue #519, #545）
+    // （参加者側は獲得ポイント表示で確認済み、issue #519, #545）。回答数・正答数の
+    // 2列（issue #698）: はなこは1回答1正答、たろうは1回答0正答（不正解判定のみ）
     await roomInfoLink.click();
-    await expect(adminPage.getByRole('row').nth(1)).toHaveText('はなこ接続中1pt', { timeout: 15000 });
-    await expect(adminPage.getByRole('row').nth(2)).toHaveText('たろう接続中0pt');
+    await expect(adminPage.getByRole('row').nth(1)).toHaveText('はなこ接続中11', { timeout: 15000 });
+    await expect(adminPage.getByRole('row').nth(2)).toHaveText('たろう接続中10');
   } finally {
     // カバレッジ計測（issue #541）: 失敗時も可能な範囲でカバレッジを収集するため、
     // コンテキストを閉じる前にtry節の成否に関わらず停止・収集する

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -658,7 +658,7 @@ function App() {
 
       nextContentRef.current = {
         type: "result",
-        content: { time: elapsedTime, difficulty, isFast, answer: targetPhrase.answer, winner: winner ?? null },
+        content: { time: elapsedTime, difficulty, isFast, answer: targetPhrase.answer, explanation: targetPhrase.explanation, winner: winner ?? null },
       };
 
       // 結果表示のフェード完了を待ってから次の札の取得・再生に進む。
@@ -1369,6 +1369,13 @@ function App() {
             <>
               <div className="text-muted mt-4 mb-2">答え</div>
               <div className="h4 fw-bold text-dark">{result.answer}</div>
+            </>
+          )}
+
+          {result.explanation && result.explanation !== "-" && (
+            <>
+              <div className="text-muted mt-4 mb-2">解説</div>
+              <div className="fs-6 text-dark">{result.explanation}</div>
             </>
           )}
         </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -910,6 +910,9 @@ function App() {
     createQuizRoom,
     joinQuizRoom,
     judgeQuizRoomBuzz,
+    adminSessionRoomId,
+    adminSessionRestoreError,
+    switchToAdminMode,
   } = useQuizRoomAdmin({
     view,
     selectedCategories,
@@ -1154,7 +1157,15 @@ function App() {
   }
 
   if (view === "quiz-room") {
-    return <QuizRoomView setView={setView} wsBaseUrl={WS_BASE_URL} />;
+    return (
+      <QuizRoomView
+        setView={setView}
+        wsBaseUrl={WS_BASE_URL}
+        adminSessionRoomId={adminSessionRoomId}
+        adminSessionRestoreError={adminSessionRestoreError}
+        switchToAdminMode={switchToAdminMode}
+      />
+    );
   }
 
   // ルーム情報（ルームコード・QRコード・招待URL）表示は、以前は通常のゲーム画面内の

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -637,7 +637,9 @@ function App() {
         const updatedCategoryHistory = [...newHistory[categoryKey]];
         const lastReadPhrase = updatedCategoryHistory[0];
         if (lastReadPhrase.id === targetPhrase.id && lastReadPhrase.category === targetPhrase.category) {
-          updatedCategoryHistory[0] = { ...lastReadPhrase, elapsedTime: elapsedTime.toFixed(2) };
+          // クイズ大会モードの正解者表示（issue #695）: winnerは早押しが正解と
+          // 判定された参加者名。クイズ大会モード以外・誰も正解しなかった場合はnull
+          updatedCategoryHistory[0] = { ...lastReadPhrase, elapsedTime: elapsedTime.toFixed(2), winner: winner ?? null };
           newHistory[categoryKey] = updatedCategoryHistory;
         }
       }
@@ -1556,6 +1558,10 @@ function App() {
                       <span className="text-dark">{p.phrase}</span>
                     </div>
                     <div className="d-flex align-items-center">
+                      {/* クイズ大会モードの正解者表示（issue #695）: winnerは早押しが
+                          正解と判定された参加者名。クイズ大会モード以外・誰も正解
+                          しなかった場合は表示しない */}
+                      {p.winner && <span className="text-success small me-3 notranslate">🎉 {p.winner}さん正解</span>}
                       {p.elapsedTime && <span className="text-muted small me-3">{p.elapsedTime}秒</span>}
                       <span className="text-primary small">詳細・報告 →</span>
                     </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -905,6 +905,7 @@ function App() {
     openQuizRooms,
     quizRoomBuzzedBy,
     quizRoomPoints,
+    quizRoomAnswerCounts,
     quizRoomParticipants,
     quizRoomConnectionStatus,
     reconnectQuizRoom,
@@ -1182,6 +1183,7 @@ function App() {
           roomId={quizRoom.roomId}
           quizRoomParticipants={quizRoomParticipants}
           quizRoomPoints={quizRoomPoints}
+          quizRoomAnswerCounts={quizRoomAnswerCounts}
           resetQuizRoomPoints={resetQuizRoomPoints}
         />
         {/* issue #613: 早押し判定モーダルはこの画面を開いている間も表示する

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1319,7 +1319,7 @@ function App() {
                   disabled={draftCategories.length === 0}
                   className="btn btn-success btn-lg px-5 py-2 fw-bold rounded-pill shadow"
                 >
-                  かるたを始める（{draftCategories.length}件選択中）
+                  かるたを始める
                 </button>
                 <button
                   onClick={handlePrintEfudaClick}
@@ -1641,7 +1641,6 @@ function App() {
             )}
           </div>
         </section>
-      <p className="text-muted small mb-4">履歴はこのタブを閉じるまで保持されます（リロードしても消えません）。</p>
       <div className="d-flex flex-wrap gap-2 justify-content-center mb-4">
         {division === "kids" && (
           // こども向け（issue #636）はかるた選択画面に「決定」ボタンが無く印刷ボタンを
@@ -1707,7 +1706,7 @@ function App() {
                 onClick={() => setShowPlayerRegistration(prev => !prev)}
                 className="btn btn-sm btn-outline-secondary rounded-pill px-3"
               >
-                {showPlayerRegistration ? "参加者登録を閉じる" : players.length > 0 ? "参加者を編集する" : "取った人を記録する参加者を登録する"}
+                {showPlayerRegistration ? "参加者登録を閉じる" : players.length > 0 ? "参加者を編集する" : "取った人を記録する"}
               </button>
               {showPlayerRegistration && (
                 <div className="mt-3 mx-auto text-start" style={{ maxWidth: "360px" }}>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1152,7 +1152,7 @@ describe('App', () => {
     expect(cat3Button).toBeDisabled();
     fireEvent.click(cat3Button);
     expect(cat3Button).toHaveAttribute('aria-pressed', 'false');
-    expect(screen.getByText(/かるたを始める/)).toHaveTextContent('かるたを始める（2件選択中）');
+    expect(screen.getByText(/かるたを始める/)).toHaveTextContent('かるたを始める');
   });
 
   it('fills a page across the category boundary instead of leaving trailing blanks', async () => {
@@ -2381,7 +2381,7 @@ describe('App', () => {
 
     // 参加者登録（issue #518）はカテゴリ確定モーダルではなく、読み札画面のボタンから行う
     await waitFor(() => screen.getByText('次の札'));
-    fireEvent.click(screen.getByText('取った人を記録する参加者を登録する'));
+    fireEvent.click(screen.getByText('取った人を記録する'));
 
     const nameInput = screen.getByPlaceholderText('名前を入力');
     fireEvent.change(nameInput, { target: { value: 'たろう' } });
@@ -2449,7 +2449,7 @@ describe('App', () => {
 
     expect(screen.queryByPlaceholderText('名前を入力')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByText('取った人を記録する参加者を登録する'));
+    fireEvent.click(screen.getByText('取った人を記録する'));
     expect(screen.getByPlaceholderText('名前を入力')).toBeInTheDocument();
 
     fireEvent.change(screen.getByPlaceholderText('名前を入力'), { target: { value: 'たろう' } });

--- a/frontend/src/hooks/useQuizRoomAdmin.js
+++ b/frontend/src/hooks/useQuizRoomAdmin.js
@@ -81,6 +81,9 @@ export function useQuizRoomAdmin({
   // ポイント制（issue #519）: 名前→累計ポイントのマップ。管理者には参加者ごとの
   // ポイントを一覧表示する
   const [quizRoomPoints, setQuizRoomPoints] = useState({});
+  // 回答数集計（issue #698）: 名前→{attempts, correct}のマップ。pointsと同様、
+  // 切断・退室後も保持され続ける
+  const [quizRoomAnswerCounts, setQuizRoomAnswerCounts] = useState({});
   // 参加者一覧（issue #545）: 名前確定済みの参加者名一覧。ポイントと統合して
   // 「参加者名（0pt含む全員）」の1つのリストとして表示する
   const [quizRoomParticipants, setQuizRoomParticipants] = useState([]);
@@ -145,8 +148,21 @@ export function useQuizRoomAdmin({
       playQuizSfx("buzz", "quiz-buzz.mp3").catch(() => {});
       setQuizRoomBuzzedBy(buzzedBy);
     },
-    onPoints: setQuizRoomPoints,
+    onPoints: (points, answerCounts) => {
+      setQuizRoomPoints(points);
+      // 回答数集計（issue #698）: 正解判定時（type:"points"ブロードキャスト）の更新
+      if (answerCounts) {
+        setQuizRoomAnswerCounts(answerCounts);
+      }
+    },
     onParticipants: setQuizRoomParticipants,
+    // 回答数集計（issue #698）: 不正解判定時（type:"roundReset"ブロードキャスト）にも
+    // attemptsが増えるため、管理者側もこのイベントでanswerCountsを更新する
+    onRoundReset: ({ answerCounts }) => {
+      if (answerCounts) {
+        setQuizRoomAnswerCounts(answerCounts);
+      }
+    },
   });
 
   // 管理者セッション復帰（issue #697）: switchToAdminModeで保存済みトークンを使った
@@ -318,6 +334,7 @@ export function useQuizRoomAdmin({
     openQuizRooms,
     quizRoomBuzzedBy,
     quizRoomPoints,
+    quizRoomAnswerCounts,
     quizRoomParticipants,
     quizRoomConnectionStatus,
     reconnectQuizRoom,

--- a/frontend/src/hooks/useQuizRoomAdmin.js
+++ b/frontend/src/hooks/useQuizRoomAdmin.js
@@ -183,7 +183,7 @@ export function useQuizRoomAdmin({
         type: "result",
         // winner: 早押しが正解と判定された場合、その回答者名（issue #600）。
         // 誰も正解しなかった場合（通常の「次の札」による結果表示）はnull
-        content: { time: r.time, isFast: r.isFast, difficulty: r.difficulty, answer: r.answer, winner: r.winner ?? null },
+        content: { time: r.time, isFast: r.isFast, difficulty: r.difficulty, answer: r.answer, explanation: r.explanation, winner: r.winner ?? null },
       });
     } else {
       broadcastQuizRoomState({ type: "initial" });

--- a/frontend/src/hooks/useQuizRoomAdmin.js
+++ b/frontend/src/hooks/useQuizRoomAdmin.js
@@ -8,6 +8,33 @@ import { unlockAudioPlayback, playQuizSfx } from "../utils/audioUnlock";
 // 使う必要がないため、何もしない関数を安定した参照として渡す
 const noop = () => {};
 
+// 管理者セッション復帰（issue #697）: 管理者トークンをlocalStorageへ保存する際のキー。
+// ブラウザ/タブを閉じてもルームへ管理者として復帰できるようにするため、
+// createQuizRoom成功時にここへ{roomId, adminToken}を保存する
+const ADMIN_SESSION_STORAGE_KEY = "quizRoomAdminSession";
+
+function readStoredAdminSession() {
+  try {
+    const raw = localStorage.getItem(ADMIN_SESSION_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.roomId === "string" && typeof parsed.adminToken === "string") {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function clearStoredAdminSession() {
+  try {
+    localStorage.removeItem(ADMIN_SESSION_STORAGE_KEY);
+  } catch {
+    // プライベートブラウズ等でlocalStorageが使えない環境では何もしない
+  }
+}
+
 // 開設中ルーム一覧（issue #489）の定期更新間隔。REST GET1本のみで参加者数に
 // 応じて増える負荷ではないため、issue #619のsyncポーリングほど頻度を絞る必要はない
 const OPEN_ROOMS_POLL_INTERVAL_MS = 15000;
@@ -34,6 +61,16 @@ export function useQuizRoomAdmin({
   const [quizRoom, setQuizRoom] = useState(null); // { roomId, adminToken } | null
   const [creatingQuizRoom, setCreatingQuizRoom] = useState(false);
   const [quizRoomCreateError, setQuizRoomCreateError] = useState(null);
+  // 管理者セッション復帰（issue #697）: 保存済みの管理者トークンが指すルームID。
+  // QuizRoomView.jsx（参加者画面）側で、このルームIDに一致する場合のみ
+  // 「管理者に切り替える」ボタンを表示する
+  const [adminSessionRoomId, setAdminSessionRoomId] = useState(() => readStoredAdminSession()?.roomId ?? null);
+  const [adminSessionRestoreError, setAdminSessionRestoreError] = useState(null);
+  // switchToAdminMode経由で復帰を試みている間だけtrueにする。この間に接続が
+  // エラーになった場合のみ「トークンが無効化された」と判断して保存済みトークンを
+  // 破棄する（既に管理者として正常稼働中の接続が、一時的なネットワーク不調で
+  // エラーになった場合にまで誤ってトークンを破棄しないようにするため）
+  const [isRestoringAdminSession, setIsRestoringAdminSession] = useState(false);
   // トップページ下部に表示する、開設中のクイズ大会ルーム一覧（issue #489）
   const [openQuizRooms, setOpenQuizRooms] = useState([]);
   // 早押し機能（issue #510）: 現在のラウンドで最初に回答した参加者名。次の札が
@@ -111,6 +148,32 @@ export function useQuizRoomAdmin({
     onPoints: setQuizRoomPoints,
     onParticipants: setQuizRoomParticipants,
   });
+
+  // 管理者セッション復帰（issue #697）: switchToAdminModeで保存済みトークンを使った
+  // 復帰を試みている間、接続が確立できれば復帰成功とみなして監視を終了する。
+  // 逆に接続がエラーになった場合は、トークンが無効（ルーム失効・削除済み等）と
+  // 判断し、保存済みトークンを破棄したうえで通常の参加者フローへフォールバックする。
+  // レンダー中のstate調整パターン（QuizRoomView.jsxのbuzzRoundKey判定と同じ考え方）で、
+  // 副作用を伴わないstate更新はuseEffectを介さずレンダー中に直接行う
+  // （react-hooks/set-state-in-effect対策）
+  const [lastRestoreCheckedStatus, setLastRestoreCheckedStatus] = useState(quizRoomConnectionStatus);
+  if (quizRoomConnectionStatus !== lastRestoreCheckedStatus) {
+    setLastRestoreCheckedStatus(quizRoomConnectionStatus);
+    if (isRestoringAdminSession) {
+      if (quizRoomConnectionStatus === "connected") {
+        setIsRestoringAdminSession(false);
+      } else if (quizRoomConnectionStatus === "error") {
+        setIsRestoringAdminSession(false);
+        clearStoredAdminSession();
+        setAdminSessionRoomId(null);
+        setQuizRoom(null);
+        setAdminSessionRestoreError("保存されていた管理者情報でルームに接続できませんでした。ルームが終了しているか、情報が無効になっている可能性があります。");
+        // quizRoomがnullに戻るとview==="quiz-room-info"の表示条件を満たさなくなる
+        // ため、エラーメッセージが表示できる参加者画面（quiz-room）へ明示的に戻す
+        setView("quiz-room");
+      }
+    }
+  }
 
   // 早押し正誤判定（issue #546）: 「正解」「不正解」を選んだら判定結果をサーバーへ
   // 送信し、モーダルはローカルで即座に閉じる（roundResetのブロードキャストは
@@ -204,6 +267,15 @@ export function useQuizRoomAdmin({
       }
       const data = await response.json();
       setQuizRoom({ roomId: data.roomId, adminToken: data.adminToken });
+      // 管理者セッション復帰（issue #697）: ブラウザ/タブを閉じても管理者として
+      // 復帰できるよう、トークンをlocalStorageへ保存する
+      try {
+        localStorage.setItem(ADMIN_SESSION_STORAGE_KEY, JSON.stringify({ roomId: data.roomId, adminToken: data.adminToken }));
+      } catch {
+        // プライベートブラウズ等でlocalStorageが使えない環境では保存をあきらめる
+        // （復帰できないだけで、今回のセッションでの利用自体には影響しない）
+      }
+      setAdminSessionRoomId(data.roomId);
     } catch (error) {
       console.error("Failed to create quiz room:", error);
       setQuizRoomCreateError("ルームの作成に失敗しました。もう一度お試しください。");
@@ -224,6 +296,21 @@ export function useQuizRoomAdmin({
     setView("quiz-room");
   };
 
+  // 管理者セッション復帰（issue #697）: 参加者画面（QuizRoomView.jsx）の
+  // 「管理者に切り替える」ボタンから呼ばれる。保存済みの管理者トークンが
+  // 現在のroomIdに一致する場合のみ管理者として再接続し、trueを返す
+  const switchToAdminMode = (roomId) => {
+    const stored = readStoredAdminSession();
+    if (!stored || stored.roomId !== roomId) {
+      return false;
+    }
+    unlockAudioPlayback();
+    setAdminSessionRestoreError(null);
+    setIsRestoringAdminSession(true);
+    setQuizRoom({ roomId: stored.roomId, adminToken: stored.adminToken });
+    return true;
+  };
+
   return {
     quizRoom,
     creatingQuizRoom,
@@ -238,5 +325,8 @@ export function useQuizRoomAdmin({
     createQuizRoom,
     joinQuizRoom,
     judgeQuizRoomBuzz,
+    adminSessionRoomId,
+    adminSessionRestoreError,
+    switchToAdminMode,
   };
 }

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -685,6 +685,103 @@ describe('useQuizRoomAdmin (via App)', () => {
     expect(await screen.findByText('🎉 はなこさん正解')).toBeInTheDocument();
   }, 40000);
 
+  it('reflects both attempts (回答数) and correct (正答数) counts in the room-info participant table after an incorrect judgment followed by a different participant\'s correct judgment (issue #698)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      if (url.includes('/get-phrase?')) {
+        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: '答え1', audioData: 'dummy' }) };
+      }
+      if (url.includes('/record-time')) return { ok: true, json: async () => ({}) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    const roomInfoLink = await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    const ws = MockWebSocket.instances[0];
+    act(() => {
+      ws.readyState = MockWebSocket.OPEN;
+      ws.onopen?.();
+      ws.onmessage?.({ data: JSON.stringify({ type: 'participants', names: ['たろう', 'はなこ'] }) });
+    });
+
+    fireEvent.click(screen.getByText('次の札'));
+    await waitFor(() => {
+      expect(ws.sent.find((msg) => msg.includes('"type":"phrase"'))).toBeDefined();
+    }, { timeout: 20000 });
+
+    // たろうが早押しし、管理者が不正解と判定する。実際のバックエンド
+    // （backend/quizRoomHandler.jsのjudgeQuizRoomBuzz）は判定結果をルーム内の
+    // 全接続（管理者自身を含む）へブロードキャストするため、ここでは
+    // そのブロードキャストをモックWebSocket経由で模擬する
+    act(() => {
+      ws.onmessage?.({ data: JSON.stringify({ type: 'buzz', name: 'たろう', connectionId: 'conn-1' }) });
+    });
+    fireEvent.click(screen.getByText('不正解'));
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: 'roundReset', excludedName: 'たろう',
+          answerCounts: { たろう: { attempts: 1, correct: 0 } },
+        }),
+      });
+    });
+
+    // はなこが早押しし、管理者が正解と判定する
+    act(() => {
+      ws.onmessage?.({ data: JSON.stringify({ type: 'buzz', name: 'はなこ', connectionId: 'conn-2' }) });
+    });
+    fireEvent.click(screen.getByText('正解'));
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: 'points', points: { はなこ: 1 },
+          answerCounts: { たろう: { attempts: 1, correct: 0 }, はなこ: { attempts: 1, correct: 1 } },
+        }),
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('所要時間')).toBeInTheDocument();
+    }, { timeout: 20000 });
+
+    fireEvent.click(roomInfoLink);
+
+    // はなこ: 1回答1正答、たろう: 1回答0正答（ポイント降順、同点は名前昇順）
+    await waitFor(() => {
+      const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
+      expect(rows).toEqual(['はなこ接続中11', 'たろう接続中10']);
+    }, { timeout: 15000 });
+  }, 40000);
+
   it('does not clear the responder shown to the admin when the same card is re-broadcast (e.g. a settings change re-sends the same phrase), only when the round actually changes (issue #510)', async () => {
     class MockWebSocket {
       constructor(url) {

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -619,6 +619,72 @@ describe('useQuizRoomAdmin (via App)', () => {
     }, { timeout: 20000 });
   }, 40000);
 
+  it('shows the winner\'s name in the "これまでに読み上げた札" history once a buzz is judged correct (issue #695)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      if (url.includes('/get-phrase?')) {
+        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: '答え1', audioData: 'dummy' }) };
+      }
+      if (url.includes('/record-time')) return { ok: true, json: async () => ({}) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    const ws = MockWebSocket.instances[0];
+    act(() => {
+      ws.readyState = MockWebSocket.OPEN;
+      ws.onopen?.();
+    });
+
+    fireEvent.click(screen.getByText('次の札'));
+    await waitFor(() => {
+      expect(ws.sent.find((msg) => msg.includes('"type":"phrase"'))).toBeDefined();
+    }, { timeout: 20000 });
+
+    act(() => {
+      ws.onmessage?.({ data: JSON.stringify({ type: 'buzz', name: 'はなこ', connectionId: 'conn-2' }) });
+    });
+    fireEvent.click(screen.getByText('正解'));
+
+    await waitFor(() => {
+      expect(screen.getByText('所要時間')).toBeInTheDocument();
+    }, { timeout: 20000 });
+
+    fireEvent.click(screen.getByText(/これまでに読み上げた札を表示する/));
+
+    expect(await screen.findByText('🎉 はなこさん正解')).toBeInTheDocument();
+  }, 40000);
+
   it('does not clear the responder shown to the admin when the same card is re-broadcast (e.g. a settings change re-sends the same phrase), only when the round actually changes (issue #510)', async () => {
     class MockWebSocket {
       constructor(url) {

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -805,7 +805,7 @@ describe('useQuizRoomAdmin (via App)', () => {
     expect(screen.getByText('参加者一覧')).toBeInTheDocument();
     const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
     // たろう(3pt)がはなこ(1pt)より先（降順）に表示される
-    expect(rows).toEqual(['たろう接続中3pt', 'はなこ接続中1pt']);
+    expect(rows).toEqual(['たろう接続中03', 'はなこ接続中01']);
   }, 40000);
 
   it('shows participants who have not scored yet as 0pt in the same list once a "participants" message arrives (issue #545)', async () => {
@@ -865,7 +865,7 @@ describe('useQuizRoomAdmin (via App)', () => {
     expect(screen.getByText('参加者一覧')).toBeInTheDocument();
     const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
     // たろう(3pt)がまだ得点していないじろう・はなこ(0pt)より先（降順、同点は名前昇順）
-    expect(rows).toEqual(['たろう接続中3pt', 'じろう接続中0pt', 'はなこ接続中0pt']);
+    expect(rows).toEqual(['たろう接続中03', 'じろう接続中00', 'はなこ接続中00']);
   }, 40000);
 
   it('broadcasts the settings actually used to fetch the admin\'s own audio, even if the admin changes the voice while that card is still being read out (issue #498)', async () => {

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -86,14 +86,14 @@ describe('useQuizRoomAdmin (via App)', () => {
     await waitFor(() => screen.getByText('次の札'));
 
     // クイズ大会ルーム作成前は、参加者登録ボタンがルーム作成ボタンと並んで表示される
-    expect(screen.getByText('取った人を記録する参加者を登録する')).toBeInTheDocument();
+    expect(screen.getByText('取った人を記録する')).toBeInTheDocument();
     expect(screen.getByText('クイズ大会のルームを作成する')).toBeInTheDocument();
 
     fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
     await screen.findByText('ルーム情報を表示（クイズ大会モード）');
 
     // ルーム作成後は参加者登録ボタン自体が非表示になる
-    expect(screen.queryByText('取った人を記録する参加者を登録する')).not.toBeInTheDocument();
+    expect(screen.queryByText('取った人を記録する')).not.toBeInTheDocument();
     expect(screen.queryByText('参加者を編集する')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -44,6 +44,9 @@ describe('useQuizRoomAdmin (via App)', () => {
     vi.clearAllMocks();
     window.history.pushState({}, '', '/');
     sessionStorage.clear();
+    // 参加者名の永続化（issue #697）: あるテストで確定した名前が別のテストへ
+    // 漏れ、名前入力画面が意図せずスキップされてしまわないようにする
+    localStorage.removeItem('quizRoomParticipantName');
     resetSharedAudioForTests();
   });
 
@@ -1110,4 +1113,138 @@ describe('useQuizRoomAdmin (via App)', () => {
     await waitFor(() => expect(quizRoomsCallCount).toBe(2));
     expect(await screen.findByText('NEW999')).toBeInTheDocument();
   });
+
+  it('persists the admin token on room creation, then lets a fresh session (e.g. after closing the tab) restore admin mode from the participant screen using the saved token (issue #697)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('/quiz-room?roomId=')) {
+        return { ok: true, json: async () => ({ exists: true }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      return { ok: false };
+    });
+
+    const firstRender = await act(async () => render(<App />));
+
+    fireEvent.click(await screen.findByText('エンジニア向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    fireEvent.click(screen.getByText(/決定/));
+    await waitFor(() => screen.getByText(/「Cat1」をお手元に持っていますか？/));
+    fireEvent.click(screen.getByText('はい'));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    // 管理者トークンはlocalStorageへ保存される
+    expect(JSON.parse(localStorage.getItem('quizRoomAdminSession'))).toEqual({ roomId: 'ABC123', adminToken: 'token-1' });
+
+    // ブラウザ/タブを閉じた状況を模す。Reactのstateはここで失われるが、localStorageは残る
+    firstRender.unmount();
+
+    // 招待URL経由で参加者として同じルームへアクセスした状況を模す
+    window.history.pushState({}, '', '?view=quiz-room&roomId=ABC123');
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.change(await screen.findByPlaceholderText('お名前'), { target: { value: 'はなこ' } });
+    fireEvent.click(screen.getByText('決定'));
+    await screen.findByText('クイズ大会モード（参加者）');
+
+    // 保存済みの管理者トークンが今のルームIDと一致するため、切り替えボタンが表示される
+    const switchButton = await screen.findByText('管理者に切り替える');
+    fireEvent.click(switchButton);
+
+    // 管理者画面（ルーム情報）へ切り替わる
+    await screen.findByText('クイズ大会モードのルーム情報');
+
+    const adminConnections = MockWebSocket.instances.filter((instance) => instance.url.includes('adminToken='));
+    expect(adminConnections).toHaveLength(2); // 1回目の作成時 + 今回の復帰時
+    expect(adminConnections[1].url).toContain('roomId=ABC123');
+    expect(adminConnections[1].url).toContain('adminToken=token-1');
+
+    // 復帰した接続が確立すれば、エラー表示は出ず管理者画面に留まる
+    act(() => {
+      adminConnections[1].readyState = MockWebSocket.OPEN;
+      adminConnections[1].onopen?.();
+    });
+    expect(screen.getByText('クイズ大会モードのルーム情報')).toBeInTheDocument();
+  }, 40000);
+
+  it('discards the saved admin token and falls back to the participant screen with an error when the saved token fails to connect (issue #697)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    // 事前に（失効済み・無効化された）管理者トークンが保存されている状況を模す
+    localStorage.setItem('quizRoomAdminSession', JSON.stringify({ roomId: 'XYZ999', adminToken: 'stale-token' }));
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('/quiz-room?roomId=')) {
+        return { ok: true, json: async () => ({ exists: true }) };
+      }
+      return { ok: false };
+    });
+
+    window.history.pushState({}, '', '?view=quiz-room&roomId=XYZ999');
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.change(await screen.findByPlaceholderText('お名前'), { target: { value: 'たろう' } });
+    fireEvent.click(screen.getByText('決定'));
+    await screen.findByText('クイズ大会モード（参加者）');
+
+    const switchButton = await screen.findByText('管理者に切り替える');
+    fireEvent.click(switchButton);
+    await screen.findByText('クイズ大会モードのルーム情報');
+
+    const adminConnection = MockWebSocket.instances.find((instance) => instance.url.includes('adminToken=stale-token'));
+    expect(adminConnection).toBeDefined();
+
+    // 保存済みトークンが無効だった（ルーム失効・削除済み等）状況を模す
+    act(() => {
+      adminConnection.onerror?.();
+    });
+
+    // 参加者画面へ戻り、エラーメッセージが表示される
+    await screen.findByText('クイズ大会モード（参加者）');
+    expect(screen.getByText(/保存されていた管理者情報でルームに接続できませんでした/)).toBeInTheDocument();
+
+    // 無効だったトークンは破棄され、切り替えボタンも消える
+    expect(screen.queryByText('管理者に切り替える')).not.toBeInTheDocument();
+    expect(localStorage.getItem('quizRoomAdminSession')).toBeNull();
+  }, 40000);
 });

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -1213,9 +1213,7 @@ describe('useQuizRoomAdmin (via App)', () => {
 
     fireEvent.click(await screen.findByText('エンジニア向け'));
     fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
-    fireEvent.click(screen.getByText(/決定/));
-    await waitFor(() => screen.getByText(/「Cat1」をお手元に持っていますか？/));
-    fireEvent.click(screen.getByText('はい'));
+    fireEvent.click(screen.getByText(/かるたを始める/));
     await waitFor(() => screen.getByText('次の札'));
 
     fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));

--- a/frontend/src/hooks/useQuizRoomSync.js
+++ b/frontend/src/hooks/useQuizRoomSync.js
@@ -147,11 +147,14 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
           } else if (data?.type === "buzz") {
             onBuzzRef.current?.({ name: data.name, connectionId: data.connectionId });
           } else if (data?.type === "points") {
-            onPointsRef.current?.(data.points);
+            // 回答数集計（issue #698）: answerCountsは名前→{attempts, correct}のマップ
+            onPointsRef.current?.(data.points, data.answerCounts);
           } else if (data?.type === "nameError") {
             onNameErrorRef.current?.(data.message);
           } else if (data?.type === "roundReset") {
-            onRoundResetRef.current?.({ excludedName: data.excludedName });
+            // 回答数集計（issue #698）: 不正解判定でもattemptsが増えるため、
+            // roundResetブロードキャストにも更新後のanswerCountsを含めて配信する
+            onRoundResetRef.current?.({ excludedName: data.excludedName, answerCounts: data.answerCounts });
           } else if (data?.type === "participants") {
             onParticipantsRef.current?.(data.names);
           }

--- a/frontend/src/hooks/useQuizRoomSync.test.js
+++ b/frontend/src/hooks/useQuizRoomSync.test.js
@@ -138,7 +138,23 @@ describe('useQuizRoomSync', () => {
       MockWebSocket.instances[0].triggerMessage({ type: 'points', points: { たろう: 2, はなこ: 1 } });
     });
 
-    expect(onPoints).toHaveBeenCalledWith({ たろう: 2, はなこ: 1 });
+    expect(onPoints).toHaveBeenCalledWith({ たろう: 2, はなこ: 1 }, undefined);
+  });
+
+  it('passes answerCounts through to onPoints alongside points (issue #698)', () => {
+    const onPoints = vi.fn();
+    renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn(), onPoints }));
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+      MockWebSocket.instances[0].triggerMessage({
+        type: 'points',
+        points: { たろう: 2 },
+        answerCounts: { たろう: { attempts: 3, correct: 2 } },
+      });
+    });
+
+    expect(onPoints).toHaveBeenCalledWith({ たろう: 2 }, { たろう: { attempts: 3, correct: 2 } });
   });
 
   it('calls onNameError when a nameError message is received (issue #519)', () => {
@@ -163,6 +179,22 @@ describe('useQuizRoomSync', () => {
     });
 
     expect(onRoundReset).toHaveBeenCalledWith({ excludedName: 'たろう' });
+  });
+
+  it('passes answerCounts through to onRoundReset alongside excludedName (issue #698)', () => {
+    const onRoundReset = vi.fn();
+    renderHook(() => useQuizRoomSync({ wsBaseUrl: 'wss://example.com/dev', roomId: 'ROOM01', onState: vi.fn(), onRoundReset }));
+
+    act(() => {
+      MockWebSocket.instances[0].triggerOpen();
+      MockWebSocket.instances[0].triggerMessage({
+        type: 'roundReset',
+        excludedName: 'たろう',
+        answerCounts: { たろう: { attempts: 2, correct: 0 } },
+      });
+    });
+
+    expect(onRoundReset).toHaveBeenCalledWith({ excludedName: 'たろう', answerCounts: { たろう: { attempts: 2, correct: 0 } } });
   });
 
   it('calls onParticipants when a participants message is received (issue #545)', () => {

--- a/frontend/src/utils/audioUnlock.js
+++ b/frontend/src/utils/audioUnlock.js
@@ -63,6 +63,14 @@ export function playSharedAudio(src) {
   return audio.play();
 }
 
+// issue #696: 読み上げ中に早押しボタンが押された場合、読み上げ音声を中断するために使う。
+// sharedAudioが未生成（一度も再生されていない）場合は何もしない
+export function stopSharedAudio() {
+  if (sharedAudio) {
+    sharedAudio.pause();
+  }
+}
+
 // issue #613: 早押し関連の効果音（回答ボタン/正解/不正解）を再生する。
 // nameは"buzz"|"correct"|"incorrect"のいずれか
 export function playQuizSfx(name, src) {

--- a/frontend/src/utils/audioUnlock.test.js
+++ b/frontend/src/utils/audioUnlock.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { unlockAudioPlayback, playSharedAudio, playQuizSfx, resetSharedAudioForTests } from './audioUnlock';
+import { unlockAudioPlayback, playSharedAudio, playQuizSfx, stopSharedAudio, resetSharedAudioForTests } from './audioUnlock';
 
 const audioInstances = [];
 let audioPlayImpl = () => Promise.resolve();
@@ -70,6 +70,21 @@ describe('audioUnlock', () => {
     unlockAudioPlayback();
 
     expect(audioInstances).toHaveLength(8);
+  });
+
+  describe('stopSharedAudio (issue #696)', () => {
+    it('pauses the shared narration element if it has already been created', async () => {
+      await playSharedAudio('data:audio/mp3;base64,DUMMY');
+      const instance = audioInstances[0];
+
+      stopSharedAudio();
+
+      expect(instance.pause).toHaveBeenCalledTimes(2); // playSharedAudio内の一時停止 + stopSharedAudio
+    });
+
+    it('does nothing if the shared narration element was never created', () => {
+      expect(() => stopSharedAudio()).not.toThrow();
+    });
   });
 
   describe('playQuizSfx (issue #613)', () => {

--- a/frontend/src/utils/quizRoomParticipants.js
+++ b/frontend/src/utils/quizRoomParticipants.js
@@ -5,12 +5,22 @@
 // （backend/quizRoomHandler.jsのdisconnectQuizRoom等がブロードキャストする
 // "participants"メッセージ由来）なので、その一覧に含まれるかどうかで
 // 接続ステータスを判定できる。得点記録（points）は切断後も残り続けるため、
-// 切断済みでも一覧には引き続き表示されるが、connectedはfalseになる
-export function mergeParticipantsWithPoints(participantNames, points) {
+// 切断済みでも一覧には引き続き表示されるが、connectedはfalseになる。
+// 回答数（issue #698）: answerCountsは名前→{attempts, correct}のマップ
+// （backend/quizRoomHandler.jsのjudgeQuizRoomBuzzが正解・不正解いずれの判定でも
+// 累計する）。pointsと同じく切断・退室後も保持され続ける。correctはpoints（正答数、
+// 1問正解＝1pt）と実質同じ値のため、返り値には持たせずattempts（回答数）のみ追加する
+export function mergeParticipantsWithPoints(participantNames, points, answerCounts = {}) {
   const connectedNames = new Set(participantNames);
   const names = new Set(participantNames);
   Object.keys(points).forEach((name) => names.add(name));
+  Object.keys(answerCounts).forEach((name) => names.add(name));
   return Array.from(names)
-    .map((name) => ({ name, points: points[name] || 0, connected: connectedNames.has(name) }))
+    .map((name) => ({
+      name,
+      points: points[name] || 0,
+      attempts: answerCounts[name]?.attempts || 0,
+      connected: connectedNames.has(name),
+    }))
     .sort((a, b) => b.points - a.points || a.name.localeCompare(b.name));
 }

--- a/frontend/src/utils/quizRoomParticipants.test.js
+++ b/frontend/src/utils/quizRoomParticipants.test.js
@@ -5,16 +5,16 @@ describe('mergeParticipantsWithPoints', () => {
   it('includes participants who have not scored yet as 0pt', () => {
     const result = mergeParticipantsWithPoints(['たろう', 'はなこ'], { たろう: 2 });
     expect(result).toEqual([
-      { name: 'たろう', points: 2, connected: true },
-      { name: 'はなこ', points: 0, connected: true },
+      { name: 'たろう', points: 2, attempts: 0, connected: true },
+      { name: 'はなこ', points: 0, attempts: 0, connected: true },
     ]);
   });
 
   it('includes a scorer even if they are missing from the participant list (e.g. late-arriving broadcast)', () => {
     const result = mergeParticipantsWithPoints(['たろう'], { たろう: 1, じろう: 3 });
     expect(result).toEqual([
-      { name: 'じろう', points: 3, connected: false },
-      { name: 'たろう', points: 1, connected: true },
+      { name: 'じろう', points: 3, attempts: 0, connected: false },
+      { name: 'たろう', points: 1, attempts: 0, connected: true },
     ]);
   });
 
@@ -29,21 +29,59 @@ describe('mergeParticipantsWithPoints', () => {
     // たろうが切断し、participants一覧からは消えたが、pointsはそのまま
     const afterDisconnect = mergeParticipantsWithPoints(['はなこ'], { たろう: 2 });
     expect(afterDisconnect).toEqual([
-      { name: 'たろう', points: 2, connected: false },
-      { name: 'はなこ', points: 0, connected: true },
+      { name: 'たろう', points: 2, attempts: 0, connected: false },
+      { name: 'はなこ', points: 0, attempts: 0, connected: true },
     ]);
   });
 
   it('sorts by points descending, breaking ties by name ascending', () => {
     const result = mergeParticipantsWithPoints(['はなこ', 'たろう', 'じろう'], {});
     expect(result).toEqual([
-      { name: 'じろう', points: 0, connected: true },
-      { name: 'たろう', points: 0, connected: true },
-      { name: 'はなこ', points: 0, connected: true },
+      { name: 'じろう', points: 0, attempts: 0, connected: true },
+      { name: 'たろう', points: 0, attempts: 0, connected: true },
+      { name: 'はなこ', points: 0, attempts: 0, connected: true },
     ]);
   });
 
   it('returns an empty list when there are no participants and no scorers', () => {
     expect(mergeParticipantsWithPoints([], {})).toEqual([]);
+  });
+
+  // 回答数（issue #698）: answerCountsは名前→{attempts, correct}のマップ。
+  // pointsと同じく切断・退室後も保持され続ける
+  it('includes the attempt count (both correct and incorrect judgments) from answerCounts', () => {
+    const result = mergeParticipantsWithPoints(
+      ['たろう', 'はなこ'],
+      { たろう: 2 },
+      { たろう: { attempts: 3, correct: 2 }, はなこ: { attempts: 1, correct: 0 } }
+    );
+    expect(result).toEqual([
+      { name: 'たろう', points: 2, attempts: 3, connected: true },
+      { name: 'はなこ', points: 0, attempts: 1, connected: true },
+    ]);
+  });
+
+  it('includes a participant who only has answerCounts (e.g. all attempts so far were incorrect, so points is still 0)', () => {
+    const result = mergeParticipantsWithPoints(['たろう'], {}, { たろう: { attempts: 2, correct: 0 } });
+    expect(result).toEqual([
+      { name: 'たろう', points: 0, attempts: 2, connected: true },
+    ]);
+  });
+
+  it('keeps the attempt count after a participant disconnects, same as points (issue #698)', () => {
+    const afterDisconnect = mergeParticipantsWithPoints(
+      ['はなこ'],
+      { たろう: 2 },
+      { たろう: { attempts: 3, correct: 2 } }
+    );
+    expect(afterDisconnect).toEqual([
+      { name: 'たろう', points: 2, attempts: 3, connected: false },
+      { name: 'はなこ', points: 0, attempts: 0, connected: true },
+    ]);
+  });
+
+  it('defaults attempts to 0 when answerCounts is omitted entirely (backward compatibility)', () => {
+    const result = mergeParticipantsWithPoints(['たろう'], { たろう: 1 });
+    expect(result).toEqual([{ name: 'たろう', points: 1, attempts: 0, connected: true }]);
   });
 });

--- a/frontend/src/views/QuizRoomInfoView.jsx
+++ b/frontend/src/views/QuizRoomInfoView.jsx
@@ -8,7 +8,7 @@ import { mergeParticipantsWithPoints } from "../utils/quizRoomParticipants";
 // useQuizRoomSync（WebSocket接続）はApp.jsx側のトップレベルで呼ばれており、
 // view遷移によってApp自体がアンマウントされることはないため、この画面への
 // 遷移中も読み上げ・早押し等のクイズ大会の進行状態は維持される
-function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoomPoints = {}, resetQuizRoomPoints }) {
+function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoomPoints = {}, quizRoomAnswerCounts = {}, resetQuizRoomPoints }) {
   const [qrDataUrl, setQrDataUrl] = useState(null);
   const [copied, setCopied] = useState(false);
 
@@ -22,8 +22,9 @@ function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoom
 
   // 参加者一覧（issue #545）: まだ得点していない参加者も0ptとして含めた1つのリストに
   // 統合して表示する。以前は通常のゲーム画面にインラインで表示していたが、ルーム情報
-  // 画面（この画面）の下部へ移動し、表形式に変更した（issue #587）
-  const participantList = mergeParticipantsWithPoints(quizRoomParticipants, quizRoomPoints);
+  // 画面（この画面）の下部へ移動し、表形式に変更した（issue #587）。
+  // 回答数（issue #698）: 早押しして正誤判定された累計回数（attempts）も併せて表示する
+  const participantList = mergeParticipantsWithPoints(quizRoomParticipants, quizRoomPoints, quizRoomAnswerCounts);
 
   // ポイントリセット（issue #615）: 同じルームで2ゲーム目を始める際、前のゲームの
   // ポイントを引き継がずに再スタートしたい場合に管理者が明示的に実行する。取り消せない
@@ -79,17 +80,19 @@ function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoom
               <tr>
                 <th scope="col">名前</th>
                 <th scope="col">接続</th>
-                <th scope="col" className="text-end">得点</th>
+                <th scope="col" className="text-end">回答数</th>
+                <th scope="col" className="text-end">正答数</th>
               </tr>
             </thead>
             <tbody>
-              {participantList.map(({ name, points, connected }) => (
+              {participantList.map(({ name, points, attempts, connected }) => (
                 <tr key={name}>
                   <td className="notranslate">{name}</td>
                   <td className={connected ? "text-success" : "text-muted"}>
                     {connected ? "接続中" : "切断済み"}
                   </td>
-                  <td className="text-end">{points}pt</td>
+                  <td className="text-end">{attempts}</td>
+                  <td className="text-end">{points}</td>
                 </tr>
               ))}
             </tbody>

--- a/frontend/src/views/QuizRoomInfoView.test.jsx
+++ b/frontend/src/views/QuizRoomInfoView.test.jsx
@@ -40,7 +40,7 @@ describe('QuizRoomInfoView', () => {
     expect(screen.getByText('参加者一覧')).toBeInTheDocument();
     const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
     // たろう(3pt)がまだ得点していないじろう・はなこ(0pt)より先（降順、同点は名前昇順）
-    expect(rows).toEqual(['たろう接続中3pt', 'じろう接続中0pt', 'はなこ接続中0pt']);
+    expect(rows).toEqual(['たろう接続中03', 'じろう接続中00', 'はなこ接続中00']);
   });
 
   it('shows a participant as disconnected when they are no longer in the connected-participants list, while keeping their earned points visible (issue #599, #602)', () => {
@@ -54,7 +54,25 @@ describe('QuizRoomInfoView', () => {
     );
 
     const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
-    expect(rows).toEqual(['たろう切断済み2pt', 'はなこ接続中0pt']);
+    expect(rows).toEqual(['たろう切断済み02', 'はなこ接続中00']);
+  });
+
+  it('shows the attempt count (回答数) and correct count (正答数) as separate columns, keeping them after a participant disconnects (issue #698)', () => {
+    render(
+      <QuizRoomInfoView
+        setView={vi.fn()}
+        roomId="ABC123"
+        quizRoomParticipants={['はなこ']}
+        quizRoomPoints={{ たろう: 2 }}
+        quizRoomAnswerCounts={{ たろう: { attempts: 3, correct: 2 }, はなこ: { attempts: 1, correct: 0 } }}
+      />
+    );
+
+    expect(screen.getByText('回答数')).toBeInTheDocument();
+    expect(screen.getByText('正答数')).toBeInTheDocument();
+    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
+    // たろうは切断済みでも回答数・正答数がpointsと同様に保持され続ける
+    expect(rows).toEqual(['たろう切断済み32', 'はなこ接続中10']);
   });
 
   it('does not show the participant list section when there are no participants yet', () => {

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuizRoomSync, CONNECTION_STATUS_LABEL } from "../hooks/useQuizRoomSync";
+import { useLocalStorageState } from "../hooks/useLocalStorageState";
 import { API_BASE_URL } from "../config";
 import { unlockAudioPlayback, playSharedAudio, playQuizSfx, stopSharedAudio } from "../utils/audioUnlock";
 import { mergeParticipantsWithPoints } from "../utils/quizRoomParticipants";
@@ -11,6 +12,9 @@ import { mergeParticipantsWithPoints } from "../utils/quizRoomParticipants";
 
 const MAX_NAME_LENGTH = 20; // backend/quizRoomHandler.jsのMAX_NAME_LENGTHと合わせる（早押し機能、issue #510）
 const ROOM_CODE_LENGTH = 6; // backend/quizRoomHandler.jsのROOM_CODE_LENGTHと合わせる（issue #616）
+// 参加者名の永続化（issue #697）: ルームごとではなく端末全体で1つの名前を使い回す
+// （同じ端末で複数のルームに参加する場合も、毎回同じ名前を入力し直さずに済むようにする）
+const PARTICIPANT_NAME_STORAGE_KEY = "quizRoomParticipantName";
 
 function renderParticipantContent(roomState) {
   // ルーム作成直後（まだ一度もupdateStateが呼ばれていない）は、サーバー側の状態が
@@ -62,7 +66,7 @@ function renderParticipantContent(roomState) {
   return null;
 }
 
-function QuizRoomView({ setView, wsBaseUrl }) {
+function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRestoreError, switchToAdminMode }) {
   const urlRoomId = useMemo(() => new URLSearchParams(window.location.search).get("roomId"), []);
   const [joinRoomId, setJoinRoomId] = useState(urlRoomId);
   const [manualRoomId, setManualRoomId] = useState("");
@@ -82,9 +86,11 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   const [phraseHistory, setPhraseHistory] = useState([]);
   const [showHistory, setShowHistory] = useState(false);
 
-  // 早押し機能（issue #510）: 参加者名は入室のたびに入力してもらう（永続化しない）。
-  // confirmedNameが空の間は名前入力画面を表示し、決定後にのみ通常の参加者画面へ進む
-  const [confirmedName, setConfirmedName] = useState("");
+  // 参加者名の永続化（issue #697）: 以前はconfirmedNameを毎回空文字から始め、
+  // 入室のたびに名前入力を必須にしていた（issue #510）が、保存済みの名前があれば
+  // それを初期値として採用し、名前入力画面自体をスキップできるようにする
+  const [storedParticipantName, setStoredParticipantName] = useLocalStorageState(PARTICIPANT_NAME_STORAGE_KEY, "");
+  const [confirmedName, setConfirmedName] = useState(storedParticipantName);
   const [nameDraft, setNameDraft] = useState("");
   const [nameError, setNameError] = useState(null);
   const [buzzedBy, setBuzzedBy] = useState(null);
@@ -288,8 +294,18 @@ function QuizRoomView({ setView, wsBaseUrl }) {
     }
     setNameError(null);
     setConfirmedName(trimmed);
-    setParticipantName(trimmed);
+    // 参加者名の永続化（issue #697）: 次回以降、この端末での再接続時に
+    // 名前入力をスキップできるよう保存する
+    setStoredParticipantName(trimmed);
   };
+
+  // 参加者名の永続化（issue #697）: confirmedNameが決まったタイミング（手動確定・
+  // 保存済み名前による自動確定のいずれも）でサーバーへ表示名を伝える
+  useEffect(() => {
+    if (confirmedName) {
+      setParticipantName(confirmedName);
+    }
+  }, [confirmedName, setParticipantName]);
 
   // issue #490: 音声同期再生は明示的にスコープ外だった（管理者端末でのみ再生）ため、
   // 参加者側は通知（roomState）を受けて自分自身で/get-phraseを呼び直し、取得した
@@ -447,6 +463,10 @@ function QuizRoomView({ setView, wsBaseUrl }) {
           <h1 className="h4 fw-bold">クイズ大会モード（参加者）</h1>
           <p className="text-muted small">ルーム: {joinRoomId}</p>
         </header>
+        {/* 管理者セッション復帰（issue #697）: 保存済みの管理者トークンで管理者への
+            切り替えを試みて失敗した場合のエラー表示。この時点で保存済みトークンは
+            既に破棄されているため、「管理者に切り替える」ボタン自体も表示されなくなる */}
+        {adminSessionRestoreError && <p className="text-danger small mb-3">{adminSessionRestoreError}</p>}
         <p className="text-muted small mb-3">
           <span>接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}</span>
           {/* issue #614: 再接続の上限に達した場合、フォアグラウンド復帰・オンライン復帰では
@@ -538,6 +558,24 @@ function QuizRoomView({ setView, wsBaseUrl }) {
                 </div>
               </div>
             )}
+          </div>
+        )}
+        {/* 管理者セッション復帰（issue #697）: このルームの管理者トークンが保存されている
+            場合のみ表示する。押すと保存済みトークンで管理者として再接続し、
+            管理者画面（QuizRoomInfoView）へ切り替わる */}
+        {adminSessionRoomId === joinRoomId && (
+          <div className="mt-4">
+            <button
+              type="button"
+              onClick={() => {
+                if (switchToAdminMode(joinRoomId)) {
+                  setView("quiz-room-info");
+                }
+              }}
+              className="btn btn-sm btn-outline-dark rounded-pill px-3"
+            >
+              管理者に切り替える
+            </button>
           </div>
         )}
         <div className="mt-5">

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -49,6 +49,12 @@ function renderParticipantContent(roomState) {
               <div className="h4 fw-bold text-dark">{r.answer}</div>
             </>
           )}
+          {r.explanation && r.explanation !== "-" && (
+            <>
+              <div className="text-muted mt-4 mb-2">解説</div>
+              <div className="fs-6 text-dark">{r.explanation}</div>
+            </>
+          )}
         </div>
       </div>
     );

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuizRoomSync, CONNECTION_STATUS_LABEL } from "../hooks/useQuizRoomSync";
 import { API_BASE_URL } from "../config";
-import { unlockAudioPlayback, playSharedAudio, playQuizSfx } from "../utils/audioUnlock";
+import { unlockAudioPlayback, playSharedAudio, playQuizSfx, stopSharedAudio } from "../utils/audioUnlock";
 import { mergeParticipantsWithPoints } from "../utils/quizRoomParticipants";
 
 // クイズ大会モード（issue #470）の参加者用入口（閲覧専用）。
@@ -243,6 +243,8 @@ function QuizRoomView({ setView, wsBaseUrl }) {
   // 後から届くbuzzブロードキャスト（自分の勝ち・他の参加者の勝ちいずれも）が
   // この仮の値を正しい値で上書きする
   const handleBuzz = () => {
+    // issue #696: 読み上げ中に回答ボタンが押された場合、読み上げを中断する
+    stopSharedAudio();
     setBuzzedBy({ name: confirmedName });
     buzz();
   };
@@ -467,7 +469,11 @@ function QuizRoomView({ setView, wsBaseUrl }) {
           // ことと次の札を待つよう案内する専用の表示を出す。excludedThisRoundは
           // 次の札が届いたタイミングでfalseに戻る（上記のラウンド切り替え判定）
           <p className="fw-bold text-muted mt-4">不正解でした。次の問題まで待っててね</p>
-        ) : buzzedBy ? (
+        ) : /* issue #696: 正解と判定されresult画面に勝者（winner）が表示されている間は、
+               「回答中」の重複表示を出さない（結果画面側で既に正解者名を表示しているため）。
+               winnerが無いresult（早押しを介さない通常の「次の札」による結果表示等）では、
+               従来どおり回答者表示を維持する */
+        buzzedBy && !(roomState?.type === "result" && roomState.content?.winner) ? (
           <p className="fw-bold text-dark mt-4">🔔 {buzzedBy.name} さんが回答中</p>
         ) : roomState?.type === "phrase" && (
           <div className="mt-4">

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -101,6 +101,9 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
   // ポイント制（issue #519）: 名前→累計ポイントのマップ。集計単位はconnectionIdではなく
   // name（早押し機能の実装参照）なので、自分のポイントはpoints[confirmedName]で引く
   const [points, setPoints] = useState({});
+  // 回答数集計（issue #698）: 名前→{attempts, correct}のマップ。pointsと同様、
+  // 切断・退室後も保持され続ける
+  const [answerCounts, setAnswerCounts] = useState({});
   // 参加者一覧（issue #545）: 名前確定済みの参加者名一覧。管理者側と同様、ポイントと
   // 統合した1つのリストとして表示する
   const [participants, setParticipants] = useState([]);
@@ -181,7 +184,7 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
   // リセットして{type:"roundReset", excludedName}を返す。除外されたのが
   // 自分自身であれば早押しボタンを再表示せず、それ以外の参加者なら
   // buzzedByをクリアして再度早押しできるようにする
-  const handleRoundReset = ({ excludedName }) => {
+  const handleRoundReset = ({ excludedName, answerCounts: nextAnswerCounts }) => {
     // issue #613: 不正解の判定結果を参加者全員に音で伝える（除外された本人以外にとっては
     // 「次に早押しできるようになった」合図でもあるが、判定内容自体は不正解のため同じ音を使う）
     // issue #679: base: "./"（vite.config.js）でサブパス配下にデプロイされるため、
@@ -196,6 +199,10 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
     if (excludedName === confirmedName) {
       setExcludedThisRound(true);
     }
+    // 回答数集計（issue #698）: 不正解判定でもattemptsが増えるため更新する
+    if (nextAnswerCounts) {
+      setAnswerCounts(nextAnswerCounts);
+    }
   };
 
   const { connectionStatus, setParticipantName, buzz, reconnect } = useQuizRoomSync({
@@ -209,7 +216,13 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
       playQuizSfx("buzz", "quiz-buzz.mp3").catch(() => {});
       setBuzzedBy(buzzedByParam);
     },
-    onPoints: setPoints,
+    onPoints: (nextPoints, nextAnswerCounts) => {
+      setPoints(nextPoints);
+      // 回答数集計（issue #698）: 正解判定時（type:"points"ブロードキャスト）の更新
+      if (nextAnswerCounts) {
+        setAnswerCounts(nextAnswerCounts);
+      }
+    },
     onNameError: handleNameError,
     onRoundReset: handleRoundReset,
     onParticipants: setParticipants,
@@ -505,8 +518,9 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
         {(() => {
           // 参加者一覧（issue #545）: まだ得点していない参加者も0ptとして含めた
           // 1つのリストに統合して表示する（管理者画面と同じ並び順）。
-          // 表形式・接続ステータス表示、回答ボタンより下への配置はissue #599で対応
-          const participantList = mergeParticipantsWithPoints(participants, points);
+          // 表形式・接続ステータス表示、回答ボタンより下への配置はissue #599で対応。
+          // 回答数（issue #698）: 早押しして正誤判定された累計回数（attempts）も併せて表示する
+          const participantList = mergeParticipantsWithPoints(participants, points, answerCounts);
           return participantList.length > 0 && (
             <div className="mx-auto mt-4 text-start" style={{ maxWidth: "360px" }}>
               <p className="text-muted small mb-2">参加者一覧</p>
@@ -515,17 +529,19 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
                   <tr>
                     <th scope="col">名前</th>
                     <th scope="col">接続</th>
-                    <th scope="col" className="text-end">得点</th>
+                    <th scope="col" className="text-end">回答数</th>
+                    <th scope="col" className="text-end">正答数</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {participantList.map(({ name, points: pt, connected }) => (
+                  {participantList.map(({ name, points: pt, attempts, connected }) => (
                     <tr key={name}>
                       <td className={`notranslate ${name === confirmedName ? "fw-bold" : ""}`}>{name}</td>
                       <td className={connected ? "text-success" : "text-muted"}>
                         {connected ? "接続中" : "切断済み"}
                       </td>
-                      <td className="text-end">{pt}pt</td>
+                      <td className="text-end">{attempts}</td>
+                      <td className="text-end">{pt}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -349,6 +349,22 @@ describe('QuizRoomView', () => {
     expect(setParticipantNameMock).toHaveBeenCalledWith('はなこ');
   });
 
+  it('remembers the confirmed name across reconnects, skipping the name entry screen on the next visit (issue #697)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    const { unmount } = render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName('はなこ');
+    expect(screen.getByText('ルーム: ABC123')).toBeInTheDocument();
+    unmount();
+
+    // 別のタブ/再接続を模して再度マウントする。localStorageに保存済みの名前が
+    // あるため、名前入力画面をスキップしてそのまま参加者画面へ進む
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    expect(screen.queryByPlaceholderText('お名前')).not.toBeInTheDocument();
+    expect(screen.getByText('クイズ大会モード（参加者）')).toBeInTheDocument();
+    expect(screen.getByText('ルーム: ABC123')).toBeInTheDocument();
+    expect(setParticipantNameMock).toHaveBeenCalledWith('はなこ');
+  });
+
   it('lets a participant buzz in while a phrase is being read, and shows the responder\'s name once someone has buzzed (issue #510)', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -52,9 +52,9 @@ function emitBuzz(buzz) {
   });
 }
 
-function emitPoints(points) {
+function emitPoints(points, answerCounts) {
   act(() => {
-    onPointsCallbacks[onPointsCallbacks.length - 1]?.(points);
+    onPointsCallbacks[onPointsCallbacks.length - 1]?.(points, answerCounts);
   });
 }
 
@@ -502,7 +502,7 @@ describe('QuizRoomView', () => {
 
     expect(screen.getByText('参加者一覧')).toBeInTheDocument();
     const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
-    expect(rows).toEqual(['たろう接続中5pt', 'じろう接続中0pt', 'はなこ接続中0pt']);
+    expect(rows).toEqual(['たろう接続中05', 'じろう接続中00', 'はなこ接続中00']);
 
     const ownEntry = screen.getByText('はなこ', { selector: 'td.fw-bold' });
     expect(ownEntry).toBeInTheDocument();
@@ -520,7 +520,21 @@ describe('QuizRoomView', () => {
     emitParticipants(['はなこ']);
 
     const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
-    expect(rows).toEqual(['たろう切断済み2pt', 'はなこ接続中0pt']);
+    expect(rows).toEqual(['たろう切断済み02', 'はなこ接続中00']);
+  });
+
+  it('shows the attempt count (回答数) and correct count (正答数) as separate columns in the participant list, keeping them after a participant disconnects (issue #698)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName('はなこ');
+
+    emitParticipants(['はなこ']);
+    emitPoints({ たろう: 2 }, { たろう: { attempts: 3, correct: 2 }, はなこ: { attempts: 1, correct: 0 } });
+
+    expect(screen.getByText('回答数')).toBeInTheDocument();
+    expect(screen.getByText('正答数')).toBeInTheDocument();
+    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
+    expect(rows).toEqual(['たろう切断済み32', 'はなこ接続中10']);
   });
 
   it('sends the participant back to the name entry screen with an error when the server rejects a duplicate name (issue #519)', () => {

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -520,6 +520,20 @@ describe('QuizRoomView', () => {
     expect(screen.getByPlaceholderText('お名前')).toBeInTheDocument();
   });
 
+  it('hides the stale "回答中" display once the result screen shows a winner (correct judgment), since the winner is already shown there (issue #696)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+    emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
+    expect(screen.getByText('🔔 はなこ さんが回答中')).toBeInTheDocument();
+
+    emitState({ type: 'result', content: { time: 1.2, answer: '答え1', winner: 'はなこ' } });
+    expect(screen.queryByText('🔔 はなこ さんが回答中')).not.toBeInTheDocument();
+    expect(screen.getByText('🎉 はなこ さん正解！')).toBeInTheDocument();
+  });
+
   it('keeps showing the responder during the result screen, but resets it once a new (different) phrase is broadcast', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
@@ -696,6 +710,34 @@ describe('QuizRoomView', () => {
     expect(audioInstances).toHaveLength(4);
     expect(audioInstances[0].pause).toHaveBeenCalled();
     expect(audioInstances[0].src).toBe('data:audio/mp3;base64,DUMMY2');
+  });
+
+  it('stops the currently-playing narration audio when the participant presses the buzz button (issue #696)', async () => {
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('/quiz-room?')) {
+        return { ok: true, json: async () => ({ exists: true }) };
+      }
+      return { ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }) };
+    });
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // sharedAudio（読み上げ用）+ buzz/correct/incorrectの効果音用（issue #613）で計4要素
+    const narrationAudio = audioInstances[0];
+    narrationAudio.pause.mockClear();
+
+    fireEvent.click(screen.getByText('回答する'));
+
+    expect(narrationAudio.pause).toHaveBeenCalled();
+    expect(buzzMock).toHaveBeenCalled();
   });
 
   it('does not play audio for a phrase that was already in progress when joining, while still on the name entry screen, and does not play it retroactively once the name is confirmed (issue #530)', async () => {


### PR DESCRIPTION
## Summary

issue #693〜699（優先度: high → medium → low の順に対応）をまとめて実装しました。

- **#693**: 札データに「解説」列を追加し、回答表示時に表示する
- **#694**: かるた種別を人気順（readCount順）にソートする
- **#696**（priority: high）: 早押しUXを改善する
  - 正解と判定されresult画面に勝者が表示された後も「〇〇さんが回答中」の表示が残っていた不具合を修正
  - 読み上げ中に回答（早押し）ボタンを押した場合、読み上げ音声を中断するようにした
- **#697**（priority: high）: クイズ大会モードの管理者セッション復帰・参加者名の永続化に対応
  - 管理者トークンをlocalStorageへ保存し、ブラウザを閉じても「管理者に切り替える」ボタンから復帰できるようにした
  - 復帰失敗時（トークン無効化・ルーム失効等）は保存済みトークンを破棄し、参加者画面へフォールバックする
  - 参加者名もlocalStorageへ保存し、再接続時の名前入力を省略できるようにした
- **#695**: 「これまでに読み上げた札」一覧に正解者（winner）を表示する
- **#698**: 参加者一覧に「回答数」「正答数」を分けて表示する
  - 「得点」列は正答数と実質同じ値のため「正答数」列へ名称変更し、新たに「回答数」列を追加（ユーザー指示）
  - 回答数・正答数は切断・退室後もpoints同様に保持され続ける
- **#699**: 見た目の修正4件
  - エンジニア向けカテゴリ選択画面の「決定」ボタンから「（N件選択中）」の表示を削除
  - 参加者未登録時のボタン文言を「取った人を記録する」に変更
  - 「履歴はこのタブを閉じるまで保持されます」の説明文を削除
  - （「絵札を印刷する」ボタンのデザイン統一は、対象が既に1箇所のみとなっており対応不要と判断）

## Test plan

- [x] `frontend`・`backend` 両方で lint エラー0件を確認
- [x] `frontend`・`backend` 両方でテスト全件成功を確認（backend: 1503件、frontend: 216件）
- [ ] スマートフォンのブラウザからPRのCI結果（Job Summary）を確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_