### PR TITLE
test(quiz-room)/feat(explanation): issue #712対応 + 解説表示漏れ3箇所の追加（issue #693）

### DIFF
--- a/frontend/e2e/quiz-room.spec.js
+++ b/frontend/e2e/quiz-room.spec.js
@@ -229,15 +229,12 @@ test('admin judges a buzz, and the responder vs. other participants end up in di
 
     // ポイントが参加者一覧（管理者側、ルーム情報画面、issue #587）に反映される
     // （参加者側は獲得ポイント表示で確認済み、issue #519, #545）。
-    // 回答数・正答数の2列（issue #698）: このE2Eは実際にデプロイ済みのバックエンドに
-    // 対して実行されるため（playwright.config.js冒頭のコメント参照）、本PRで追加した
-    // answerCountsのブロードキャストは、本PRマージ後のCD実行までは反映されず「回答数」は
-    // 常に0のまま表示される。そのため現時点では「正答数（pt相当）」のみ正しく反映される
-    // 前提でアサーションする。CD実行後のフォローアップPRで「はなこ接続中11」「たろう接続中10」
-    // （実際の回答数を反映した値）へ更新すること
+    // 回答数・正答数の2列（issue #698）: PR #710マージ後のCD実行によりバックエンドの
+    // answerCountsブロードキャストが実際にデプロイ済みとなったため、実際の回答数を
+    // 反映した値でアサーションする（はなこ：1回答1正答、たろう：1回答0正答）
     await roomInfoLink.click();
-    await expect(adminPage.getByRole('row').nth(1)).toHaveText('はなこ接続中01', { timeout: 15000 });
-    await expect(adminPage.getByRole('row').nth(2)).toHaveText('たろう接続中00');
+    await expect(adminPage.getByRole('row').nth(1)).toHaveText('はなこ接続中11', { timeout: 15000 });
+    await expect(adminPage.getByRole('row').nth(2)).toHaveText('たろう接続中10');
   } finally {
     // カバレッジ計測（issue #541）: 失敗時も可能な範囲でカバレッジを収集するため、
     // コンテキストを閉じる前にtry節の成否に関わらず停止・収集する

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1192,6 +1192,7 @@ function App() {
         <QuizRoomBuzzJudgmentModal
           buzzedBy={quizRoomBuzzedBy}
           answer={currentPhrase?.answer}
+          explanation={currentPhrase?.explanation}
           onJudge={judgeQuizRoomBuzz}
         />
       </>
@@ -1683,6 +1684,7 @@ function App() {
           <QuizRoomBuzzJudgmentModal
             buzzedBy={quizRoomBuzzedBy}
             answer={currentPhrase?.answer}
+            explanation={currentPhrase?.explanation}
             onJudge={judgeQuizRoomBuzz}
           />
         </div>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1315,7 +1315,7 @@ describe('App', () => {
     randomSpy.mockRestore();
   }, 40000);
 
-  it('shows the answer on the detail/report screen opened from history', async () => {
+  it('shows the answer and explanation on the detail/report screen opened from history (issue #693)', async () => {
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0); // 常にp1を選ばせる
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) {
@@ -1326,8 +1326,8 @@ describe('App', () => {
           ok: true,
           json: async () => ({
             phrases: [
-              { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: '回答A' },
-              { id: 'p2', category: 'Cat1', kana: 'い', phrase: '読み札2', level: '-', answer: '回答B' },
+              { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: '回答A', explanation: '解説A' },
+              { id: 'p2', category: 'Cat1', kana: 'い', phrase: '読み札2', level: '-', answer: '回答B', explanation: '解説B' },
             ],
           }),
         };
@@ -1335,8 +1335,8 @@ describe('App', () => {
       if (url.includes('get-phrase')) {
         const id = new URL(url).searchParams.get('id');
         const phraseById = {
-          p1: { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: '回答A' },
-          p2: { id: 'p2', category: 'Cat1', kana: 'い', phrase: '読み札2', level: '-', answer: '回答B' },
+          p1: { id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: '回答A', explanation: '解説A' },
+          p2: { id: 'p2', category: 'Cat1', kana: 'い', phrase: '読み札2', level: '-', answer: '回答B', explanation: '解説B' },
         };
         return { ok: true, json: async () => ({ ...phraseById[id], audioData: 'dummy' }) };
       }
@@ -1368,6 +1368,7 @@ describe('App', () => {
     await waitFor(() => {
       expect(screen.getByText('答え')).toBeInTheDocument();
       expect(screen.getByText('回答A')).toBeInTheDocument();
+      expect(screen.getByText('解説A')).toBeInTheDocument();
     });
 
     // バックエンドの上限(1000文字)と揃え、送信後に拒否される体験を防ぐ
@@ -1671,6 +1672,42 @@ describe('App', () => {
     // 読み札列・答え列の幅バランスが崩れないよう、同じ幅指定クラスを共有していることを確認する
     expect(screen.getByText('読み札', { selector: 'th' })).toHaveClass('all-phrases-col-balanced');
     expect(screen.getByText('答え', { selector: 'th' })).toHaveClass('all-phrases-col-balanced');
+  });
+
+  it('shows an explanation column with data and blank fallback in all-phrases view (issue #693)', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ categories: [] }),
+    });
+    await act(async () => {
+      render(<App />);
+    });
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        return { ok: true, json: async () => ({ categories: [] }) };
+      }
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({
+            phrases: [
+              { id: 'p1', category: 'Cat1', phrase: '読み札A', level: '-', answer: '回答A', explanation: '解説A' },
+              { id: 'p2', category: 'Cat1', phrase: '読み札B', level: '-', answer: '-', explanation: '-' },
+            ],
+          }),
+        };
+      }
+      return { ok: false };
+    });
+
+    fireEvent.click(screen.getByText(/全札一覧を見る/i));
+
+    await waitFor(() => {
+      expect(screen.getByText('解説')).toBeInTheDocument();
+      expect(screen.getByText('解説A')).toBeInTheDocument();
+      expect(screen.getByText('読み札B').closest('tr')).not.toHaveTextContent('-');
+    });
   });
 
   it('shows existing comments for the phrase on the detail screen (issue #223)', async () => {

--- a/frontend/src/components/QuizRoomBuzzJudgmentModal.jsx
+++ b/frontend/src/components/QuizRoomBuzzJudgmentModal.jsx
@@ -4,7 +4,7 @@
 // 描画されず、参加者が早押ししても管理者が気づけない不具合があった（issue #613）。
 // ゲーム画面・ルーム情報画面の両方から共通で呼び出せるよう、独立したコンポーネントへ
 // 切り出した
-function QuizRoomBuzzJudgmentModal({ buzzedBy, answer, onJudge }) {
+function QuizRoomBuzzJudgmentModal({ buzzedBy, answer, explanation, onJudge }) {
   if (!buzzedBy) {
     return null;
   }
@@ -20,6 +20,9 @@ function QuizRoomBuzzJudgmentModal({ buzzedBy, answer, onJudge }) {
                 <div className="text-muted mb-2">答え</div>
                 <div className="h4 fw-bold text-dark mb-4">{answer}</div>
               </>
+            )}
+            {explanation && explanation !== "-" && (
+              <div className="fs-6 text-dark mb-4">{explanation}</div>
             )}
             <div className="d-flex gap-2 justify-content-center">
               <button onClick={() => onJudge(true)} className="btn btn-primary btn-lg px-4 rounded-pill shadow-sm fs-6">正解</button>

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -38,6 +38,26 @@ window.Audio = vi.fn().mockImplementation(function (url) {
 
 window.scrollTo = vi.fn();
 
+// 注意（issue #712）: 各テスト内のMockWebSocketはsend()した内容を記録するのみで、
+// サーバー応答（judgeQuizRoomBuzzによる`points`/`roundReset`ブロードキャスト等）は
+// 自動生成されない。判定操作（正解/不正解ボタン押下）後の状態反映を検証する場合は、
+// judgeAndEcho()を使うか、対応するws.onmessage呼び出しを明示的に追加すること。
+// 模擬を書き忘れると「値が反映されない」という誤ったテスト失敗を引き当てる
+// （issue #698対応時の実例）。楽観的UI更新（issue #600）の一部の見た目は
+// この模擬が無くても正しく動作して見えるため、模擬漏れに気づきにくい点に注意する。
+function judgeAndEcho(ws, { correct, name, points, answerCounts }) {
+  fireEvent.click(screen.getByText(correct ? '正解' : '不正解'));
+  act(() => {
+    ws.onmessage?.({
+      data: JSON.stringify(
+        correct
+          ? { type: 'points', points, ...(answerCounts ? { answerCounts } : {}) }
+          : { type: 'roundReset', excludedName: name, ...(answerCounts ? { answerCounts } : {}) }
+      ),
+    });
+  });
+}
+
 describe('useQuizRoomAdmin (via App)', () => {
   beforeEach(() => {
     fetch.mockClear();
@@ -740,33 +760,25 @@ describe('useQuizRoomAdmin (via App)', () => {
 
     // たろうが早押しし、管理者が不正解と判定する。実際のバックエンド
     // （backend/quizRoomHandler.jsのjudgeQuizRoomBuzz）は判定結果をルーム内の
-    // 全接続（管理者自身を含む）へブロードキャストするため、ここでは
-    // そのブロードキャストをモックWebSocket経由で模擬する
+    // 全接続（管理者自身を含む）へブロードキャストするため、judgeAndEcho()で
+    // 判定ボタン押下とそのブロードキャストの模擬をワンセットで行う（issue #712）
     act(() => {
       ws.onmessage?.({ data: JSON.stringify({ type: 'buzz', name: 'たろう', connectionId: 'conn-1' }) });
     });
-    fireEvent.click(screen.getByText('不正解'));
-    act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: 'roundReset', excludedName: 'たろう',
-          answerCounts: { たろう: { attempts: 1, correct: 0 } },
-        }),
-      });
+    judgeAndEcho(ws, {
+      correct: false,
+      name: 'たろう',
+      answerCounts: { たろう: { attempts: 1, correct: 0 } },
     });
 
     // はなこが早押しし、管理者が正解と判定する
     act(() => {
       ws.onmessage?.({ data: JSON.stringify({ type: 'buzz', name: 'はなこ', connectionId: 'conn-2' }) });
     });
-    fireEvent.click(screen.getByText('正解'));
-    act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: 'points', points: { はなこ: 1 },
-          answerCounts: { たろう: { attempts: 1, correct: 0 }, はなこ: { attempts: 1, correct: 1 } },
-        }),
-      });
+    judgeAndEcho(ws, {
+      correct: true,
+      points: { はなこ: 1 },
+      answerCounts: { たろう: { attempts: 1, correct: 0 }, はなこ: { attempts: 1, correct: 1 } },
     });
 
     await waitFor(() => {

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -528,7 +528,7 @@ describe('useQuizRoomAdmin (via App)', () => {
       if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
       if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
       if (url.includes('/get-phrase?')) {
-        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: '答え1', audioData: 'dummy' }) };
+        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: '答え1', explanation: '解説1', audioData: 'dummy' }) };
       }
       return { ok: false };
     });
