### PR TITLE
fix(frontend): 読み上げ進行の永久停止対策 & ci: カバレッジゲート部分有効化（issue #729, #459）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,19 @@ jobs:
       enable_e2e_test: true
       enable_standards_check: true
       workspaces: true # npm workspaces構成（issue #608）。依存インストールをリポジトリルートで一括実行する
-      # 分岐(branches)カバレッジ80%必須化（issue #459）は一時的に無効化している
-      # （coverage_threshold: 0）。backend側で、複数のテストファイルが同一の
-      # ソースファイル（例: backend/handler.js）をimportする構成において、
-      # @vitest/coverage-v8のカバレッジ集計がCI実行のたびに不安定になる
-      # （全体平均・ファイル単位判定のいずれも、ローカルでは80%超だった数値が
-      # CI上では一貫して73.73%前後と計測される）ことを確認した。ローカルでは
-      # 実行を繰り返すと正しい数値に戻ることがあるが、CIの毎回フレッシュな実行
-      # 環境では再現しない。原因（vitest/coverage-v8側の問題か、本リポジトリの
-      # テスト構成由来かは未特定）を解決するまで、ゲート自体を無効化する
-      # （issue #459は完了とせず、このブロッカーを明記してオープンのままにする）
-      coverage_threshold: 0
+      # 分岐(branches)カバレッジ80%必須化（issue #459）のうち、branches指標のみ
+      # 引き続き見送る。backend側で、複数のテストファイルが同一のソースファイル
+      # （例: backend/handler.js）をimportする構成において、@vitest/coverage-v8の
+      # カバレッジ集計（特にbranches指標）がCI実行のたびに不安定になる
+      # （ローカルでは実行のたびに50%台〜86%台まで結果が揺れ、CI上でも同様に
+      # 不安定）ことを確認済み。一方でstatements/functions/linesの3指標は
+      # 全体平均で複数回にわたり安定して80%以上を計測できたため、この3指標に
+      # 限定してゲートを有効化する（branchesは表には引き続き表示されるが、
+      # 判定対象からは除外する）。ファイル単位判定（coverage_check_per_file）は、
+      # handler.js単体で見てもこの3指標が不安定に80%を割り込むことがあったため
+      # 有効化を見送る（issue #459は完了とせず、この残課題を明記してオープンの
+      # ままにする）
+      coverage_threshold: 80
+      coverage_metrics: "statements,functions,lines"
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -485,16 +485,45 @@ function App() {
   const playAudio = useCallback((audioData) => {
     return new Promise((resolve, reject) => {
       const audio = new Audio(audioData);
-      currentAudioRef.current = { audio, resolve };
-      audio.onended = () => {
+      let settled = false;
+      // モバイルブラウザでは、ユーザー操作を伴わない呼び出し（自動で次への
+      // setTimeout起点）でaudio.play()のPromiseが拒否も解決もされないまま
+      // 待機し続けることがある（issue #729）。onended/onerrorのどちらも発火せず
+      // ハングすると、これを直列でawaitしている読み上げ進行全体（次の札の表示・
+      // 読み上げ）が永久に止まってしまうため、上限時間で強制的に諦めて先へ進める。
+      // stopReading()がcurrentAudioRef.current.resolve()を直接呼ぶ経路も
+      // このsettleResolve経由にし、タイマー解除とsettledフラグを確実に揃える
+      const AUDIO_TIMEOUT_MS = 15000;
+      const settleResolve = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
         if (currentAudioRef.current?.audio === audio) currentAudioRef.current = null;
         resolve();
       };
+      currentAudioRef.current = { audio, resolve: settleResolve };
+      const timeoutId = setTimeout(() => {
+        if (settled) return;
+        console.error("Audio playback timed out (issue #729)");
+        settleResolve();
+      }, AUDIO_TIMEOUT_MS);
+      audio.onended = () => {
+        settleResolve();
+      };
       audio.onerror = (e) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
         if (currentAudioRef.current?.audio === audio) currentAudioRef.current = null;
         reject(e);
       };
-      audio.play().catch(e => reject(e));
+      audio.play().catch(e => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        if (currentAudioRef.current?.audio === audio) currentAudioRef.current = null;
+        reject(e);
+      });
     });
   }, []);
 
@@ -575,10 +604,11 @@ function App() {
         return;
       }
 
-      if (!phraseData) {
-        nextContentRef.current = { type: 'initial' };
-        setIsFadingOut(true);
-      }
+      // phraseDataが無い（repeatPhrase由来の音声のみの再生）場合は、表示中の画面
+      // （phrase/result/initialいずれの状態でも）を変えずに音声だけ再生する。
+      // 以前はここで表示をinitialへ強制的に戻していたが、読み上げ中のカードを
+      // クリックして「もう一度」再生しただけで画面が準備完了画面に戻ってしまう
+      // 不具合（issue #729の調査で判明）だったため、表示状態の変更自体をやめた
 
       setAudioQueue(prev => prev.slice(1));
       setIsReading(false);

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1679,6 +1679,74 @@ describe('App', () => {
     localStorage.removeItem('autoAdvanceInterval');
   }, 40000);
 
