### PR TITLE
test(backend): backendの分岐カバレッジを引き上げ、CIへ80%ゲートを有効化する（issue #459）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,16 @@ jobs:
       enable_e2e_test: true
       enable_standards_check: true
       workspaces: true # npm workspaces構成（issue #608）。依存インストールをリポジトリルートで一括実行する
-      # 分岐(branches)カバレッジを基準に80%を必須化する（issue #459）。
-      # ファイル単位判定（coverage_check_per_file）は一時的に無効化している。
-      # @vitest/coverage-v8が、複数のテストファイルが同一のソースファイル（例:
-      # backend/handler.js）をimportする構成において、実行ごとにカバレッジの
-      # 集計結果が不安定になる（同一コマンド・同一コードで50%前後〜84%前後まで
-      # 揺れる）ことをローカルで繰り返し確認した。全体平均（total）は揺れの影響を
-      # 受けにくく安定して80%を超えているため、ファイル単位判定はこの計測の
-      # 不安定性が解消されるまで無効化する。再度有効化する際はcoverage_check_per_file:
-      # trueに戻すこと
-      coverage_threshold: 80
-      coverage_metrics: "branches"
+      # 分岐(branches)カバレッジ80%必須化（issue #459）は一時的に無効化している
+      # （coverage_threshold: 0）。backend側で、複数のテストファイルが同一の
+      # ソースファイル（例: backend/handler.js）をimportする構成において、
+      # @vitest/coverage-v8のカバレッジ集計がCI実行のたびに不安定になる
+      # （全体平均・ファイル単位判定のいずれも、ローカルでは80%超だった数値が
+      # CI上では一貫して73.73%前後と計測される）ことを確認した。ローカルでは
+      # 実行を繰り返すと正しい数値に戻ることがあるが、CIの毎回フレッシュな実行
+      # 環境では再現しない。原因（vitest/coverage-v8側の問題か、本リポジトリの
+      # テスト構成由来かは未特定）を解決するまで、ゲート自体を無効化する
+      # （issue #459は完了とせず、このブロッカーを明記してオープンのままにする）
+      coverage_threshold: 0
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,9 @@ jobs:
       enable_e2e_test: true
       enable_standards_check: true
       workspaces: true # npm workspaces構成（issue #608）。依存インストールをリポジトリルートで一括実行する
+      # 分岐(branches)カバレッジを基準に80%を必須化し、ファイル単位でも80%を必須化する（issue #459）
+      coverage_threshold: 80
+      coverage_metrics: "branches"
+      coverage_check_per_file: true
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ci:
-    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.6.1
+    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.6.2
     with:
       frontend_dir: frontend
       backend_dir: backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,16 @@ jobs:
       enable_e2e_test: true
       enable_standards_check: true
       workspaces: true # npm workspaces構成（issue #608）。依存インストールをリポジトリルートで一括実行する
-      # 分岐(branches)カバレッジを基準に80%を必須化し、ファイル単位でも80%を必須化する（issue #459）
+      # 分岐(branches)カバレッジを基準に80%を必須化する（issue #459）。
+      # ファイル単位判定（coverage_check_per_file）は一時的に無効化している。
+      # @vitest/coverage-v8が、複数のテストファイルが同一のソースファイル（例:
+      # backend/handler.js）をimportする構成において、実行ごとにカバレッジの
+      # 集計結果が不安定になる（同一コマンド・同一コードで50%前後〜84%前後まで
+      # 揺れる）ことをローカルで繰り返し確認した。全体平均（total）は揺れの影響を
+      # 受けにくく安定して80%を超えているため、ファイル単位判定はこの計測の
+      # 不安定性が解消されるまで無効化する。再度有効化する際はcoverage_check_per_file:
+      # trueに戻すこと
       coverage_threshold: 80
       coverage_metrics: "branches"
-      coverage_check_per_file: true
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ci:
-    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.6.2
+    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.6.3
     with:
       frontend_dir: frontend
       backend_dir: backend

--- a/backend/backfill-polly-cache-ttl.test.js
+++ b/backend/backfill-polly-cache-ttl.test.js
@@ -65,4 +65,19 @@ describe('backfillPollyCacheTtl', () => {
     expect(updatedCount).toBe(0);
     expect(ddbMock.commandCalls(UpdateCommand).length).toBe(0);
   });
+
+  it('treats a Scan response with no Items field as an empty page instead of throwing', async () => {
+    ddbMock.on(ScanCommand).resolves({});
+
+    const updatedCount = await backfillPollyCacheTtl();
+
+    expect(updatedCount).toBe(0);
+  });
+
+  it('rethrows an Update failure that is not a ConditionalCheckFailedException', async () => {
+    ddbMock.on(ScanCommand).resolves({ Items: [{ id: 'cache1' }] });
+    ddbMock.on(UpdateCommand).rejects(new Error('ProvisionedThroughputExceededException'));
+
+    await expect(backfillPollyCacheTtl()).rejects.toThrow('ProvisionedThroughputExceededException');
+  });
 });

--- a/backend/efudaPdfHandler.test.js
+++ b/backend/efudaPdfHandler.test.js
@@ -95,6 +95,20 @@ describe('generateEfudaPdf', () => {
     const response = await generateEfudaPdf({ body: JSON.stringify({ categoryParam: 'Cat1', side: 'front' }) });
     expect(response.statusCode).toBe(500);
   });
+
+  it('treats a missing Count from DynamoDB as 0 cards for that category', async () => {
+    ddbMock.on(QueryCommand, { ExpressionAttributeValues: { ':cat': 'Cat1' } }).resolves({});
+    lambdaMock.on(InvokeCommand).resolves({ StatusCode: 202 });
+
+    const response = await generateEfudaPdf({ body: JSON.stringify({ categoryParam: 'Cat1', side: 'front' }) });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('treats a missing request body as an empty object instead of throwing', async () => {
+    const response = await generateEfudaPdf({});
+    expect(response.statusCode).toBe(400);
+  });
 });
 
 describe('renderEfudaPdfWorker', () => {
@@ -164,6 +178,11 @@ describe('getEfudaPdfStatus', () => {
     expect(response.statusCode).toBe(400);
   });
 
+  it('rejects when queryStringParameters itself is missing, instead of throwing', async () => {
+    const response = await getEfudaPdfStatus({});
+    expect(response.statusCode).toBe(400);
+  });
+
   it('returns a presigned download URL (with a correctly encoded Japanese filename) when the PDF exists', async () => {
     s3Mock.on(HeadObjectCommand).resolves({});
 
@@ -207,6 +226,28 @@ describe('getEfudaPdfStatus', () => {
   it('handles unexpected errors', async () => {
     s3Mock.on(HeadObjectCommand).rejects(new Error('S3 outage'));
     const response = await getEfudaPdfStatus({ queryStringParameters: { jobId: 'job-4' } });
+    expect(response.statusCode).toBe(500);
+  });
+
+  it('defaults to the front-side label and "karuta" category label when side/categoryLabel are omitted', async () => {
+    s3Mock.on(HeadObjectCommand).resolves({});
+
+    const response = await getEfudaPdfStatus({ queryStringParameters: { jobId: 'job-5' } });
+    const body = JSON.parse(response.body);
+
+    expect(body.status).toBe('DONE');
+    const url = new URL(body.url);
+    expect(url.searchParams.get('response-content-disposition')).toBe(
+      `attachment; filename*=UTF-8''${encodeURIComponent('karuta_絵札_表面.pdf')}`
+    );
+  });
+
+  it('propagates an unexpected error from the error-marker lookup as a 500, instead of masking it as IN_PROGRESS', async () => {
+    s3Mock.on(HeadObjectCommand).rejects(Object.assign(new Error('not found'), { name: 'NotFound' }));
+    s3Mock.on(GetObjectCommand).rejects(new Error('S3 outage'));
+
+    const response = await getEfudaPdfStatus({ queryStringParameters: { jobId: 'job-6' } });
+
     expect(response.statusCode).toBe(500);
   });
 });

--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
 import { DynamoDBDocumentClient, ScanCommand, PutCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { PollyClient, SynthesizeSpeechCommand } from '@aws-sdk/client-polly';
-import { getCategories, getPhrasesList, getComments, postComment, getPhrase, getCongratulationAudio, recordTime } from './handler';
+import { getCategories, getPhrasesList, getComments, postComment, getPhrase, getCongratulationAudio, recordTime, resolveAllowedOrigin } from './handler';
 import { Readable } from 'stream';
 import { UpdateCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import crypto from 'crypto';
@@ -13,6 +13,17 @@ const pollyMock = mockClient(PollyClient);
 vi.spyOn(crypto, 'randomUUID').mockReturnValue('mock-uuid');
 vi.spyOn(console, 'error').mockImplementation(() => {});
 
+
+describe('resolveAllowedOrigin', () => {
+  it('reflects the request origin when it is on the allow-list', () => {
+    expect(resolveAllowedOrigin({ headers: { origin: 'http://localhost:5173' } })).toBe('http://localhost:5173');
+  });
+
+  it('falls back to the production origin when the request origin is not on the allow-list (or missing entirely)', () => {
+    expect(resolveAllowedOrigin({ headers: { origin: 'https://evil.example.com' } })).toBe('https://bamiyanapp.github.io');
+    expect(resolveAllowedOrigin({})).toBe('https://bamiyanapp.github.io');
+  });
+});
 
 describe('getCategories', () => {
   beforeEach(() => {
@@ -110,6 +121,30 @@ describe('getCategories', () => {
     const response = await getCategories({});
     expect(response.statusCode).toBe(500);
   });
+
+  it('treats a Scan response with no Items field as empty, returning the default category', async () => {
+    ddbMock.on(ScanCommand).resolves({});
+
+    const response = await getCategories({});
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body.categories).toEqual([{ name: '大ピンチずかん', group: 'kids', requiresPossessionCheck: true, count: 0, readCount: 0 }]);
+  });
+
+  it('groups an item with no category field under the default category name (大ピンチずかん)', async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [{ group: 'kids', answer: '-' }],
+    });
+
+    const response = await getCategories({});
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body.categories).toEqual([
+      { name: '大ピンチずかん', group: 'kids', requiresPossessionCheck: true, count: 1, readCount: 0 },
+    ]);
+  });
 });
 
 describe('getPhrasesList', () => {
@@ -196,6 +231,26 @@ describe('getPhrasesList', () => {
         { id: '1', category: 'Category1', readCount: 4, averageTime: 10, averageDifficulty: 2 },
       ]);
     });
+
+    it('treats a Scan response with no Items field as an empty list instead of throwing', async () => {
+      ddbMock.on(ScanCommand).resolves({});
+
+      const response = await getPhrasesList({});
+      const body = JSON.parse(response.body);
+
+      expect(response.statusCode).toBe(200);
+      expect(body.phrases).toEqual([]);
+    });
+
+    it('treats a Query response with no Items field as an empty list instead of throwing', async () => {
+      ddbMock.on(QueryCommand).resolves({});
+
+      const response = await getPhrasesList({ queryStringParameters: { category: 'Category1' } });
+      const body = JSON.parse(response.body);
+
+      expect(response.statusCode).toBe(200);
+      expect(body.phrases).toEqual([]);
+    });
 });
 
 describe('getComments', () => {
@@ -220,6 +275,14 @@ describe('getComments', () => {
         ddbMock.on(ScanCommand).rejects(new Error('DynamoDB error'));
         const response = await getComments({});
         expect(response.statusCode).toBe(500);
+    });
+
+    it('treats a Scan response with no Items field as an empty list instead of throwing', async () => {
+        ddbMock.on(ScanCommand).resolves({});
+        const response = await getComments({});
+        const body = JSON.parse(response.body);
+        expect(response.statusCode).toBe(200);
+        expect(body.comments).toEqual([]);
     });
 });
 
@@ -247,6 +310,12 @@ describe('postComment', () => {
 
     it('should return 400 for invalid input', async () => {
         const event = { body: JSON.stringify({ phraseId: 'p1' }) }; // missing comment
+        const response = await postComment(event);
+        expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 when phraseId is missing', async () => {
+        const event = { body: JSON.stringify({ comment: 'This is a comment' }) };
         const response = await postComment(event);
         expect(response.statusCode).toBe(400);
     });
@@ -659,6 +728,106 @@ describe('getPhrase', () => {
         expect(body.id).toBe('p1');
         expect(body.readCount).toBe(5);
         expect(body.averageTime).toBe(12.3);
+    });
+
+    it('looks up a phrase directly via GetItem (skipping the Scan) when both id and category are provided', async () => {
+        ddbMock.on(GetCommand, { TableName: 'TestTable' }).resolves({
+            Item: { id: 'p1', category: 'c1', phrase: 'phrase 1', level: '1' },
+        });
+        ddbMock.on(GetCommand, { TableName: 'CacheTable' }).resolves({ Item: undefined });
+        ddbMock.on(PutCommand).resolves({});
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1', category: 'c1' } };
+        const response = await getPhrase(event);
+        const body = JSON.parse(response.body);
+
+        expect(response.statusCode).toBe(200);
+        expect(body.id).toBe('p1');
+        expect(ddbMock.commandCalls(ScanCommand).length).toBe(0);
+    });
+
+    it('filters out items whose category does not match (tolerating a missing category field on other items), returning 404 when nothing matches', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [
+                { id: 'p1', phrase: 'no category field' }, // categoryフィールド自体が無いアイテム
+                { id: 'p2', category: 'OtherCategory', phrase: 'different category' },
+            ],
+        });
+
+        const event = { queryStringParameters: { category: 'c1' } };
+        const response = await getPhrase(event);
+
+        expect(response.statusCode).toBe(404);
+    });
+
+    it('falls back to the Japanese phrase text for English speech when phrase_en is not set', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'c1', phrase: '日本語のみ', level: '-' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        ddbMock.on(PutCommand).resolves({});
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1', lang: 'en' } };
+        const response = await getPhrase(event);
+
+        expect(response.statusCode).toBe(200);
+        const pollyParams = pollyMock.commandCalls(SynthesizeSpeechCommand)[0].args[0].input;
+        expect(pollyParams.Text).toContain('日本語のみ');
+    });
+
+    it('skips the Polly cache lookup/write entirely when POLLY_CACHE_TABLE_NAME is not configured', async () => {
+        delete process.env.POLLY_CACHE_TABLE_NAME;
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', level: '-' }],
+        });
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1' } };
+        const response = await getPhrase(event);
+
+        expect(response.statusCode).toBe(200);
+        expect(ddbMock.commandCalls(GetCommand).length).toBe(0);
+        expect(ddbMock.commandCalls(PutCommand).length).toBe(0);
+    });
+
+    it('uses averageTime/averageDifficulty as a legacy fallback (0 when also absent) when only one of totalTime/totalDifficulty is present (partial migration)', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{
+                id: 'p1', category: 'c1', phrase: 'phrase 1', level: '-',
+                readCount: 0, totalTime: 30, averageTime: 55,
+                // totalDifficultyもaverageDifficultyも無い状態
+            }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        ddbMock.on(PutCommand).resolves({});
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1' } };
+        const response = await getPhrase(event);
+        const body = JSON.parse(response.body);
+
+        // readCountが0のため（totalTimeが数値であっても）平均は計算せず、既存のaverageTimeをそのまま使う
+        expect(body.averageTime).toBe(55);
+        // averageDifficultyの元になる値が無いため0にフォールバックする
+        expect(body.averageDifficulty).toBe(0);
     });
 
     it('should compute averageTime/averageDifficulty from totalTime/totalDifficulty when present (post-migration data)', async () => {
@@ -1090,5 +1259,32 @@ describe('recordTime', () => {
         // readCountとtotalTimeが常に対応するサンプル数を保つよう、
         // 異常値のときはDB書き込み自体を行わない（部分更新はしない）
         expect(ddbMock.commandCalls(UpdateCommand).length).toBe(0);
+    });
+
+    it('should return 400 when id is missing', async () => {
+        const event = { body: JSON.stringify({ category: 'c1', time: 10 }) };
+        const response = await recordTime(event);
+        expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 when time is not a number', async () => {
+        const event = { body: JSON.stringify({ id: 'p1', category: 'c1', time: '10' }) };
+        const response = await recordTime(event);
+        expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 when time exceeds JSON-safe integer precision (Infinity, serialized as null)', async () => {
+        // JSONにNaN/Infinityのリテラルは存在しないため、Infinityはnullとしてシリアライズされる
+        // （typeof time !== 'number'に該当し、400になることを確認する）
+        const event = { body: JSON.stringify({ id: 'p1', category: 'c1', time: Infinity }) };
+        const response = await recordTime(event);
+        expect(response.statusCode).toBe(400);
+    });
+
+    it('should propagate (as a 500) an Update failure that is not a ConditionalCheckFailedException', async () => {
+        ddbMock.on(UpdateCommand).rejects(new Error('ProvisionedThroughputExceededException'));
+        const event = { body: JSON.stringify({ id: 'p1', category: 'c1', time: 10 }) };
+        const response = await recordTime(event);
+        expect(response.statusCode).toBe(500);
     });
 });

--- a/backend/seed.test.js
+++ b/backend/seed.test.js
@@ -76,4 +76,60 @@ describe('seed', () => {
     expect(putItem.averageTime).toBe(0);
     expect(putItem.averageDifficulty).toBe(0);
   });
+
+  it('treats a Scan response with no Items field, and blank CSV fields, as defaults instead of throwing', async () => {
+    // categoryが空欄の行は「大ピンチずかん」、level/kana/answer/explanationは「-」、
+    // phrase/phrase_en/groupは空文字にフォールバックすることを確認する
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(
+      'id,category,level,kana,phrase,phrase_en,answer,group,explanation\n9998,,,,,,,,'
+    );
+    ddbMock.on(ScanCommand).resolves({}); // Itemsフィールド自体が無いレスポンス
+    ddbMock.on(PutCommand).resolves({});
+
+    await seed();
+
+    const putItem = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item;
+    expect(putItem.category).toBe('大ピンチずかん');
+    expect(putItem.level).toBe('-');
+    expect(putItem.kana).toBe('-');
+    expect(putItem.phrase).toBe('');
+    expect(putItem.phrase_en).toBe('');
+    expect(putItem.answer).toBe('-');
+    expect(putItem.explanation).toBe('-');
+    expect(putItem.group).toBe('kids');
+  });
+
+  it('keeps a real explanation value from the CSV instead of falling back to "-"', async () => {
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(
+      'id,category,level,kana,phrase,phrase_en,answer,group,explanation\n9997,新カテゴリ,-,し,新しい札,new phrase,-,kids,補足説明です'
+    );
+    ddbMock.on(ScanCommand).resolves({ Items: [] });
+    ddbMock.on(PutCommand).resolves({});
+
+    await seed();
+
+    const putItem = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item;
+    expect(putItem.explanation).toBe('補足説明です');
+  });
+
+  it('treats missing averageDifficulty/totalTime/totalDifficulty on an existing item as 0, while still carrying over readCount/averageTime', async () => {
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(
+      `${CSV_HEADER}\n2002,大ピンチずかん,-,あ,テスト,test,-,kids`
+    );
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        { id: '2002', category: '大ピンチずかん', readCount: 5, averageTime: 3.5 },
+      ],
+    });
+    ddbMock.on(PutCommand).resolves({});
+
+    await seed();
+
+    const putItem = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item;
+    expect(putItem.readCount).toBe(5);
+    expect(putItem.averageTime).toBe(3.5);
+    expect(putItem.averageDifficulty).toBe(0);
+    expect(putItem.totalTime).toBe(0);
+    expect(putItem.totalDifficulty).toBe(0);
+  });
 });

--- a/docs/cicd-pipeline-specification.md
+++ b/docs/cicd-pipeline-specification.md
@@ -51,6 +51,7 @@ E2Eテスト実行中に読み込まれたJS（フロントエンドのビルド
 | `frontend-e2e-test` | `enable_e2e_test: true`（有効） | 上記「E2Eテスト」節を参照 |
 | `standards-check` | `enable_standards_check: true`（有効） | dev-standardsサブモジュールの`sync-manifest.json`に基づき、symlinkの欠落・リンク切れ・`.gitignore`等コピー対象ファイルの内容乾離を検知する。`node dev-standards/scripts/bootstrap.js --check`を実行する |
 | `package-test` | 未指定（無効、デフォルトのまま） | `inputs.packages`（frontend/backend以外の小さなパッケージをmatrix展開する仕組み）向けで、karutaは`frontend_dir`/`backend_dir`による固定2パッケージ構成のため対象がなく不要。パッケージ構成が増えた場合に改めて検討する |
+| カバレッジ閾値ゲート（`frontend-test`/`backend-test`共通） | `coverage_threshold: 80`・`coverage_metrics: "branches"`・`coverage_check_per_file: true`（有効、issue #459） | 分岐(branches)カバレッジを基準に80%を必須化し、パッケージ全体平均だけでなくファイル単位でも80%を必須化する。一部ファイルのカバレッジが著しく低くても全体平均でクリアしてしまう問題（issue #459）に対応するため、`coverage_check_per_file: true`をあわせて指定している。カバレッジ表自体は常に4指標（statements/branches/functions/lines）を表示し、ゲート判定のみ`branches`に絞り込む。前提となる`check-coverage-threshold`複合アクションのファイル単位判定・指標絞り込み対応は[dev-standards#57](https://github.com/bamiyanapp/dev-standards/issues/57)で実装済み |
 
 ### `.gitignore`の同期について
 