@@ -562,6 +562,8 @@ describe('useQuizRoomAdmin (via App)', () => {
 
     expect(screen.getByText('🔔 はなこ さんが回答中')).toBeInTheDocument();
     expect(screen.getByText('答え1')).toBeInTheDocument();
+    // issue #693: 判定モーダルにも解説を表示する
+    expect(screen.getByText('解説1')).toBeInTheDocument();
   }, 40000);
 
   it('reveals the result screen (and stops the elapsed-time measurement) as soon as a buzz is judged correct, instead of waiting for the admin to click 次の札, and broadcasts the winner\'s name (issue #600)', async () => {

--- a/frontend/src/views/AllPhrasesView.jsx
+++ b/frontend/src/views/AllPhrasesView.jsx
@@ -86,6 +86,9 @@ function AllPhrasesView({
                     <th scope="col" className="all-phrases-col-balanced" style={{ cursor: "pointer" }} tabIndex={0} role="button" aria-sort={getAriaSort('answer')} onClick={() => handleSort('answer')} onKeyDown={handleHeaderKeyDown('answer')}>
                       答え{renderSortArrow('answer')}
                     </th>
+                    <th scope="col" className="all-phrases-col-balanced">
+                      解説
+                    </th>
                     <th scope="col" style={{ cursor: "pointer" }} tabIndex={0} role="button" aria-sort={getAriaSort('level')} onClick={() => handleSort('level')} onKeyDown={handleHeaderKeyDown('level')}>
                       Lv{renderSortArrow('level')}
                     </th>
@@ -107,6 +110,7 @@ function AllPhrasesView({
                       <td className="ps-4 text-muted small">{p.category}</td>
                       <td className="fw-bold">{p.phrase}</td>
                       <td>{p.answer && p.answer !== "-" ? p.answer : ""}</td>
+                      <td>{p.explanation && p.explanation !== "-" ? p.explanation : ""}</td>
                       <td>{p.level !== "-" ? p.level : ""}</td>
                       <td>{p.readCount || 0}</td>
                       <td>{(p.averageTime || 0).toFixed(2)}s</td>

--- a/frontend/src/views/DetailView.jsx
+++ b/frontend/src/views/DetailView.jsx
@@ -47,6 +47,9 @@ function DetailView({
                 <div className="h4 fw-bold text-dark">{detailPhrase.answer}</div>
               </div>
             )}
+            {detailPhrase.explanation && detailPhrase.explanation !== "-" && (
+              <div className="mb-4 fs-6 text-dark">{detailPhrase.explanation}</div>
+            )}
             <div className="mb-5">
               <button
                 onClick={repeatPhrase}


### PR DESCRIPTION
## Summary

- issue #712（クイズ大会モードのモックWebSocketテストで、サーバー応答の模擬漏れによる無駄なデバッグが発生した）に対応
  - `useQuizRoomAdmin.test.jsx`に`judgeAndEcho(ws, { correct, name, points, answerCounts })`ヘルパーを追加し、判定ボタン（正解/不正解）のクリックと、それに対応するサーバー（`judgeQuizRoomBuzz`）のブロードキャスト（`points`/`roundReset`）模擬を1回の呼び出しに束ねた
  - ファイル冒頭に、`MockWebSocket`がサーバー応答を自動生成しない旨の注意コメントを追加した
- issue #693（札データに「解説」列を追加し、回答表示時に解説も表示する）を検証したところ、PR #710では要求仕様の対象5箇所のうち2箇所（App.jsxの結果表示、QuizRoomView.jsx）にしか解説表示が実装されておらず、残る3箇所に実装漏れがあったため追加した
  - `QuizRoomBuzzJudgmentModal.jsx`（早押し判定モーダル）に`explanation`propを追加し、答えと併せて表示
  - `AllPhrasesView.jsx`（全札一覧）に「解説」列を追加
  - `DetailView.jsx`（詳細画面）に解説表示を追加
  - バックエンド（`phrases.csv`/`seed.js`/`handler.js`）は既に全箇所でexplanationを提供済みのため、フロントエンドの表示のみを追加

## Test plan

- [x] `frontend`・`backend` 両方で lint エラー0件を確認
- [x] `frontend`・`backend` 両方でテスト全件成功を確認（backend: 1503件、frontend: 220件）
- [x] `npm run build`（frontend）成功
- [ ] スマートフォンからPRの差分（`useQuizRoomAdmin.test.jsx`、`QuizRoomBuzzJudgmentModal.jsx`、`AllPhrasesView.jsx`、`DetailView.jsx`）をご確認ください

Closes #712
Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX