### PR TITLE
chore(release): v1.50.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.50.0](https://github.com/bamiyanapp/karuta/compare/v1.49.3...v1.50.0) (2026-07-23)
+
+
+### Features
+
+* **frontend:** 全札一覧の種別絞り込みをこども向け/エンジニア向けで先に絞り込めるようにする（issue [#730](https://github.com/bamiyanapp/karuta/issues/730)） ([#738](https://github.com/bamiyanapp/karuta/issues/738)) ([ab8547f](https://github.com/bamiyanapp/karuta/commit/ab8547f4f0e550776330e6f65d56564c6e1938bc))
+
 ## [1.49.3](https://github.com/bamiyanapp/karuta/compare/v1.49.2...v1.49.3) (2026-07-23)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.49.3",
+    "version": "1.50.0",
     "date": "2026/07/23",
+    "body": "### Features\n\n* **frontend:** 全札一覧の種別絞り込みをこども向け/エンジニア向けで先に絞り込めるようにする（issue [#730](https://github.com/bamiyanapp/karuta/issues/730)） ([#738](https://github.com/bamiyanapp/karuta/issues/738)) ([ab8547f](https://github.com/bamiyanapp/karuta/commit/ab8547f4f0e550776330e6f65d56564c6e1938bc))"
+  },
+  {
+    "version": "1.49.3",
+    "date": "2026/07/23 11:48",
     "body": "### Bug Fixes\n\n* **frontend:** 最後の1枚読み上げ中は「次の札」を無効化する（issue [#721](https://github.com/bamiyanapp/karuta/issues/721)） ([#727](https://github.com/bamiyanapp/karuta/issues/727)) ([57279f0](https://github.com/bamiyanapp/karuta/commit/57279f02c0ba455d5742f0c751f2b03b52d09ebf)), closes [#590](https://github.com/bamiyanapp/karuta/issues/590) [#590](https://github.com/bamiyanapp/karuta/issues/590)"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.49.3",
+  "version": "1.50.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.49.3",
+      "version": "1.50.0",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.49.3"
+  "version": "1.50.0"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。