### PR TITLE
fix(e2e): CIでE2E失敗の詳細をジョブログへ出力する（issue #711）

### DIFF
--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -16,7 +16,13 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: [
-    process.env.CI ? ['html', { open: 'never' }] : ['list'],
+    // issue #711: CI用のhtmlレポーターは失敗の詳細（アサーション差分・エラー
+    // メッセージ）をコンソール（GitHub Actionsのジョブログ）へ一切出力しない。
+    // htmlレポート自体はAzure Blobストレージ経由のアーティファクトとしてしか
+    // 取得できず、組織のプロキシポリシー等でダウンロードできない環境もあるため、
+    // ジョブログのテキストだけで一次診断できるよう`line`レポーターを併用する
+    process.env.CI ? ['line'] : ['list'],
+    process.env.CI ? ['html', { open: 'never' }] : null,
     // JSカバレッジ算出結果のログ出力（issue #541）。frontend/e2e/coverage.jsの
     // startCoverage/stopCoverageで各ページのカバレッジを収集し、ここで登録した
     // グローバルレポートへ集約する。console-summaryでコンソールへ要約を出力しつつ、
@@ -37,7 +43,7 @@ export default defineConfig({
         reports: [['console-summary'], ['json-summary']],
       },
     }],
-  ],
+  ].filter(Boolean),
   use: {
     baseURL: 'http://localhost:4173',
     trace: 'on-first-retry',


### PR DESCRIPTION
## Summary

- Closes #711
- CI用のE2Eレポーターがhtml（Azure Blobアーティファクト経由でしか閲覧できない）とmonocart-reporter（カバレッジ集計専用）のみで、失敗したテスト名・アサーション差分がジョブログに一切残らなかった
- PR #710（issue #693-699）対応でE2E失敗の原因調査に手間取った反省から、CI用に`line`レポーターを追加し、失敗詳細をジョブログのテキストだけで確認できるようにした（htmlレポート自体はこれまで通り生成し続ける）

## Test plan

- [x] `frontend`: lint 0 problems、test 219件成功を確認
- [x] `backend`: lint 0 problems、test 1503件成功を確認
- [x] reporter配列の分岐結果を`node -e`で直接確認し、非CI環境ではlist+monocart、CI環境ではline+html+monocartになることを確認した
- [ ] 次回CI実行時、実際にジョブログへline reporterの出力が表示されることをご確認ください

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_