### PR TITLE
feat: 再開可能な場合は新規作成ボタンを隠し、ルームを閉じる機能を追加する（issue #748）

### DIFF
--- a/backend/quizRoomHandler.js
+++ b/backend/quizRoomHandler.js
@@ -1,6 +1,6 @@
 const crypto = require("crypto");
 const { GetCommand, PutCommand, UpdateCommand, DeleteCommand, QueryCommand, ScanCommand } = require("@aws-sdk/lib-dynamodb");
-const { ApiGatewayManagementApiClient, PostToConnectionCommand } = require("@aws-sdk/client-apigatewaymanagementapi");
+const { ApiGatewayManagementApiClient, PostToConnectionCommand, DeleteConnectionCommand } = require("@aws-sdk/client-apigatewaymanagementapi");
 const { docClient, resolveAllowedOrigin } = require("./handler");
 
 // issue #470: クイズ大会モード（管理者ルーム開設＋複数端末同期）の最小構成。
@@ -598,6 +598,52 @@ exports.resetQuizRoomPoints = async (event) => {
         points: {},
         answerCounts: {},
       }))
+    );
+
+    return { statusCode: 200, body: "" };
+  } catch (error) {
+    console.error(error);
+    return { statusCode: 500, body: "Internal Server Error" };
+  }
+};
+
+// WebSocketカスタムルート"closeRoom"（issue #748）。管理者のみルームを明示的に終了できる。
+// ルームレコード自体を削除するため、以後の$connect試行は404で拒否される。ルーム内の
+// 全接続（参加者・管理者自身の他接続含む）へ終了をブロードキャストしたうえで、
+// 各接続をDeleteConnectionCommandで強制切断する。切断により$disconnectが呼ばれ、
+// 既存のdisconnectQuizRoom（接続レコード削除・予約名の解放）が自然に走るため、
+// このハンドラ側で接続レコードを個別に掃除する必要はない
+exports.closeQuizRoom = async (event) => {
+  try {
+    const connectionId = event.requestContext.connectionId;
+    const connection = await docClient.send(new GetCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      Key: { connectionId },
+    }));
+    if (!connection.Item || connection.Item.role !== "admin") {
+      return { statusCode: 403, body: "Forbidden" };
+    }
+
+    const { roomId } = connection.Item;
+
+    await docClient.send(new DeleteCommand({
+      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+      Key: { roomId },
+    }));
+
+    const connections = await docClient.send(new QueryCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      IndexName: "roomId-index",
+      KeyConditionExpression: "roomId = :roomId",
+      ExpressionAttributeValues: { ":roomId": roomId },
+    }));
+    const managementApi = buildManagementApiClient(event);
+    const items = connections.Items || [];
+    await Promise.allSettled(
+      items.map((conn) => postToConnection(managementApi, conn.connectionId, { type: "roomClosed" }))
+    );
+    await Promise.allSettled(
+      items.map((conn) => managementApi.send(new DeleteConnectionCommand({ ConnectionId: conn.connectionId })).catch(() => {}))
     );
 
     return { statusCode: 200, body: "" };

--- a/backend/quizRoomHandler.test.js
+++ b/backend/quizRoomHandler.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
 import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, DeleteCommand, QueryCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
