### PR TITLE
fix(frontend): 停止ボタン押下時に画面を準備完了画面へ強制的に戻さないようにする（issue #755）

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -905,9 +905,11 @@ function App() {
     // 中断された読み上げの計測を、次回の記録に誤って持ち越さないようにする
     startTimeRef.current = null;
 
+    // 停止は音声・タイマーの中断のみを行い、画面表示は変更しない（issue #755）。
+    // 以前はここで表示を強制的にinitial（準備完了画面）へ戻していたが、読み上げ中の
+    // 画面を見ながら停止したユーザーが、押した瞬間に画面が切り替わってしまうのは
+    // 不適切な挙動だった
     setIsFadingOut(false);
-    nextContentRef.current = { type: "initial" };
-    setDisplayContent({ type: "initial" });
     setAudioQueue([]);
     setIsReading(false);
   };

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2363,6 +2363,72 @@ describe('App', () => {
     window.Audio = originalAudio;
   }, 25000);
 
+  it('keeps the currently displayed phrase card visible after pressing stop, instead of jumping back to the initial screen (issue #755)', async () => {
+    const originalAudio = window.Audio;
+    // イントロ音（wadodon.mp3）はすぐ完了させ、本編音声だけは意図的にonendedを
+    // 発火させないままにして、読み札がフリップ表示された後も「読み上げ中」の
+    // 状態（isReading）を維持したまま停止ボタンを押せるようにする
+    window.Audio = vi.fn().mockImplementation(function (url) {
+      const audio = {
+        play: vi.fn().mockResolvedValue(),
+        pause: vi.fn(),
+        load: vi.fn(),
+        _src: undefined,
+        get src() {
+          return this._src;
+        },
+        set src(u) {
+          this._src = u;
+          if (u === 'wadodon.mp3') {
+            setTimeout(() => {
+              if (this.onended) this.onended();
+            }, 0);
+          }
+          // 本編音声（dummy）はonendedを意図的に発火させない
+        },
+      };
+      if (url) audio.src = url;
+      return audio;
+    });
+
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      if (url.includes('/get-phrase?')) return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', audioData: 'dummy' }) };
+      return { ok: false };
+    });
+
+    try {
+      await act(async () => {
+        render(<App />);
+      });
+
+      fireEvent.click(await screen.findByText('こども向け'));
+      fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+
+      await waitFor(() => screen.getByText('次の札'));
+      fireEvent.click(screen.getByText('次の札'));
+
+      // フリップ演出（3秒待機＋フェード）を経て読み札が実際に表示されるまで待つ
+      await waitFor(() => {
+        expect(screen.getByText('読み札1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+      }, { timeout: 15000 });
+
+      const stopButton = screen.getByRole('button', { name: '停止' });
+      expect(stopButton).not.toBeDisabled();
+      fireEvent.click(stopButton);
+
+      // 停止直後も読み札の表示はそのまま残り、準備完了画面へは切り替わらない
+      await waitFor(() => {
+        expect(stopButton).toBeDisabled();
+      });
+      expect(screen.getByText('読み札1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
+      expect(screen.queryByText('準備完了')).not.toBeInTheDocument();
+    } finally {
+      window.Audio = originalAudio;
+    }
+  }, 25000);
+
   it('recovers isReading (does not get stuck) after stopping mid-intro-sound and starting the next card (issue #262)', async () => {
     const originalAudio = window.Audio;
     const pauseMock = vi.fn();


### PR DESCRIPTION
## Summary

- issue #755（「停止」ボタンを押すと読み上げ中の画面が準備完了画面へ強制的に戻ってしまう）に対応
- `stopReading()`から表示を`initial`（準備完了画面）へ強制的に戻す処理を削除し、音声・タイマーの中断はそのまま行いつつ、停止時点で表示していた内容（読み札・結果画面等）を維持するようにした
- issue #729の調査で見つかっていた「音声のみの操作（もう一度）が無条件で表示をinitialへ戻す」バグの修正と同種のパターンで、当時は`stopReading()`側がスコープ外として残っていた

## Test plan

- [x] frontend・backend双方で`npx eslint .`エラー0件
- [x] frontend全235件のテストが成功
  - 新規: 読み札がフリップ表示された状態で停止ボタンを押しても、読み札の表示が維持され準備完了画面へ切り替わらないことを検証するテスト（issue #755）を追加
  - 既存の「イントロ音再生中に停止ボタンを押す」テストの回帰が無いことを確認
- [x] backend全1542件のテストが成功
- [x] `npm run build`（frontend）成功

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_