### PR TITLE
chore(release): v1.49.3 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.49.3](https://github.com/bamiyanapp/karuta/compare/v1.49.2...v1.49.3) (2026-07-23)
+
+
+### Bug Fixes
+
+* **frontend:** 最後の1枚読み上げ中は「次の札」を無効化する（issue [#721](https://github.com/bamiyanapp/karuta/issues/721)） ([#727](https://github.com/bamiyanapp/karuta/issues/727)) ([57279f0](https://github.com/bamiyanapp/karuta/commit/57279f02c0ba455d5742f0c751f2b03b52d09ebf)), closes [#590](https://github.com/bamiyanapp/karuta/issues/590) [#590](https://github.com/bamiyanapp/karuta/issues/590)
+
 ## [1.49.2](https://github.com/bamiyanapp/karuta/compare/v1.49.1...v1.49.2) (2026-07-23)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.49.2",
+    "version": "1.49.3",
     "date": "2026/07/23",
+    "body": "### Bug Fixes\n\n* **frontend:** 最後の1枚読み上げ中は「次の札」を無効化する（issue [#721](https://github.com/bamiyanapp/karuta/issues/721)） ([#727](https://github.com/bamiyanapp/karuta/issues/727)) ([57279f0](https://github.com/bamiyanapp/karuta/commit/57279f02c0ba455d5742f0c751f2b03b52d09ebf)), closes [#590](https://github.com/bamiyanapp/karuta/issues/590) [#590](https://github.com/bamiyanapp/karuta/issues/590)"
+  },
+  {
+    "version": "1.49.2",
+    "date": "2026/07/23 09:03",
     "body": "### Bug Fixes\n\n* **frontend:** 全カテゴリ選択時のかるたデータ取得失敗を部分的に許容する（issue [#474](https://github.com/bamiyanapp/karuta/issues/474)） ([#723](https://github.com/bamiyanapp/karuta/issues/723)) ([a4cde54](https://github.com/bamiyanapp/karuta/commit/a4cde54e5dc0292fdcff90e4019dd7d63463ec70))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.49.2",
+  "version": "1.49.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.49.2",
+      "version": "1.49.3",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.49.2"
+  "version": "1.49.3"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。