-import { ApiGatewayManagementApiClient, PostToConnectionCommand } from '@aws-sdk/client-apigatewaymanagementapi';
+import { ApiGatewayManagementApiClient, PostToConnectionCommand, DeleteConnectionCommand } from '@aws-sdk/client-apigatewaymanagementapi';
 import crypto from 'crypto';
 import {
   createQuizRoom,
@@ -15,6 +15,7 @@ import {
   buzzQuizRoom,
   judgeQuizRoomBuzz,
   resetQuizRoomPoints,
+  closeQuizRoom,
 } from './quizRoomHandler';
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
@@ -1107,6 +1108,82 @@ describe('resetQuizRoomPoints', () => {
   it('handles unexpected errors', async () => {
     ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
     const response = await resetQuizRoomPoints(wsEvent({}));
+    expect(response.statusCode).toBe(500);
+  });
+});
+
+describe('closeQuizRoom', () => {
+  it('rejects when the caller is not an admin', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { connectionId: 'conn-1', roomId: 'ROOM01', role: 'participant' } });
+    const response = await closeQuizRoom(wsEvent({}));
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('rejects when the connection record is missing', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+    const response = await closeQuizRoom(wsEvent({}));
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('deletes the room record, broadcasts roomClosed, and force-disconnects every connection (issue #748)', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+    });
+    ddbMock.on(DeleteCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+        { connectionId: 'conn-p', roomId: 'ROOM01', role: 'participant' },
+      ],
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+    managementApiMock.on(DeleteConnectionCommand).resolves({});
+
+    const response = await closeQuizRoom(wsEvent({ connectionId: 'conn-admin' }));
+
+    expect(response.statusCode).toBe(200);
+    // ルームレコード自体を削除するため、以後の$connect試行は404で拒否される
+    const deleteRoomCall = ddbMock.commandCalls(DeleteCommand)[0].args[0].input;
+    expect(deleteRoomCall.TableName).toBe('TestQuizRooms');
+    expect(deleteRoomCall.Key).toEqual({ roomId: 'ROOM01' });
+
+    const postCalls = managementApiMock.commandCalls(PostToConnectionCommand);
+    expect(postCalls).toHaveLength(2);
+    const payload = JSON.parse(Buffer.from(postCalls[0].args[0].input.Data).toString('utf-8'));
+    expect(payload).toEqual({ type: 'roomClosed' });
+
+    // 参加者・管理者自身の接続の両方を強制切断する（$disconnectで接続レコードの
+    // 掃除・予約名の解放が自然に走るため、このハンドラ側では個別に掃除しない）
+    const deleteConnectionCalls = managementApiMock.commandCalls(DeleteConnectionCommand);
+    expect(deleteConnectionCalls).toHaveLength(2);
+    expect(deleteConnectionCalls.map((c) => c.args[0].input.ConnectionId).sort()).toEqual(['conn-admin', 'conn-p']);
+  });
+
+  it('does not let one failed force-disconnect stop the others from being closed', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+    });
+    ddbMock.on(DeleteCommand).resolves({});
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { connectionId: 'conn-admin', roomId: 'ROOM01', role: 'admin' },
+        { connectionId: 'conn-p', roomId: 'ROOM01', role: 'participant' },
+      ],
+    });
+    managementApiMock.on(PostToConnectionCommand).resolves({});
+    managementApiMock.on(DeleteConnectionCommand)
+      .rejectsOnce(new Error('already gone'))
+      .resolves({});
+
+    const response = await closeQuizRoom(wsEvent({ connectionId: 'conn-admin' }));
+
+    expect(response.statusCode).toBe(200);
+    expect(managementApiMock.commandCalls(DeleteConnectionCommand)).toHaveLength(2);
+  });
+
+  it('handles unexpected errors', async () => {
+    ddbMock.on(GetCommand).rejects(new Error('DynamoDB error'));
+    const response = await closeQuizRoom(wsEvent({}));
     expect(response.statusCode).toBe(500);
   });
 });

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -77,10 +77,12 @@ provider:
           # api-id/stageをワイルドカードにしているのはAWS公式ドキュメントで案内されている定型パターン。
           # Serverless Frameworkが自動生成するWebSocket APIの論理ID（未確定・デプロイ時に決まる）を
           # !Subで直接参照する方式は、名前を誤ると循環参照等でデプロイ自体が壊れるリスクがあるため
-          # 採用しない（このAWSアカウントは本サービス専用でほかにWebSocket APIを持たない前提）
+          # 採用しない（このAWSアカウントは本サービス専用でほかにWebSocket APIを持たない前提）。
+          # メソッド部分はPOST（PostToConnectionCommand）に加え、ルーム終了時の強制切断
+          # （DeleteConnectionCommand、issue #748）が使うDELETEも許可するようワイルドカードにする
           Action:
             - execute-api:ManageConnections
-          Resource: "arn:aws:execute-api:${aws:region}:${aws:accountId}:*/*/POST/@connections/*"
+          Resource: "arn:aws:execute-api:${aws:region}:${aws:accountId}:*/*/*/@connections/*"
 
 custom:
   esbuild: # @sparticuz/chromium・puppeteer-coreはefudaPdfHandler.js内で動的import()するESM専用
@@ -253,6 +255,11 @@ functions:
     events:
       - websocket:
           route: resetPoints
+  closeQuizRoom: # 追加（issue #748）。管理者のみルームを明示的に終了でき、ルーム内全接続へ終了を通知して強制切断する
+    handler: quizRoomHandler.closeQuizRoom
+    events:
+      - websocket:
+          route: closeRoom
 
 resources:
   Resources:

