### PR TITLE
fix(frontend): 最後の1枚読み上げ中は「次の札」を無効化する（issue #721）

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -181,6 +181,17 @@ function App() {
     return categoryKey ? (scoresByCategory[categoryKey] || {}) : {};
   }, [categoryKey, scoresByCategory]);
 
+  // 途中の札はaudioQueueが直前の再生完了まで次の音声を溜めておくため、読み上げ中に
+  // 「次の札」を押しても現在の再生を止めずに済む。しかし最後の1枚だけは次に読む札が
+  // 無いため、押した瞬間にplayKarutaInternalが即座に全札読了（おめでとう画面）へ
+  // 進んでしまい、最後の音声が最後まで再生されないまま打ち切られる（issue #721）。
+  // この最後の1枚を読み上げている間だけ「次の札」を無効化する
+  const isReadingLastPhrase = useMemo(() => {
+    if (!isReading) return false;
+    const readKeys = new Set(currentHistory.map(p => `${p.category}:${p.id}`));
+    return allPhrasesForCategory.every(p => readKeys.has(`${p.category}:${p.id}`));
+  }, [isReading, currentHistory, allPhrasesForCategory]);
+
   // 読了時のスコア集計（参加者が1人以上登録されている場合のみ表示する）
   const scoreSummary = useMemo(() => {
     if (!isAllRead || division === "kids" || players.length === 0) return null;
@@ -1566,7 +1577,7 @@ function App() {
             )}
 
             <div className="d-flex flex-wrap gap-3 justify-content-center mb-5">
-              <button onClick={playKaruta} disabled={loading} className="btn btn-lg px-4 py-3 fw-bold rounded-pill shadow btn-karuta">
+              <button onClick={playKaruta} disabled={loading || isReadingLastPhrase} className="btn btn-lg px-4 py-3 fw-bold rounded-pill shadow btn-karuta">
                 {loading && <span className="spinner-border spinner-border-sm me-2"></span>}
                 {loading ? "読み込み中..." : "次の札"}
               </button>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2236,6 +2236,87 @@ describe('App', () => {
     }
   }, 65000);
 
+  it('keeps 次の札 disabled while the last remaining phrase is still being read, instead of racing ahead to the congratulations screen (issue #721)', async () => {
+    const originalAudio = window.Audio;
+    // イントロ音（wadodon.mp3）は従来どおり即座に終わらせるが、本編の音声は
+    // テストが明示的にonendedを呼ぶまで意図的に終了させない。これにより
+    // isReadingがtrueであり続ける状態（＝まだ読み上げ中）を作り出す
+    window.Audio = vi.fn().mockImplementation(function (url) {
+      const isIntro = url === 'wadodon.mp3';
+      const audio = {
+        play: vi.fn().mockResolvedValue(),
+        pause: vi.fn(),
+        load: vi.fn(),
+        _src: undefined,
+        get src() { return this._src; },
+        set src(newUrl) {
+          this._src = newUrl;
+          if (isIntro) {
+            setTimeout(() => {
+              if (this.oncanplaythrough) this.oncanplaythrough();
+              if (this.onended) setTimeout(this.onended, 0);
+            }, 0);
+          }
+        },
+      };
+      if (url) audio.src = url;
+      return audio;
+    });
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      if (url.includes('/get-phrase?')) return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', audioData: 'dummy' }) };
+      if (url.includes('/record-time')) return { ok: true, json: async () => ({}) };
+      if (url.includes('get-congratulation-audio')) return { ok: true, json: async () => ({ audioData: 'dummy' }) };
+      return { ok: false };
+    });
+
+    try {
+      await act(async () => {
+        render(<App />);
+      });
+
+      fireEvent.click(await screen.findByText('こども向け'));
+      fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+      await waitFor(() => screen.getByText('次の札'));
+      fireEvent.click(screen.getByText('次の札'));
+
+      // フリップ演出は音声再生とは独立したタイマーで進むため、本編音声が
+      // 再生中でも読み札自体は表示される
+      await waitFor(() => {
+        expect(screen.getByText('読み札1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+      }, { timeout: 20000 });
+
+      // このカテゴリの唯一（＝最後）の札がまだ読み上げ中の間は、「次の札」ボタンが
+      // 無効化されており、押しても全札読了（おめでとう画面）や結果表示には進まない
+      expect(screen.getByText('次の札').closest('button')).toBeDisabled();
+      fireEvent.click(screen.getByText('次の札'));
+      expect(screen.queryByText('🎉 おめでとう！ 🎉')).not.toBeInTheDocument();
+      expect(screen.queryByText('所要時間')).not.toBeInTheDocument();
+
+      // 本編音声の再生が実際に完了すると、ボタンが再度押せるようになる
+      const phraseAudio = window.Audio.mock.results.map((r) => r.value).find((a) => a.src === 'dummy');
+      act(() => {
+        phraseAudio.onended?.();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('次の札').closest('button')).not.toBeDisabled();
+      }, { timeout: 10000 });
+
+      // 読み上げ完了後に改めて「次の札」を押すと、最後の1枚だったため
+      // 正しく全札読了（おめでとう画面）まで進む
+      fireEvent.click(screen.getByText('次の札'));
+      await waitFor(() => {
+        expect(screen.getByText('🎉 おめでとう！ 🎉')).toBeInTheDocument();
+      }, { timeout: 20000 });
+    } finally {
+      window.Audio = originalAudio;
+    }
+  }, 40000);
+
   it('reads many phrases back-to-back without ever stalling, all the way through to the session summary (issue #262 regression coverage)', async () => {
     // 未読み札から常に先頭（p1→p2→...の順）を選ばせ、カードの出現順を固定する
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);


### PR DESCRIPTION
## Summary

- issue #721（管理者が最後の1枚の読み上げ完了を待たず全札読了画面へ進んでしまう不具合）に対応
- 途中の札はaudioQueueが現在の再生完了まで次の音声を溜めておく仕組みのため、読み上げ中に「次の札」を押しても現在の再生を止めずに次の音声がキューされるだけで安全だが、最後の1枚だけは次に読む札が無いため、押した瞬間に`playKarutaInternal`の`unreadPhrases.length === 0`分岐へ直行し、全札読了（おめでとう画面）へ即座に進んでしまい、最後の音声が最後まで再生されないまま打ち切られていた
- 現在読み上げ中の札が、そのカテゴリの最後の未読了の1枚である場合のみ「次の札」を無効化する`isReadingLastPhrase`を追加し、対症療法的に`isReading`全体で無効化するのではなく、影響範囲をissue #721の不具合ケースのみに絞った

## Test plan

- [x] `frontend`・`backend` 両方で lint エラー0件を確認
- [x] `frontend`・`backend` 両方でテスト全件成功を確認（backend: 1510件、frontend: 62件）
- [x] `npm run build`（frontend）成功
- [x] 最後の1枚を読み上げ中は「次の札」が無効化され、おめでとう画面や結果表示へ進まないこと、実際に読み上げ完了後は再度押せて正しく全札読了まで進むことを検証するテストを追加
- [x] 既存の「連打対策(issue #590)」テストが引き続き成功することを確認（`isReading`全体で無効化する初期案では回帰していたため、最後の1枚に限定する設計に変更した経緯あり）

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_