### PR TITLE
ci: reusable-ci.ymlの参照バージョンをv1.7.1へ更新する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ci:
-    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.6.3
+    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.7.1
     with:
       frontend_dir: frontend
       backend_dir: backend


### PR DESCRIPTION
## Summary

issue #750（E2Eスクリーンショットの画像diff機能）に対応するため、`.github/workflows/ci.yml`の`reusable-ci.yml`参照バージョンを`v1.6.3`から`v1.7.1`へ更新した。

- bamiyanapp/dev-standards#107（v1.7.0、`compare-e2e-screenshots`複合アクション追加）
- bamiyanapp/dev-standards#108（v1.6.1→v1.7.0への内部参照ref更新、squash mergeで`chore:`扱いになりv1.7.0では未リリースのまま残っていた）
- bamiyanapp/dev-standards#109（v1.7.1、sparse-checkoutパターン修正とあわせて#108の内容も取り込み）

v1.6.3→v1.7.1の差分を確認し、入力（inputs）の追加・削除・リネームが無く、E2Eスクリーンショット関連ステップの純粋な追加のみであることを確認済み。karuta側の追加対応（screenshot.js等）は不要。

## Test plan

- [x] 本変更はCI設定のみのためfrontend/backendのコード変更はなし
- [x] frontend/backend双方で`npx eslint .`エラー0件を確認
- [ ] 本変更自体（E2Eスクリーンショットの画像diffが実際に機能するか）の動作確認は、次回のPRでのCI実行結果でご確認ください

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_