### PR TITLE
feat(frontend): 読み上げ画面から管理者セッションを再開できるようにする（issue #744）

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -976,6 +976,7 @@ function App() {
     judgeQuizRoomBuzz,
     adminSessionRoomId,
     adminSessionRestoreError,
+    isRestoringAdminSession,
     switchToAdminMode,
   } = useQuizRoomAdmin({
     view,
@@ -1674,15 +1675,29 @@ function App() {
       ) : (
         <div className="mb-4 d-flex flex-wrap gap-3 justify-content-center align-items-start">
           <div>
+            {/* 管理者セッション復帰（issue #697）: ブラウザを閉じて読み上げ画面へ戻ってきた
+                場合でも、保存済みの管理者セッションがあれば新規作成の前に再開できるようにする
+                （issue #744: 従来はこの画面に再開の導線が無く、常に新規ルームを作ってしまっていた） */}
+            {adminSessionRoomId && (
+              <button
+                type="button"
+                onClick={() => switchToAdminMode(adminSessionRoomId)}
+                disabled={isRestoringAdminSession || creatingQuizRoom}
+                className="btn btn-outline-dark px-4 rounded-pill me-2"
+              >
+                {isRestoringAdminSession ? "再開中..." : "クイズ大会のルームを再開する"}
+              </button>
+            )}
             <button
               type="button"
               onClick={createQuizRoom}
-              disabled={creatingQuizRoom}
+              disabled={creatingQuizRoom || isRestoringAdminSession}
               className="btn btn-outline-dark px-4 rounded-pill"
             >
               {creatingQuizRoom ? "作成中..." : "クイズ大会のルームを作成する"}
             </button>
             {quizRoomCreateError && <p className="text-danger small">{quizRoomCreateError}</p>}
+            {adminSessionRestoreError && <p className="text-danger small">{adminSessionRestoreError}</p>}
           </div>
           {division !== "kids" && (
             <div>

--- a/frontend/src/hooks/useQuizRoomAdmin.js
+++ b/frontend/src/hooks/useQuizRoomAdmin.js
@@ -350,6 +350,7 @@ export function useQuizRoomAdmin({
     judgeQuizRoomBuzz,
     adminSessionRoomId,
     adminSessionRestoreError,
+    isRestoringAdminSession,
     switchToAdminMode,
   };
 }

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -1461,6 +1461,78 @@ describe('useQuizRoomAdmin (via App)', () => {
     expect(screen.getByText('クイズ大会モードのルーム情報')).toBeInTheDocument();
   }, 40000);
 
+  it('offers to resume the saved admin session from the reading screen itself, instead of only via the participant URL (issue #744)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      return { ok: false };
+    });
+
+    const firstRender = await act(async () => render(<App />));
+
+    fireEvent.click(await screen.findByText('エンジニア向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    fireEvent.click(screen.getByText(/かるたを始める/));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    // ブラウザ/タブを閉じた状況を模す。Reactのstateはここで失われるが、localStorageは残る
+    firstRender.unmount();
+
+    // URLの?roomId=を経由せず、素朴にトップから読み上げ画面へ戻ってきた状況を模す
+    window.history.pushState({}, '', '/');
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('エンジニア向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    fireEvent.click(screen.getByText(/かるたを始める/));
+    await waitFor(() => screen.getByText('次の札'));
+
+    // 従来は「クイズ大会のルームを作成する」ボタンしかなく、これを押すと別の新しい
+    // ルームが作られてしまっていた（issue #744）。保存済みセッションがある今は、
+    // 読み上げ画面自体に「再開する」ボタンが出て、新規作成ボタンと並んで選べる
+    expect(screen.getByText('クイズ大会のルームを作成する')).toBeInTheDocument();
+    const resumeButton = screen.getByText('クイズ大会のルームを再開する');
+    fireEvent.click(resumeButton);
+
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    const adminConnections = MockWebSocket.instances.filter((instance) => instance.url.includes('adminToken='));
+    expect(adminConnections).toHaveLength(2); // 1回目の作成時 + 今回の再開時
+    expect(adminConnections[1].url).toContain('roomId=ABC123');
+    expect(adminConnections[1].url).toContain('adminToken=token-1');
+
+    // 復帰した接続が確立すれば、エラー表示は出ずルーム情報画面に留まる
+    act(() => {
+      adminConnections[1].readyState = MockWebSocket.OPEN;
+      adminConnections[1].onopen?.();
+    });
+    expect(screen.getByText('ルーム情報を表示（クイズ大会モード）')).toBeInTheDocument();
+  }, 40000);
+
   it('discards the saved admin token and falls back to the participant screen with an error when the saved token fails to connect (issue #697)', async () => {
     class MockWebSocket {
       constructor(url) {


### PR DESCRIPTION
## Summary

- issue #744（ブラウザを閉じてから読み上げ画面へ戻ると、既存の管理者セッションを再開できず「クイズ大会のルームを作成する」を押すと新しい別のルームが作られてしまう）に対応
- 管理者セッション復帰の仕組み自体（issue #697）はあったが、「管理者に切り替える」ボタンが参加者画面（`?roomId=`付きURL）にしか実装されておらず、読み上げ画面側は保存済みセッションを一切参照していなかったことが原因だった
- 読み上げ画面の「クイズ大会のルームを作成する」ボタンの隣に、保存済みの管理者セッションがある場合のみ「クイズ大会のルームを再開する」ボタンを表示するようにした。押下時は既存の`switchToAdminMode`（issue #697で実装済み）をそのまま呼ぶ
- 再開中・作成中はお互いのボタンをdisabledにし、復帰失敗時のエラーメッセージもこの画面に表示するようにした

## Test plan

- [x] frontend・backend双方で`npx eslint .`エラー0件
- [x] frontend全231件のテストが成功
  - 新規: ルーム作成後にブラウザを閉じ、URLの`?roomId=`を経由せず素朴に読み上げ画面へ戻った場合でも「再開する」ボタンから同じルームへ管理者として復帰できることを検証するテスト（issue #744）を追加
- [x] backend全1537件のテストが成功（statements 88.92%/functions 86.66%/lines 89.35%で引き続き閾値80%を満たす）
- [x] `npm run build`（frontend）成功

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_