### PR DESCRIPTION
## Summary

- issue #459（分岐カバレッジ80%必須化）対応として着手したが、**CI環境でのカバレッジ計測ツール自体の不安定性**により、ゲート有効化は見送った（詳細は下記「判明した問題」を参照）
- backend側のテストは予定通り追加済み（`handler.js`等の実カバレッジは向上している）
- `.github/workflows/ci.yml`の`coverage_threshold`は`0`（無効）のまま据え置く

## 判明した問題（issue #459が未完了の理由）

`@vitest/coverage-v8`が、複数のテストファイルが同一のソースファイル（`backend/handler.js`）をimportする構成（`handler.test.js`・`quizRoomHandler.test.js`・`efudaPdfHandler.test.js`がいずれも`handler.js`由来の関数を利用）において、カバレッジの集計結果が実行環境ごとに大きく異なることを確認した。

- `handler.js`単体のテストのみでは分岐カバレッジ97%以上
- 上記3ファイルを一緒に実行すると、ローカルでは実行のたびに50%前後〜84%前後まで結果が揺れる
- CI（GitHub Actionsのフレッシュな実行環境）では、複数回のCI再実行を通じて**一貫して**73.73%（全体平均）・50%（`handler.js`単体）という低い値が計測され続けた

`--no-file-parallelism`・`--no-isolate`（bamiyanapp/dev-standards#104, #105で試行）、`coverage_check_per_file`の無効化、いずれの対応でもCI上の数値は改善しなかった。実際のテストカバレッジ不足ではなく計測ツール側の不安定性のため、テストの追加では解決しないと判断した。

この問題を解決するには、vitest/`@vitest/coverage-v8`側への追加調査（Issue報告等）、またはbackend側のテストファイル構成の見直し（`handler.js`を複数ファイルから参照する現構成の変更）が必要と考えられるが、本PRのスコープを超えるため別途対応とする。

## Test plan

- [x] `frontend`・`backend` 両方で lint エラー0件を確認
- [x] `backend`のテスト全件成功を確認（1537件）
- [x] backend側の実カバレッジ改善自体は確認済み（`handler.js`単体テストで97%以上）
- [ ] issue #459（カバレッジゲート自体の有効化）は本PRでは完了せず、オープンのままとする

Refs #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX