### PR TITLE
chore(release): v1.51.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.51.0](https://github.com/bamiyanapp/karuta/compare/v1.50.1...v1.51.0) (2026-07-23)
+
+
+### Features
+
+* **frontend:** 読み上げ画面から管理者セッションを再開できるようにする（issue [#744](https://github.com/bamiyanapp/karuta/issues/744)） ([#746](https://github.com/bamiyanapp/karuta/issues/746)) ([bc26a19](https://github.com/bamiyanapp/karuta/commit/bc26a198d6f52a54d089a0eebc62bccd12cca693))
+
 ## [1.50.1](https://github.com/bamiyanapp/karuta/compare/v1.50.0...v1.50.1) (2026-07-23)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.50.1",
+    "version": "1.51.0",
     "date": "2026/07/23",
+    "body": "### Features\n\n* **frontend:** 読み上げ画面から管理者セッションを再開できるようにする（issue [#744](https://github.com/bamiyanapp/karuta/issues/744)） ([#746](https://github.com/bamiyanapp/karuta/issues/746)) ([bc26a19](https://github.com/bamiyanapp/karuta/commit/bc26a198d6f52a54d089a0eebc62bccd12cca693))"
+  },
+  {
+    "version": "1.50.1",
+    "date": "2026/07/23 20:40",
     "body": "### Bug Fixes\n\n* **frontend:** 読み上げ進行の永久停止対策 & ci: カバレッジゲート部分有効化（issue [#729](https://github.com/bamiyanapp/karuta/issues/729), [#459](https://github.com/bamiyanapp/karuta/issues/459)） ([#743](https://github.com/bamiyanapp/karuta/issues/743)) ([eea0eb6](https://github.com/bamiyanapp/karuta/commit/eea0eb612d1d983c88bbc24c581e8da726858b9e))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.50.1",
+  "version": "1.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.50.1",
+      "version": "1.51.0",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.50.1"
+  "version": "1.51.0"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。