+  it('recovers and advances to the next phrase even if audio.play() never settles (issue #729)', async () => {
+    const originalAudio = window.Audio;
+    // モバイルブラウザのオートプレイポリシー等により、audio.play()のPromiseが
+    // 解決も拒否もされないまま（onendedも発火しないまま）ハングし続けるケースを再現する。
+    // vitest v4はvi.fn()のモック実装をnewで呼び出す場合、アロー関数を許容しないため通常の関数式を使う
+    window.Audio = vi.fn().mockImplementation(function () {
+      const audio = {
+        play: vi.fn(() => new Promise(() => {})), // 永久に解決/拒否されない
+        pause: vi.fn(),
+        load: vi.fn(),
+        set src(_url) {
+          // onendedを意図的に発火させない（ハングを模擬する）
+        },
+      };
+      return audio;
+    });
+
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    localStorage.setItem('autoAdvance', 'true');
+    localStorage.setItem('autoAdvanceInterval', '1');
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) {
+        return {
+          ok: true,
+          json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }, { id: 'p2', category: 'Cat1' }] }),
+        };
+      }
+      if (url.includes('/get-phrase?')) {
+        const id = new URL(url).searchParams.get('id');
+        return { ok: true, json: async () => ({ id, category: 'Cat1', phrase: `読み札${id}`, audioData: 'dummy' }) };
+      }
+      return { ok: false };
+    });
+
+    try {
+      await act(async () => {
+        render(<App />);
+      });
+
+      fireEvent.click(await screen.findByText('こども向け'));
+      fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+      await waitFor(() => screen.getByText('次の札'));
+      fireEvent.click(screen.getByText('次の札'));
+
+      // イントロ音・本編音声のaudio.play()が両方ハングしても、タイムアウトにより
+      // 強制的に諦めて読み上げ進行（表示のフェード）が先へ進むことを確認する
+      // （タイムアウト15秒×2回分の余裕を見て待つ）
+      await waitFor(() => {
+        expect(screen.getByText('読み札p1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+      }, { timeout: 45000 });
+
+      // 「次の札」ボタンを一切押さずに、自動読み上げでp2まで進むことを確認する
+      // （p1と同様にp2側もaudio.play()がハングするため、さらにタイムアウト分待つ）
+      await waitFor(() => {
+        expect(screen.getByText('読み札p2', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+      }, { timeout: 45000 });
+
+      randomSpy.mockRestore();
+      localStorage.removeItem('autoAdvance');
+      localStorage.removeItem('autoAdvanceInterval');
+    } finally {
+      window.Audio = originalAudio;
+    }
+  }, 100000);
+
   it('applies the selected theme to the document and persists it', async () => {
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
@@ -2567,6 +2635,10 @@ describe('App', () => {
 
     // リピート再生（イントロ音＋本編）が終わるまで待つ
     await waitFor(() => expect(screen.getByText('もう一度')).not.toBeDisabled(), { timeout: 20000 });
+
+    // リピート再生完了後も、画面が準備完了画面（初期表示）に戻らず、
+    // 読み上げていたカードの表示のままであることを確認する（issue #729の調査で判明した回帰）
+    expect(screen.getByText('読み札1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
 
     fetch.mockClear();
     fireEvent.click(screen.getByText('次の札'));


### PR DESCRIPTION
## Summary

### issue #729（自動読み上げが途中で止まる）

- 追加の再現情報（「停止→もう一度」を押すと音声は再生されるが画面表示が準備完了画面のままになる）から、`playNextInQueue`内で「もう一度」（repeatPhrase、phraseDataを伴わない音声のみの再生）完了時に無条件で表示をinitial（準備完了画面）へ戻していた処理が原因と特定し、削除した
- 自動読み上げ本体が結果画面へ遷移した後に完全に止まる本体症状については、issue #729本文が示唆していたとおり、`setTimeout`起点（ユーザー操作を伴わない）での`audio.play()`呼び出しがモバイルブラウザの自動再生ポリシー等に抵触し、Promiseが未解決のまま留まるケースを最有力の原因と判断。`playAudio()`にタイムアウト（15秒）を追加し、ハングし続けても上限時間で強制的に諦めて読み上げ進行を先へ進めるようにした
- `stopReading()`が`currentAudioRef.current.resolve()`を直接呼ぶ経路も同じ`settleResolve`関数を経由させ、タイマー解除とsettledフラグの整合を保証した

### issue #459（カバレッジ80%ゲート）

- backend側のカバレッジ計測不安定性を再調査し、branches指標のみが不安定（handler.jsのファイル単位で50%〜86%まで変動）で、statements/functions/lines指標は全体平均で複数回の再実行を通じて安定して80%以上を計測できることを確認した
- `coverage_threshold: 0`（全面無効化）から`coverage_threshold: 80` + `coverage_metrics: "statements,functions,lines"`へ変更（branchesは表示のみで判定対象外、ファイル単位判定は不安定性再発を避けるため今回は有効化しない）

## Test plan

- [x] frontend・backend双方で`npx eslint .`エラー0件
- [x] frontend全230件のテストが成功
  - 新規: `audio.play()`が永久にハングしても自動読み上げでp1→p2まで進むことを検証するテスト（issue #729）を追加
  - 既存の「リピート再生前後で経過時間の計測開始点がリセットされない」テストに、リピート再生完了後も画面表示がphraseのまま変わらないことの検証を追加
- [x] backend全1537件のテストが成功
- [x] backendカバレッジを4回連続実行し、statements/functions/lines全体平均が安定して80%以上であることを確認（branchesのみ73.73-86.26%で変動）
- [x] frontendカバレッジは全指標87%以上で余裕あり

Refs #729, #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)