--- a/frontend/e2e/quiz-room.spec.js
+++ b/frontend/e2e/quiz-room.spec.js
@@ -66,12 +66,12 @@ test('admin creates a quiz room and a participant sees the same card update in r
 });
 
 // issue #640: 管理者がリロードした（このテストの再現方法）その場での挙動を固定化する
-// 回帰テスト。adminTokenはissue #697でlocalStorageへ永続化されたが、それはあくまで
-// 「参加者画面から『管理者に切り替える』ボタンで再接続する」という別導線での復帰を
-// 可能にするものであり、リロードされた本人のタブが自動的に管理者画面へ戻るわけではない。
-// そのため、このテストが記録する「リロードした直後のタブでは元のルーム作成前の状態に戻る」
-// という挙動自体は現在も変わらない。「治る」ことを検証するテストではなく、現状の既知の制約
-// （参加者側にも通知が一切届かない）をそのまま記録することが目的
+// 回帰テスト。adminTokenはissue #697でlocalStorageへ永続化されており、当初は
+// 「参加者画面から『管理者に切り替える』ボタンで再接続する」という別導線でのみ
+// 復帰できたが、issue #744・#748でリロードされた本人のタブ（読み上げ画面）からも
+// 「再開する」ボタンで直接復帰できるようになった。それでも quizRoom（React state）
+// 自体は失われるため、リロード直後は一瞬ルーム作成前の画面に戻る点、および参加者側には
+// 管理者の一時切断について一切通知が届かない点（現状の既知の制約）は変わらない
 test('when the admin reloads mid-game, the quiz room association is lost and the participant gets no notification (issue #640)', async ({ browser }, testInfo) => {
   const adminContext = await browser.newContext();
   const adminPage = await adminContext.newPage();
@@ -112,11 +112,15 @@ test('when the admin reloads mid-game, the quiz room association is lost and the
 
     // division・カテゴリ選択はURLクエリパラメータ経由で復元される（useUrlQuerySync）ため
     // ゲーム画面自体には戻るが、quizRoom（roomId・adminToken）はReact stateにしか
-    // 保持されておらず永続化されていないため失われ、「ルームを作成する」ボタンが
-    // 再度表示される（＝管理者は同じルームへの管理者としての復帰手段を持たない）
+    // 保持されておらず永続化されていないため失われる。ただし管理者トークン自体は
+    // createQuizRoom時にlocalStorageへ保存されている（issue #697）ため、読み上げ画面に
+    // 「クイズ大会のルームを作成する」ではなく「クイズ大会のルームを再開する」ボタンが
+    // 表示される（issue #744・#748: 読み上げ画面から保存済みセッションで再開できるように
+    // なった）。「作成する」を誤って押して別の新しいルームを作ってしまう心配はない
     await expect(nextButton).toBeVisible({ timeout: 15000 });
-    await expect(adminPage.getByText('クイズ大会のルームを作成する')).toBeVisible();
-    await captureScreenshot(adminPage, testInfo, 'admin-lost-room-after-reload', '管理者：リロード後にルーム作成前の状態へ戻り、同じルームへの復帰手段が無い状態');
+    await expect(adminPage.getByText('クイズ大会のルームを再開する')).toBeVisible();
+    await expect(adminPage.getByText('クイズ大会のルームを作成する')).not.toBeVisible();
+    await captureScreenshot(adminPage, testInfo, 'admin-lost-room-after-reload', '管理者：リロード後、ルーム作成前の画面に戻るが「再開する」ボタンから同じルームへ復帰できる状態');
 
     // 参加者側は管理者の切断について一切通知を受け取らず、リロード直前の画面のまま
     // 変化しない（現状の既知の制約）

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -971,6 +971,7 @@ function App() {
     quizRoomConnectionStatus,
     reconnectQuizRoom,
     resetQuizRoomPoints,
+    closeQuizRoom,
     createQuizRoom,
     joinQuizRoom,
     judgeQuizRoomBuzz,
@@ -1252,6 +1253,7 @@ function App() {
           quizRoomPoints={quizRoomPoints}
           quizRoomAnswerCounts={quizRoomAnswerCounts}
           resetQuizRoomPoints={resetQuizRoomPoints}
+          closeQuizRoom={closeQuizRoom}
         />
         {/* issue #613: 早押し判定モーダルはこの画面を開いている間も表示する
             （以前はゲーム画面のレンダー内にしか存在せず、この画面滞在中は
@@ -1677,25 +1679,29 @@ function App() {
           <div>
             {/* 管理者セッション復帰（issue #697）: ブラウザを閉じて読み上げ画面へ戻ってきた
                 場合でも、保存済みの管理者セッションがあれば新規作成の前に再開できるようにする
-                （issue #744: 従来はこの画面に再開の導線が無く、常に新規ルームを作ってしまっていた） */}
-            {adminSessionRoomId && (
+                （issue #744: 従来はこの画面に再開の導線が無く、常に新規ルームを作ってしまっていた）。
+                再開できる場合は、誤って別の新しいルームを作ってしまわないよう、新規作成ボタン自体を
+                隠す（issue #748）。作成ボタンが必要な場合は先にルーム詳細画面から現在のルームを
+                閉じることで再開できない状態にできる（issue #748） */}
+            {adminSessionRoomId ? (
               <button
                 type="button"
                 onClick={() => switchToAdminMode(adminSessionRoomId)}
-                disabled={isRestoringAdminSession || creatingQuizRoom}
-                className="btn btn-outline-dark px-4 rounded-pill me-2"
+                disabled={isRestoringAdminSession}
+                className="btn btn-outline-dark px-4 rounded-pill"
               >
                 {isRestoringAdminSession ? "再開中..." : "クイズ大会のルームを再開する"}
               </button>
+            ) : (
+              <button
+                type="button"
+                onClick={createQuizRoom}
+                disabled={creatingQuizRoom}
+                className="btn btn-outline-dark px-4 rounded-pill"
+              >
+                {creatingQuizRoom ? "作成中..." : "クイズ大会のルームを作成する"}
+              </button>
             )}
-            <button
-              type="button"
-              onClick={createQuizRoom}
-              disabled={creatingQuizRoom || isRestoringAdminSession}
-              className="btn btn-outline-dark px-4 rounded-pill"
-            >
-              {creatingQuizRoom ? "作成中..." : "クイズ大会のルームを作成する"}
-            </button>
             {quizRoomCreateError && <p className="text-danger small">{quizRoomCreateError}</p>}
             {adminSessionRestoreError && <p className="text-danger small">{adminSessionRestoreError}</p>}
           </div>

--- a/frontend/src/hooks/useQuizRoomAdmin.js
+++ b/frontend/src/hooks/useQuizRoomAdmin.js
@@ -135,6 +135,7 @@ export function useQuizRoomAdmin({
     broadcastState: broadcastQuizRoomState,
     judgeBuzz,
     resetPoints: resetQuizRoomPoints,
+    closeRoom: closeQuizRoomConnection,
     reconnect: reconnectQuizRoom,
   } = useQuizRoomSync({
     wsBaseUrl: WS_BASE_URL,
@@ -163,6 +164,15 @@ export function useQuizRoomAdmin({
       if (answerCounts) {
         setQuizRoomAnswerCounts(answerCounts);
       }
+    },
+    // ルームを閉じる（issue #748）: 自分自身の操作（closeQuizRoom）・別タブでの操作の
+    // いずれで閉じられた場合も同じ経路で受け取り、保存済みセッション・管理者状態を
+    // クリアして読み上げ画面へ戻す
+    onRoomClosed: () => {
+      clearStoredAdminSession();
+      setAdminSessionRoomId(null);
+      setQuizRoom(null);
+      setView("game");
     },
   });
 
@@ -333,6 +343,14 @@ export function useQuizRoomAdmin({
     return true;
   };
 
+  // ルームを閉じる（issue #748）: ルーム詳細画面（QuizRoomInfoView.jsx）の
+  // 「ルームを閉じる」ボタンから呼ばれる。実際の状態クリア（保存済みセッションの
+  // 破棄・quizRoomのリセット・画面遷移）はサーバーからのroomClosedブロードキャストを
+  // 受けて上記onRoomClosedで行う
+  const closeQuizRoom = () => {
+    closeQuizRoomConnection();
+  };
+
   return {
     quizRoom,
     creatingQuizRoom,
@@ -352,5 +370,6 @@ export function useQuizRoomAdmin({
     adminSessionRestoreError,
     isRestoringAdminSession,
     switchToAdminMode,
+    closeQuizRoom,
   };
 }

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -67,6 +67,11 @@ describe('useQuizRoomAdmin (via App)', () => {
     // 参加者名の永続化（issue #697）: あるテストで確定した名前が別のテストへ
     // 漏れ、名前入力画面が意図せずスキップされてしまわないようにする
     localStorage.removeItem('quizRoomParticipantName');
+    // 管理者セッション復帰（issue #697）: あるテストでルームを作成すると保存される
+    // quizRoomAdminSessionが別のテストへ漏れると、読み上げ画面が「再開する」ボタンの
+    // 表示に切り替わってしまい（issue #748）、「作成する」ボタンを前提にした他の
+    // テストが軒並み壊れるため、テストごとに毎回明示的にクリアする
+    localStorage.removeItem('quizRoomAdminSession');
     resetSharedAudioForTests();
   });
 
@@ -1513,8 +1518,9 @@ describe('useQuizRoomAdmin (via App)', () => {
 
     // 従来は「クイズ大会のルームを作成する」ボタンしかなく、これを押すと別の新しい
     // ルームが作られてしまっていた（issue #744）。保存済みセッションがある今は、
-    // 読み上げ画面自体に「再開する」ボタンが出て、新規作成ボタンと並んで選べる
-    expect(screen.getByText('クイズ大会のルームを作成する')).toBeInTheDocument();
+    // 読み上げ画面自体に「再開する」ボタンが出る。誤って別の新しいルームを作って
+    // しまわないよう、再開可能な間は新規作成ボタン自体を表示しない（issue #748）
+    expect(screen.queryByText('クイズ大会のルームを作成する')).not.toBeInTheDocument();
     const resumeButton = screen.getByText('クイズ大会のルームを再開する');
     fireEvent.click(resumeButton);
 
@@ -1588,5 +1594,122 @@ describe('useQuizRoomAdmin (via App)', () => {
     // 無効だったトークンは破棄され、切り替えボタンも消える
     expect(screen.queryByText('管理者に切り替える')).not.toBeInTheDocument();
     expect(localStorage.getItem('quizRoomAdminSession')).toBeNull();
+  }, 40000);
+
+  it('closes the room from the room-info screen, clears the saved admin session, and returns to the reading screen (issue #748)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      return { ok: false };
+    });
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('エンジニア向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    fireEvent.click(screen.getByText(/かるたを始める/));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+    expect(JSON.parse(localStorage.getItem('quizRoomAdminSession'))).toEqual({ roomId: 'ABC123', adminToken: 'token-1' });
+
+    const adminConnection = MockWebSocket.instances.find((instance) => instance.url.includes('adminToken=token-1'));
+    act(() => {
+      adminConnection.readyState = MockWebSocket.OPEN;
+      adminConnection.onopen?.();
+    });
+
+    fireEvent.click(screen.getByText('ルーム情報を表示（クイズ大会モード）'));
+    const closeButton = await screen.findByText('ルームを閉じる');
+    fireEvent.click(closeButton);
+    expect(confirmSpy).toHaveBeenCalled();
+
+    expect(adminConnection.sent).toContainEqual(JSON.stringify({ action: 'closeRoom' }));
+
+    // サーバーからのroomClosedブロードキャストを模す
+    act(() => {
+      adminConnection.onmessage?.({ data: JSON.stringify({ type: 'roomClosed' }) });
+    });
+
+    // 読み上げ画面へ戻り、保存済みセッションが破棄されるため、新規作成ボタンが再び表示される
+    await screen.findByText('クイズ大会のルームを作成する');
+    expect(screen.queryByText('クイズ大会のルームを再開する')).not.toBeInTheDocument();
+    expect(localStorage.getItem('quizRoomAdminSession')).toBeNull();
+
+    confirmSpy.mockRestore();
+  }, 40000);
+
+  it('does not close the room when the confirmation dialog is dismissed', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'engineer' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      return { ok: false };
+    });
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('エンジニア向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    fireEvent.click(screen.getByText(/かるたを始める/));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+    fireEvent.click(screen.getByText('ルーム情報を表示（クイズ大会モード）'));
+
+    const closeButton = await screen.findByText('ルームを閉じる');
+    fireEvent.click(closeButton);
+    expect(confirmSpy).toHaveBeenCalled();
+
+    const adminConnection = MockWebSocket.instances.find((instance) => instance.url.includes('adminToken=token-1'));
+    expect(adminConnection.sent).not.toContainEqual(JSON.stringify({ action: 'closeRoom' }));
+    expect(JSON.parse(localStorage.getItem('quizRoomAdminSession'))).toEqual({ roomId: 'ABC123', adminToken: 'token-1' });
+
+    confirmSpy.mockRestore();
   }, 40000);
 });

--- a/frontend/src/hooks/useQuizRoomSync.js
+++ b/frontend/src/hooks/useQuizRoomSync.js
@@ -39,7 +39,10 @@ export const CONNECTION_STATUS_LABEL = {
 // されたときはサーバーから{type:"roundReset", excludedName}が返るのでonRoundResetを呼ぶ
 // 参加者一覧（issue #545）: サーバーから{type:"participants", names}（名前確定済みの
 // 参加者名一覧）を受け取るたびonParticipantsを呼ぶ
-export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz, onPoints, onNameError, onRoundReset, onParticipants }) {
+// ルームを閉じる（issue #748）: 管理者はcloseRoomでルームの終了を送信できる。サーバーが
+// ルームを削除し全接続へ{type:"roomClosed"}を配信したうえで強制切断するので、これを
+// 受け取るたびonRoomClosedを呼ぶ
+export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz, onPoints, onNameError, onRoundReset, onParticipants, onRoomClosed }) {
   const [internalStatus, setInternalStatus] = useState("idle"); // connecting|connected|error（idleはwsBaseUrl/roomId未設定時に導出する）
   const connectionStatus = (!wsBaseUrl || !roomId) ? "idle" : internalStatus;
   const wsRef = useRef(null);
@@ -49,6 +52,7 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
   const onNameErrorRef = useRef(onNameError);
   const onRoundResetRef = useRef(onRoundReset);
   const onParticipantsRef = useRef(onParticipants);
+  const onRoomClosedRef = useRef(onRoomClosed);
   const reconnectAttemptsRef = useRef(0);
   const reconnectTimeoutRef = useRef(null);
   const closedByCleanupRef = useRef(false);
@@ -88,6 +92,10 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
   useEffect(() => {
     onParticipantsRef.current = onParticipants;
   }, [onParticipants]);
+
+  useEffect(() => {
+    onRoomClosedRef.current = onRoomClosed;
+  }, [onRoomClosed]);
 
   useEffect(() => {
     if (!wsBaseUrl || !roomId) {
@@ -157,6 +165,8 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
             onRoundResetRef.current?.({ excludedName: data.excludedName, answerCounts: data.answerCounts });
           } else if (data?.type === "participants") {
             onParticipantsRef.current?.(data.names);
+          } else if (data?.type === "roomClosed") {
+            onRoomClosedRef.current?.();
           }
         } catch (error) {
           console.error("Failed to parse quiz room message:", error);
@@ -292,5 +302,15 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
     }
   }, []);
 
-  return { connectionStatus, broadcastState, setParticipantName, buzz, judgeBuzz, resetPoints, reconnect: forceReconnect };
+  // ルームを閉じる（issue #748）: 管理者がルームを明示的に終了する際に送信する。
+  // サーバー側でルームレコードが削除され、全接続へroomClosedがブロードキャストされた
+  // うえで強制切断されるため、呼び出し元はonRoomClosedで自身のroomId等の状態を
+  // クリアすることを想定している
+  const closeRoom = useCallback(() => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ action: "closeRoom" }));
+    }
+  }, []);
+
+  return { connectionStatus, broadcastState, setParticipantName, buzz, judgeBuzz, resetPoints, closeRoom, reconnect: forceReconnect };
 }

