### PR TITLE
fix(frontend): カテゴリ取得の自動リトライとPWA更新プロンプトの表示位置を修正する

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -333,9 +333,12 @@ function App() {
       return <span style={{ opacity: 0.3 }}> ⇅</span>;
   };
 
-  // カテゴリ一覧を取得
+  // カテゴリ一覧を取得。PWA更新直後（Service Workerがclients.claim()で制御を握った
+  // 直後のページリロード等）はfetch自体が一過性で失敗しやすいため（issue #758）、
+  // 例外発生時は即座にアラートを出さず、1秒後に1回だけ自動で再試行する
   useEffect(() => {
-    const fetchCategories = async () => {
+    let cancelled = false;
+    const fetchCategories = async (isRetry = false) => {
       try {
         const response = await fetch(`${API_BASE_URL}/get-categories`);
         const data = await response.json();
@@ -352,11 +355,22 @@ function App() {
             });
           }
         }
-    } catch {
+    } catch (error) {
+      if (cancelled) return;
+      if (!isRetry) {
+        console.error("Error fetching categories, retrying once:", error);
+        setTimeout(() => {
+          if (!cancelled) fetchCategories(true);
+        }, 1000);
+        return;
+      }
       alert("カテゴリの取得に失敗しました。");
     }
     };
     fetchCategories();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // カテゴリが選択されたら、選択中の全カテゴリの札IDリストを取得して結合する。

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -67,7 +67,8 @@ describe('App', () => {
     expect(screen.getByText('エンジニア向け')).toBeInTheDocument();
   });
 
-  it('shows a get-categories-specific error message when fetching categories fails, instead of the generic submit-failure message', async () => {
+  it('retries once before showing a get-categories-specific error message when fetching categories keeps failing (issue #758)', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) throw new Error('network error');
       return { ok: false };
@@ -77,7 +78,42 @@ describe('App', () => {
       render(<App />);
     });
 
-    expect(window.alert).toHaveBeenCalledWith('カテゴリの取得に失敗しました。');
+    // 1回目の失敗直後はまだアラートを出さず、1秒後の自動リトライを待つ
+    expect(window.alert).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith('カテゴリの取得に失敗しました。');
+    }, { timeout: 5000 });
+
+    const categoriesCalls = fetch.mock.calls.filter(([url]) => url.includes('get-categories'));
+    expect(categoriesCalls).toHaveLength(2);
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('does not show an error when the automatic get-categories retry succeeds (issue #758)', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let categoriesCallCount = 0;
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('get-categories')) {
+        categoriesCallCount += 1;
+        if (categoriesCallCount === 1) throw new Error('network error');
+        return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      }
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    await screen.findByRole('button', { name: /Cat1/ });
+
+    expect(window.alert).not.toHaveBeenCalled();
+    expect(categoriesCallCount).toBe(2);
+
+    consoleErrorSpy.mockRestore();
   });
 
   it('shows the matching category list after choosing a division', async () => {

--- a/frontend/src/PwaUpdatePrompt.css
+++ b/frontend/src/PwaUpdatePrompt.css
@@ -1,8 +1,11 @@
 .pwa-update-prompt {
   position: fixed;
-  bottom: 1rem;
+  /* 画面下部固定だと、入力欄フォーカスでソフトウェアキーボードが表示された際に
+     隠れて操作できなくなる（issue #759）ため、キーボードに覆われにくい
+     画面中央よりやや上の位置に固定する */
+  top: 40%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   z-index: 1000;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

2件の独立した不具合に対応。

### issue #758: PWA更新直後にカテゴリ取得が一時的に失敗する

- PWA更新プロンプトの「更新する」押下後（Service Worker切り替え＋ページリロード）、`clients.claim()`直後の一過性のネットワークエラーで「カテゴリの取得に失敗しました。」が表示されていた
- `fetchCategories`が例外で失敗した場合、即座にアラートを出さず1秒後に1回だけ自動で再試行するようにした。再試行も失敗した場合のみ、従来どおりアラートを表示する

### issue #759: PWA更新プロンプトがソフトウェアキーボードに隠れる

- 画面下部固定（`bottom: 1rem`）だと、入力欄フォーカスでキーボードが表示された際に「更新する」ボタンが隠れて押せなくなっていた
- 表示位置を画面中央よりやや上（`top: 40%`）へ変更した

## Test plan

- [x] frontend・backend双方で`npx eslint .`エラー0件
- [x] frontend全236件のテストが成功
  - 既存の「カテゴリ取得失敗時にアラートを表示する」テストを、1回目の失敗直後はアラートが出ず1秒後の自動リトライを経てから出ることを検証するテストへ更新
  - 新規: 自動リトライが成功した場合はアラートが出ないことを検証するテスト（issue #758）を追加
- [x] backend全1542件のテストが成功
- [x] `npm run build`（frontend）成功

Closes #758, Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_