### PR TITLE
fix(frontend): 全カテゴリ選択時のかるたデータ取得失敗を部分的に許容する（issue #474）

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -72,6 +72,9 @@ function App() {
   const [allComments, setAllComments] = useState([]);
 
   const [allPhrasesForCategory, setAllPhrasesForCategory] = useState([]);
+  // issue #474: 選択中のカテゴリのうち1件でも取得に失敗したかどうか。
+  // 「まだ読み込んでいない」(allPhrasesForCategory.length === 0)と区別するための専用state
+  const [phrasesFetchError, setPhrasesFetchError] = useState(false);
   const [allPhrases, setAllPhrases] = useState([]); // 全札一覧用
   const [sortConfig, setSortConfig] = useState({ key: null, direction: 'asc' }); // ソート設定
   const [filterCategory, setFilterCategory] = useState(''); // 全札一覧フィルタ
@@ -345,33 +348,50 @@ function App() {
     fetchCategories();
   }, []);
 
-  // カテゴリが選択されたら、選択中の全カテゴリの札IDリストを取得して結合する
+  // カテゴリが選択されたら、選択中の全カテゴリの札IDリストを取得して結合する。
+  // issue #474: 以前はPromise.allを使っており、選択中の1カテゴリでも取得に失敗すると
+  // 全体がrejectしてallPhrasesForCategoryが空配列にリセットされていた（カテゴリ数が
+  // 多い「全カテゴリ選択」ほど並列リクエスト数が増え、個々の失敗確率も上がるため
+  // 発生しやすかった）。Promise.allSettledに変更し、失敗したカテゴリがあっても
+  // 成功分はそのまま反映しつつ、phrasesFetchErrorで失敗の有無だけ別途知らせる。
+  // phrasesFetchRetryTokenは「再試行する」ボタンから同じカテゴリ構成のまま
+  // 再フェッチを起動するためだけのstateで、値自体に意味はない
+  const [phrasesFetchRetryToken, setPhrasesFetchRetryToken] = useState(0);
   useEffect(() => {
     const fetchPhrasesList = async () => {
       if (selectedCategories.length === 0) {
         setAllPhrasesForCategory([]);
+        setPhrasesFetchError(false);
         return;
       }
-      try {
-        const results = await Promise.all(
-          selectedCategories.map(async (cat) => {
-            const response = await fetch(`${API_BASE_URL}/get-phrases-list?category=${encodeURIComponent(cat)}`);
-            if (!response.ok) {
-              throw new Error(`Failed to fetch phrases for category: ${cat}`);
-            }
-            const data = await response.json();
-            return data.phrases || [];
-          })
-        );
-        setAllPhrasesForCategory(results.flat());
-      } catch (error) {
-        console.error("Error fetching phrases list:", error);
-        alert("かるたデータの取得に失敗したカテゴリがあります。もう一度選び直してください。");
-        setAllPhrasesForCategory([]);
+      const settled = await Promise.allSettled(
+        selectedCategories.map(async (cat) => {
+          const response = await fetch(`${API_BASE_URL}/get-phrases-list?category=${encodeURIComponent(cat)}`);
+          if (!response.ok) {
+            throw new Error(`Failed to fetch phrases for category: ${cat}`);
+          }
+          const data = await response.json();
+          return data.phrases || [];
+        })
+      );
+      const succeeded = settled.filter((r) => r.status === "fulfilled").flatMap((r) => r.value);
+      const failedCount = settled.filter((r) => r.status === "rejected").length;
+      settled.forEach((r, i) => {
+        if (r.status === "rejected") {
+          console.error(`Error fetching phrases for category "${selectedCategories[i]}":`, r.reason);
+        }
+      });
+      setAllPhrasesForCategory(succeeded);
+      setPhrasesFetchError(failedCount > 0);
+      // 選択中の全カテゴリが失敗した場合（部分的な失敗ではなく完全な失敗）のみ、
+      // 従来どおりアラートで知らせる。1カテゴリの失敗程度ではアラートを出さない
+      if (failedCount > 0 && succeeded.length === 0) {
+        alert("かるたデータの取得に失敗しました。もう一度お試しください。");
       }
     };
     fetchPhrasesList();
-  }, [selectedCategories]);
+  }, [selectedCategories, phrasesFetchRetryToken]);
+  const retryFetchPhrasesList = () => setPhrasesFetchRetryToken((token) => token + 1);
 
   // 詳細データの取得
   useEffect(() => {
@@ -1125,6 +1145,8 @@ function App() {
         onBack={handlePrintEfudaBack}
         selectedCategories={selectedCategories}
         allPhrasesForCategory={allPhrasesForCategory}
+        phrasesFetchError={phrasesFetchError}
+        onRetryFetchPhrases={retryFetchPhrasesList}
         efudaPages={efudaPages}
         efudaPerPage={EFUDA_PER_PAGE}
       />

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -719,6 +719,82 @@ describe('App', () => {
     expect(document.querySelector('.efuda-card-category')).toHaveTextContent('Cat1');
   });
 
+  it('shows the phrases from categories that succeeded, plus a retry banner, when only some selected categories fail to fetch (issue #474)', async () => {
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }, { name: 'Cat2', group: 'engineer' }] }) };
+      if (url.includes('get-phrases-list') && url.includes('category=Cat1')) {
+        return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', answer: '回答1' }] }) };
+      }
+      if (url.includes('get-phrases-list') && url.includes('category=Cat2')) {
+        return { ok: false };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('エンジニア向け'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Cat1/ })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Cat2/ })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Cat1/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Cat2/ }));
+
+    await waitFor(() => screen.getByText('絵札を印刷する'));
+    fireEvent.click(screen.getByText('絵札を印刷する'));
+
+    await waitFor(() => {
+      // Cat1（成功分）は表示され、「読み込み中...」で止まったままにはならない
+      expect(screen.getByText('回答1')).toBeInTheDocument();
+    });
+
+    // 一部失敗のみでは、完全失敗時のアラートは出さない
+    expect(window.alert).not.toHaveBeenCalledWith(expect.stringContaining('かるたデータの取得'));
+    // 一部失敗を知らせる警告と再試行導線が表示される
+    expect(screen.getByText(/一部のかるたデータの取得に失敗した/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '再試行する' })).toBeInTheDocument();
+  });
+
+  it('shows a retry option instead of getting stuck on "読み込み中..." when all selected categories fail to fetch, and recovers after retrying (issue #474)', async () => {
+    let cat1ShouldFail = true;
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) {
+        if (cat1ShouldFail) return { ok: false };
+        return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', answer: '回答1' }] }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+    await waitFor(() => screen.getByText('絵札を印刷する'));
+    fireEvent.click(screen.getByText('絵札を印刷する'));
+
+    await waitFor(() => {
+      expect(screen.getByText('かるたデータの取得に失敗しました。')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('読み込み中...')).not.toBeInTheDocument();
+    expect(window.alert).toHaveBeenCalledWith('かるたデータの取得に失敗しました。もう一度お試しください。');
+
+    cat1ShouldFail = false;
+    fireEvent.click(screen.getByRole('button', { name: '再試行する' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('回答1')).toBeInTheDocument();
+    });
+  });
+
   it('switches the efuda print view to show the back side (category and level) (issue #363)', async () => {
     const phrases = [
       { id: 'p0', category: 'Cat1', kana: 'あ', phrase: '読み札テキスト0', answer: '-', level: '3' },

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -59,7 +59,7 @@ const resolvePhraseIndex = (slotIndex, printSide) => {
   return row * EFUDA_GRID_COLUMNS + (EFUDA_GRID_COLUMNS - 1 - col);
 };
 
-function PrintEfudaView({ categoryLabel, onBack, selectedCategories, allPhrasesForCategory, efudaPages, efudaPerPage }) {
+function PrintEfudaView({ categoryLabel, onBack, selectedCategories, allPhrasesForCategory, phrasesFetchError, onRetryFetchPhrases, efudaPages, efudaPerPage }) {
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
 
   // この画面を開いている間、PwaUpdatePromptの「オフラインで利用可能になりました」
@@ -144,10 +144,24 @@ function PrintEfudaView({ categoryLabel, onBack, selectedCategories, allPhrasesF
 
       {selectedCategories.length === 0 ? (
         <p className="text-muted text-center py-5 no-print">カテゴリを選択してください。</p>
+      ) : allPhrasesForCategory.length === 0 && phrasesFetchError ? (
+        // issue #474: 「読み込み中」と「取得失敗」を区別する。以前はどちらも
+        // allPhrasesForCategory.length === 0だけで判定していたため、取得に失敗した
+        // 場合も「読み込み中...」の表示のまま進まなくなっていた
+        <div className="text-center py-5 no-print">
+          <p className="text-danger mb-3">かるたデータの取得に失敗しました。</p>
+          <button onClick={onRetryFetchPhrases} className="btn btn-outline-dark rounded-pill px-4">再試行する</button>
+        </div>
       ) : allPhrasesForCategory.length === 0 ? (
         <p className="text-muted text-center py-5 no-print">読み込み中...</p>
       ) : (
         <>
+          {phrasesFetchError && (
+            <div className="alert alert-warning no-print text-center d-flex align-items-center justify-content-center gap-3 flex-wrap">
+              <span>一部のかるたデータの取得に失敗したため、表示されていない種別があります。</span>
+              <button onClick={onRetryFetchPhrases} className="btn btn-sm btn-outline-dark rounded-pill">再試行する</button>
+            </div>
+          )}
           <div className="no-print text-center mb-4">
             <p className="text-muted small mb-3">
               用紙（顔料インク用）: <a href="https://www.a-one.co.jp/product/search/detail.php?id=51677" target="_blank" rel="noopener noreferrer">エーワン マルチカード A4・10面用 品番51677</a><br />


### PR DESCRIPTION
## Summary

- issue #474（全カテゴリ選択時に「取得できなかったデータがある」エラーが出て印刷画面が読み込み中のまま進まない）に対応
- `App.jsx`の`fetchPhrasesList`を`Promise.all`から`Promise.allSettled`へ変更し、選択中カテゴリの一部が取得に失敗しても、成功分は`allPhrasesForCategory`へ反映するようにした
- 「読み込み中」（`allPhrasesForCategory.length === 0`）と「取得失敗」を区別する`phrasesFetchError`stateを追加
- `PrintEfudaView.jsx`: 全カテゴリ失敗時はエラー表示＋再試行ボタン、一部失敗時は成功分の絵札を表示しつつ警告バナー＋再試行ボタンを出すようにした
- 全カテゴリが失敗した場合のみ、従来どおりアラートを表示する（一部失敗ではアラートを出さない）

## Test plan

- [x] `frontend`・`backend` 両方で lint エラー0件を確認
- [x] `frontend`・`backend` 両方でテスト全件成功を確認（backend: 1510件、frontend: 224件）
- [x] `npm run build`（frontend）成功
- [ ] スマートフォンからPRの差分をご確認ください

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_