### PR TITLE
feat(frontend): 全札一覧の種別絞り込みをこども向け/エンジニア向けで先に絞り込めるようにする（issue #730）

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -78,6 +78,9 @@ function App() {
   const [allPhrases, setAllPhrases] = useState([]); // 全札一覧用
   const [sortConfig, setSortConfig] = useState({ key: null, direction: 'asc' }); // ソート設定
   const [filterCategory, setFilterCategory] = useState(''); // 全札一覧フィルタ
+  // 全札一覧の種別ボタンが多すぎて探しづらい問題（issue #730）に対応するため、
+  // まず「こども向け/エンジニア向け」で絞り込んでから種別ボタンを表示する
+  const [filterDivision, setFilterDivision] = useState('');
   const [searchQuery, setSearchQuery] = useState(''); // 全札一覧テキスト検索
   const [currentPhrase, setCurrentPhrase] = useState(null);
   
@@ -303,6 +306,21 @@ function App() {
   const uniqueCategories = useMemo(() => {
     return [...new Set(allPhrases.map(p => p.category))].sort((a, b) => a.localeCompare(b, 'ja'));
   }, [allPhrases]);
+
+  // allPhrases（get-phrases-list由来）自体にはgroupフィールドが無いため、
+  // getCategories由来のcategories（division選択でも使っているgroup情報を持つ）と
+  // カテゴリ名で突き合わせる。group不明時は既定値である"kids"扱いにする
+  // （backend/handler.jsのgetCategoriesの既定値と合わせる）
+  const categoryGroupMap = useMemo(() => {
+    const map = new Map();
+    categories.forEach(cat => map.set(cat.name, cat.group));
+    return map;
+  }, [categories]);
+
+  const visibleCategories = useMemo(() => {
+    if (!filterDivision) return uniqueCategories;
+    return uniqueCategories.filter(name => (categoryGroupMap.get(name) || "kids") === filterDivision);
+  }, [uniqueCategories, filterDivision, categoryGroupMap]);
 
   const categoryCount = useMemo(() => {
     const counts = {};
@@ -1170,9 +1188,11 @@ function App() {
         allPhrases={allPhrases}
         filterCategory={filterCategory}
         setFilterCategory={setFilterCategory}
+        filterDivision={filterDivision}
+        setFilterDivision={setFilterDivision}
         searchQuery={searchQuery}
         setSearchQuery={setSearchQuery}
-        uniqueCategories={uniqueCategories}
+        uniqueCategories={visibleCategories}
         categoryCount={categoryCount}
         filteredPhrases={filteredPhrases}
         renderSortArrow={renderSortArrow}

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2014,12 +2014,82 @@ describe('App', () => {
       expect(screen.queryByText('読み札Cat2')).not.toBeInTheDocument();
     });
 
-    // 「すべて」ボタンで全件に戻る
-    fireEvent.click(screen.getByRole('button', { name: /^すべて/ }));
+    // 「すべて」ボタンで全件に戻る（種別絞り込み側。division絞り込み側の「すべて」
+    // ボタンと区別するため、件数の括弧付きで一致させる）
+    fireEvent.click(screen.getByRole('button', { name: /^すべて \(/ }));
 
     await waitFor(() => {
       expect(screen.getByText('読み札Cat1')).toBeInTheDocument();
       expect(screen.getByText('読み札Cat2')).toBeInTheDocument();
+    });
+  });
+
+  it('narrows the category buttons in all-phrases view by division (kids/engineer), issue #730', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        categories: [
+          { name: 'KidsCat', group: 'kids' },
+          { name: 'EngineerCat', group: 'engineer' },
+        ],
+      }),
+    });
+    await act(async () => {
+      render(<App />);
+    });
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        return {
+          ok: true,
+          json: async () => ({
+            categories: [
+              { name: 'KidsCat', group: 'kids' },
+              { name: 'EngineerCat', group: 'engineer' },
+            ],
+          }),
+        };
+      }
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({
+            phrases: [
+              { id: 'p1', category: 'KidsCat', phrase: '読み札Kids', level: '-', answer: '-' },
+              { id: 'p2', category: 'EngineerCat', phrase: '読み札Engineer', level: '-', answer: '-' },
+            ],
+          }),
+        };
+      }
+      return { ok: false };
+    });
+
+    fireEvent.click(screen.getByText(/全札一覧を見る/i));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^KidsCat/ })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^EngineerCat/ })).toBeInTheDocument();
+    });
+
+    // 「こども向け」に絞り込むと、エンジニア向けの種別ボタンは表示されなくなる
+    fireEvent.click(screen.getByRole('button', { name: 'こども向け' }));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^KidsCat/ })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /^EngineerCat/ })).not.toBeInTheDocument();
+    });
+
+    // 「エンジニア向け」に切り替えると、今度はこども向けの種別ボタンが消える
+    fireEvent.click(screen.getByRole('button', { name: 'エンジニア向け' }));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^EngineerCat/ })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /^KidsCat/ })).not.toBeInTheDocument();
+    });
+
+    // 「すべて」（division側）に戻すと両方の種別ボタンが再び表示される
+    fireEvent.click(screen.getByRole('button', { name: 'すべて' }));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^KidsCat/ })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^EngineerCat/ })).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/views/AllPhrasesView.jsx
+++ b/frontend/src/views/AllPhrasesView.jsx
@@ -2,6 +2,8 @@ function AllPhrasesView({
   allPhrases,
   filterCategory,
   setFilterCategory,
+  filterDivision,
+  setFilterDivision,
   searchQuery,
   setSearchQuery,
   uniqueCategories,
@@ -14,6 +16,17 @@ function AllPhrasesView({
   setView,
   setSelectedCategories,
 }) {
+  // uniqueCategoriesは呼び出し元（App.jsx）でfilterDivisionに応じて既に絞り込まれた
+  // 一覧が渡ってくるため、種別ボタン一覧を切り替えるたびdivisionを跨いだ絞り込みが
+  // 残らないよう、division切り替え時は種別フィルタをリセットする
+  const changeFilterDivision = (division) => {
+    setFilterDivision(division);
+    setFilterCategory('');
+  };
+
+  // 「すべて」ボタンの件数は、選択中のdivisionに属する種別だけの合計にする
+  // （division未選択時はuniqueCategoriesが全種別のためallPhrases.length相当になる）
+  const visibleTotal = uniqueCategories.reduce((sum, cat) => sum + (categoryCount[cat] || 0), 0);
   const getAriaSort = (key) => {
     if (sortConfig.key !== key) return 'none';
     return sortConfig.direction === 'asc' ? 'ascending' : 'descending';
@@ -30,7 +43,7 @@ function AllPhrasesView({
     <div className="container py-4 mx-auto">
       <header className="text-center mb-4 border-bottom pb-3">
         <div className="d-flex justify-content-between align-items-center">
-          <button onClick={() => { setView("game"); setSelectedCategories([]); setFilterCategory(''); setSearchQuery(''); }} className="btn btn-sm btn-outline-secondary rounded-pill">← 戻る</button>
+          <button onClick={() => { setView("game"); setSelectedCategories([]); setFilterCategory(''); setFilterDivision(''); setSearchQuery(''); }} className="btn btn-sm btn-outline-secondary rounded-pill">← 戻る</button>
           <h1 className="h2 fw-bold m-0 text-dark">全札一覧</h1>
           <div style={{ width: "60px" }}></div>
         </div>
@@ -42,12 +55,33 @@ function AllPhrasesView({
         ) : (
           <div className="all-phrases-scroll-container">
             <div className="mb-3 d-flex flex-wrap align-items-center gap-2">
+              <span className="text-muted small fw-bold me-1">対象:</span>
+              <button
+                className={`btn btn-sm rounded-pill ${filterDivision === '' ? 'btn-dark' : 'btn-outline-secondary'}`}
+                onClick={() => changeFilterDivision('')}
+              >
+                すべて
+              </button>
+              <button
+                className={`btn btn-sm rounded-pill ${filterDivision === 'kids' ? 'btn-dark' : 'btn-outline-secondary'}`}
+                onClick={() => changeFilterDivision('kids')}
+              >
+                こども向け
+              </button>
+              <button
+                className={`btn btn-sm rounded-pill ${filterDivision === 'engineer' ? 'btn-dark' : 'btn-outline-secondary'}`}
+                onClick={() => changeFilterDivision('engineer')}
+              >
+                エンジニア向け
+              </button>
+            </div>
+            <div className="mb-3 d-flex flex-wrap align-items-center gap-2">
               <span className="text-muted small fw-bold me-1">種別:</span>
               <button
                 className={`btn btn-sm rounded-pill ${filterCategory === '' ? 'btn-dark' : 'btn-outline-secondary'}`}
                 onClick={() => setFilterCategory('')}
               >
-                すべて ({allPhrases.length})
+                すべて ({visibleTotal})
               </button>
               {uniqueCategories.map(cat => (
                 <button


### PR DESCRIPTION
## Summary

- issue #730（全札一覧の種別絞り込みボタンが多すぎて探しづらい）に対応
- `AllPhrasesView.jsx`に既存の種別（カテゴリ）絞り込みボタン一覧の上に「すべて/こども向け/エンジニア向け」のdivision絞り込みトグルを追加
- `App.jsx`側では`getCategories`由来の`categories`（既にdivision選択で使っているgroup情報を持つ）から`categoryGroupMap`を作り、選択中のdivisionに応じて種別ボタン一覧を絞り込んだ`visibleCategories`を算出
- division切り替え時は種別フィルタを自動リセットし、division間で無関係な絞り込みが残らないようにした
- backend側の変更は不要（`allPhrases`自体にgroupフィールドを追加する必要はなく、既存の`categories`情報をカテゴリ名で突き合わせるだけで実現）

## Test plan

- [x] `frontend`・`backend` 両方で lint エラー0件を確認
- [x] frontend全229件のテストが成功することを確認（division切り替えでの種別ボタン絞り込みを検証する新規テストを含む）
- [x] `npm run build`（frontend）成功

Closes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_