--- a/frontend/src/views/QuizRoomInfoView.jsx
+++ b/frontend/src/views/QuizRoomInfoView.jsx
@@ -8,7 +8,7 @@ import { mergeParticipantsWithPoints } from "../utils/quizRoomParticipants";
 // useQuizRoomSync（WebSocket接続）はApp.jsx側のトップレベルで呼ばれており、
 // view遷移によってApp自体がアンマウントされることはないため、この画面への
 // 遷移中も読み上げ・早押し等のクイズ大会の進行状態は維持される
-function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoomPoints = {}, quizRoomAnswerCounts = {}, resetQuizRoomPoints }) {
+function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoomPoints = {}, quizRoomAnswerCounts = {}, resetQuizRoomPoints, closeQuizRoom }) {
   const [qrDataUrl, setQrDataUrl] = useState(null);
   const [copied, setCopied] = useState(false);
 
@@ -33,6 +33,14 @@ function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoom
   const handleResetPoints = () => {
     if (window.confirm("参加者全員のポイントをリセットします。よろしいですか？")) {
       resetQuizRoomPoints?.();
+    }
+  };
+
+  // ルームを閉じる（issue #748）: 参加者全員が切断され、以後このルームIDでは
+  // 再接続できなくなる取り消せない操作のため、ポイントリセットと同様に確認ダイアログを挟む
+  const handleCloseRoom = () => {
+    if (window.confirm("このルームを閉じます。参加者全員が切断され、元に戻せません。よろしいですか？")) {
+      closeQuizRoom?.();
     }
   };
 
@@ -105,6 +113,11 @@ function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoom
         </div>
       )}
       <div className="mt-5">
+        <button type="button" onClick={handleCloseRoom} className="btn btn-sm btn-outline-danger rounded-pill px-3">
+          ルームを閉じる
+        </button>
+      </div>
+      <div className="mt-3">
         <button onClick={() => setView("game")} className="btn btn-link text-muted text-decoration-none">← 戻る</button>
       </div>
     </div>

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -76,6 +76,10 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
   // チェックで存在を確認する。確認自体が失敗した場合（バックエンド障害等）は
   // 参加をブロックせず、従来どおり接続を試みさせる（安全側にフォールバックする）
   const [roomInvalid, setRoomInvalid] = useState(false);
+  // ルームを閉じる（issue #748）: 管理者がルームを閉じると、サーバーから
+  // {type: "roomClosed"}が届いたのち強制切断される。理由不明のまま「接続できません
+  // でした」表示に落ちるのを避け、終了したことを明示的に案内する
+  const [roomClosedNotice, setRoomClosedNotice] = useState(false);
 
   const [roomState, setRoomState] = useState(null);
   // これまでに読み上げた札の履歴（issue #548）: サーバー側では履歴を保持・配信していない
@@ -208,8 +212,8 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
   const { connectionStatus, setParticipantName, buzz, reconnect } = useQuizRoomSync({
     wsBaseUrl,
     // issue #616: 存在しないルームだと判明した場合はroomIdをnullに落とし、
-    // WebSocketの無駄な接続リトライを打ち切る
-    roomId: roomInvalid ? null : joinRoomId,
+    // WebSocketの無駄な接続リトライを打ち切る（issue #748: ルームが閉じられた場合も同様）
+    roomId: (roomInvalid || roomClosedNotice) ? null : joinRoomId,
     onState: setRoomState,
     onBuzz: (buzzedByParam) => {
       // issue #613: 早押し発生（自分・他の参加者いずれの場合も）を音で通知する
@@ -226,6 +230,7 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
     onNameError: handleNameError,
     onRoundReset: handleRoundReset,
     onParticipants: setParticipants,
+    onRoomClosed: () => setRoomClosedNotice(true),
   });
 
   // 早押し結果表示のリセット判定（issue #510）。ラウンドを表す値（buzzRoundKey）を
@@ -399,6 +404,20 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
     return (
       <div className="container py-5 mx-auto text-center">
         <p className="text-muted mb-4">クイズ大会モードは現在準備中です。しばらくお待ちください。</p>
+        <button onClick={goBack} className="btn btn-outline-dark rounded-pill">← 戻る</button>
+      </div>
+    );
+  }
+
+  // ルームを閉じる（issue #748）: 管理者がルームを閉じた場合、理由不明のまま
+  // 「接続できませんでした」表示に落ちるのを避け、終了したことを明示的に案内する
+  if (joinRoomId && roomClosedNotice) {
+    return (
+      <div className="container py-5 mx-auto text-center">
+        <header className="mb-4">
+          <h1 className="h4 fw-bold">クイズ大会モード（参加者）</h1>
+        </header>
+        <p className="text-danger mb-4">このルームはホストによって終了されました。</p>
         <button onClick={goBack} className="btn btn-outline-dark rounded-pill">← 戻る</button>
       </div>
     );

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -9,19 +9,21 @@ const onPointsCallbacks = [];
 const onNameErrorCallbacks = [];
 const onRoundResetCallbacks = [];
 const onParticipantsCallbacks = [];
+const onRoomClosedCallbacks = [];
 let mockConnectionStatus = 'connected';
 const setParticipantNameMock = vi.fn();
 const buzzMock = vi.fn();
 const reconnectMock = vi.fn();
 
 vi.mock('../hooks/useQuizRoomSync', () => ({
-  useQuizRoomSync: ({ onState, onBuzz, onPoints, onNameError, onRoundReset, onParticipants }) => {
+  useQuizRoomSync: ({ onState, onBuzz, onPoints, onNameError, onRoundReset, onParticipants, onRoomClosed }) => {
     onStateCallbacks.push(onState);
     onBuzzCallbacks.push(onBuzz);
     onPointsCallbacks.push(onPoints);
     onNameErrorCallbacks.push(onNameError);
     onRoundResetCallbacks.push(onRoundReset);
     onParticipantsCallbacks.push(onParticipants);
+    onRoomClosedCallbacks.push(onRoomClosed);
     return {
       connectionStatus: mockConnectionStatus,
       broadcastState: vi.fn(),
@@ -76,6 +78,12 @@ function emitParticipants(names) {
   });
 }
 
+function emitRoomClosed() {
+  act(() => {
+    onRoomClosedCallbacks[onRoomClosedCallbacks.length - 1]?.();
+  });
+}
+
 // 早押し機能（issue #510）: 参加者画面は名前入力を先に確定させないと通常画面へ進まないため、
 // 名前を関係しないテストではこのヘルパーで確定させておく
 function confirmName(name = 'たろう') {
@@ -110,6 +118,7 @@ beforeEach(() => {
   onNameErrorCallbacks.length = 0;
   onRoundResetCallbacks.length = 0;
   onParticipantsCallbacks.length = 0;
+  onRoomClosedCallbacks.length = 0;
   mockConnectionStatus = 'connected';
   setParticipantNameMock.mockClear();
   buzzMock.mockClear();
@@ -174,6 +183,24 @@ describe('QuizRoomView', () => {
     emitState({ type: 'result', content: { time: 1.234, answer: '答え1' } });
     expect(screen.getByText('1.23')).toBeInTheDocument();
     expect(screen.getByText('答え1')).toBeInTheDocument();
+  });
+
+  it('shows a "closed by the host" message and stops trying to reconnect when the admin closes the room (issue #748)', () => {
+    const setView = vi.fn();
+    window.history.pushState({}, '', '?view=quiz-room&roomId=ABC123');
+
+    render(<QuizRoomView setView={setView} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
+
+    expect(screen.getByText('クイズ大会モード（参加者）')).toBeInTheDocument();
+
+    emitRoomClosed();
+
+    expect(screen.getByText('このルームはホストによって終了されました。')).toBeInTheDocument();
+    expect(screen.queryByText('ホストの操作を待っています...')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('← 戻る'));
+    expect(setView).toHaveBeenCalledWith('game');
   });
 
   it('shows an error and does not proceed to the name entry screen when the room does not exist (issue #616)', async () => {


### PR DESCRIPTION
## Summary

issue #748（issue #744のフォローアップ）に対応。

1. 読み上げ画面で、保存済みの管理者セッションがある場合は「クイズ大会のルームを再開する」ボタンのみを表示し、「クイズ大会のルームを作成する」ボタンは表示しないようにした（誤って別の新しいルームを作ってしまうリスクを解消）
2. ルーム詳細画面（QuizRoomInfoView）に「ルームを閉じる」ボタンを新設した
   - backend: 新しいWebSocketカスタムルート`closeRoom`を追加。管理者のみルームレコードを削除でき、ルーム内の全接続へ`{type: "roomClosed"}`をブロードキャストしたうえで強制切断する（既存の`$disconnect`ハンドラが接続レコード削除・名前解放を自然に行う）
   - IAMポリシー（`execute-api:ManageConnections`）のResourceがPOSTメソッドのみに限定されていたため、強制切断（DELETE）も許可するよう修正した
   - frontend: `useQuizRoomSync`→`useQuizRoomAdmin`→`QuizRoomInfoView`の経路で実装。押下時は既存の「ポイントをリセット」と同様`window.confirm`で確認を挟む
   - 参加者画面（QuizRoomView）もルーム終了を受け取り、「このルームはホストによって終了されました。」の専用画面を表示し、無駄な再接続を行わないようにした

## Test plan

- [x] backend: `npx eslint .`エラー0件、`npx vitest run --no-isolate --coverage`全1542件成功（新規5件）
- [x] frontend: `npx eslint .`エラー0件、`npx vitest run --no-file-parallelism`全234件成功（新規4件・既存1件更新）
- [x] frontend: `npm run build`成功

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_