### PR TITLE
chore(release): v1.50.1 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.50.1](https://github.com/bamiyanapp/karuta/compare/v1.50.0...v1.50.1) (2026-07-23)
+
+
+### Bug Fixes
+
+* **frontend:** 読み上げ進行の永久停止対策 & ci: カバレッジゲート部分有効化（issue [#729](https://github.com/bamiyanapp/karuta/issues/729), [#459](https://github.com/bamiyanapp/karuta/issues/459)） ([#743](https://github.com/bamiyanapp/karuta/issues/743)) ([eea0eb6](https://github.com/bamiyanapp/karuta/commit/eea0eb612d1d983c88bbc24c581e8da726858b9e))
+
 # [1.50.0](https://github.com/bamiyanapp/karuta/compare/v1.49.3...v1.50.0) (2026-07-23)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.50.0",
+    "version": "1.50.1",
     "date": "2026/07/23",
+    "body": "### Bug Fixes\n\n* **frontend:** 読み上げ進行の永久停止対策 & ci: カバレッジゲート部分有効化（issue [#729](https://github.com/bamiyanapp/karuta/issues/729), [#459](https://github.com/bamiyanapp/karuta/issues/459)） ([#743](https://github.com/bamiyanapp/karuta/issues/743)) ([eea0eb6](https://github.com/bamiyanapp/karuta/commit/eea0eb612d1d983c88bbc24c581e8da726858b9e))"
+  },
+  {
+    "version": "1.50.0",
+    "date": "2026/07/23 16:07",
     "body": "### Features\n\n* **frontend:** 全札一覧の種別絞り込みをこども向け/エンジニア向けで先に絞り込めるようにする（issue [#730](https://github.com/bamiyanapp/karuta/issues/730)） ([#738](https://github.com/bamiyanapp/karuta/issues/738)) ([ab8547f](https://github.com/bamiyanapp/karuta/commit/ab8547f4f0e550776330e6f65d56564c6e1938bc))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.50.0",
+  "version": "1.50.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.50.0",
+      "version": "1.50.1",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.50.0"
+  "version": "1.50.1"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。