### PR TITLE
fix: /get-phraseのexplanation欠落を修正し、全札一覧の解説列を削除する（issue #763）

### DIFF
--- a/backend/handler.js
+++ b/backend/handler.js
@@ -436,6 +436,7 @@ exports.getPhrase = async (event) => {
       level: selectedItem.level,
       kana: selectedItem.kana,
       answer: selectedItem.answer,
+      explanation: selectedItem.explanation,
       audioData: audioData,
       readCount: stats.readCount || 0,
       averageTime: stats.averageTime || 0,

--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -576,6 +576,25 @@ describe('getPhrase', () => {
         expect(putParams.Item.ttl).toBeCloseTo(expectedTtl, -1);
     });
 
+    it('includes explanation in the response, along with answer (issue #763)', async () => {
+        ddbMock.on(ScanCommand).resolves({
+            Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', level: '1', answer: 'answer 1', explanation: 'explanation 1' }],
+        });
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        ddbMock.on(PutCommand).resolves({});
+
+        const audioStream = new Readable();
+        audioStream.push('audio data');
+        audioStream.push(null);
+        pollyMock.on(SynthesizeSpeechCommand).resolves({ AudioStream: audioStream });
+
+        const event = { queryStringParameters: { id: 'p1' } };
+        const response = await getPhrase(event);
+        const body = JSON.parse(response.body);
+        expect(body.answer).toBe('answer 1');
+        expect(body.explanation).toBe('explanation 1');
+    });
+
     it('should return a phrase with audio from cache', async () => {
         ddbMock.on(ScanCommand).resolves({
             Items: [{ id: 'p1', category: 'c1', phrase: 'phrase 1', level: '1' }],

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1852,42 +1852,9 @@ describe('App', () => {
     // 読み札列・答え列の幅バランスが崩れないよう、同じ幅指定クラスを共有していることを確認する
     expect(screen.getByText('読み札', { selector: 'th' })).toHaveClass('all-phrases-col-balanced');
     expect(screen.getByText('答え', { selector: 'th' })).toHaveClass('all-phrases-col-balanced');
-  });
 
-  it('shows an explanation column with data and blank fallback in all-phrases view (issue #693)', async () => {
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ categories: [] }),
-    });
-    await act(async () => {
-      render(<App />);
-    });
-
-    fetch.mockImplementation(async (url) => {
-      if (url.includes('get-categories')) {
-        return { ok: true, json: async () => ({ categories: [] }) };
-      }
-      if (url.includes('get-phrases-list')) {
-        return {
-          ok: true,
-          json: async () => ({
-            phrases: [
-              { id: 'p1', category: 'Cat1', phrase: '読み札A', level: '-', answer: '回答A', explanation: '解説A' },
-              { id: 'p2', category: 'Cat1', phrase: '読み札B', level: '-', answer: '-', explanation: '-' },
-            ],
-          }),
-        };
-      }
-      return { ok: false };
-    });
-
-    fireEvent.click(screen.getByText(/全札一覧を見る/i));
-
-    await waitFor(() => {
-      expect(screen.getByText('解説')).toBeInTheDocument();
-      expect(screen.getByText('解説A')).toBeInTheDocument();
-      expect(screen.getByText('読み札B').closest('tr')).not.toHaveTextContent('-');
-    });
+    // 解説列は一覧表示の項目からは削除している（issue #763）
+    expect(screen.queryByText('解説', { selector: 'th' })).not.toBeInTheDocument();
   });
 
   it('shows existing comments for the phrase on the detail screen (issue #223)', async () => {

--- a/frontend/src/views/AllPhrasesView.jsx
+++ b/frontend/src/views/AllPhrasesView.jsx
@@ -120,9 +120,6 @@ function AllPhrasesView({
                     <th scope="col" className="all-phrases-col-balanced" style={{ cursor: "pointer" }} tabIndex={0} role="button" aria-sort={getAriaSort('answer')} onClick={() => handleSort('answer')} onKeyDown={handleHeaderKeyDown('answer')}>
                       答え{renderSortArrow('answer')}
                     </th>
-                    <th scope="col" className="all-phrases-col-balanced">
-                      解説
-                    </th>
                     <th scope="col" style={{ cursor: "pointer" }} tabIndex={0} role="button" aria-sort={getAriaSort('level')} onClick={() => handleSort('level')} onKeyDown={handleHeaderKeyDown('level')}>
                       Lv{renderSortArrow('level')}
                     </th>
@@ -144,7 +141,6 @@ function AllPhrasesView({
                       <td className="ps-4 text-muted small">{p.category}</td>
                       <td className="fw-bold">{p.phrase}</td>
                       <td>{p.answer && p.answer !== "-" ? p.answer : ""}</td>
-                      <td>{p.explanation && p.explanation !== "-" ? p.explanation : ""}</td>
                       <td>{p.level !== "-" ? p.level : ""}</td>
                       <td>{p.readCount || 0}</td>
                       <td>{(p.averageTime || 0).toFixed(2)}s</td>


### PR DESCRIPTION
## Summary

issue #763（かるた詳細画面で解説が表示されない）に対応。

### 根本原因の修正

- `backend/handler.js`の`getPhrase`（`/get-phrase`エンドポイント）が、DynamoDBから`explanation`を取得しているにもかかわらず、レスポンス組み立て時に`explanation`フィールドを含めていなかった
- issue #693・PR #716でフロントエンド側（DetailView.jsx・ResultCard.jsx・QuizRoomBuzzJudgmentModal.jsx等）に解説表示のロジックは正しく実装されていたが、このバックエンドの欠落によりデータ自体が届いておらず表示されていなかった
- `/get-phrases-list`（全札一覧）は取得したDynamoDBアイテムをそのまま返す実装のため影響を受けておらず、この画面だけは正しく表示されていた

### 追加要望: 全札一覧の解説列を削除

- ユーザーからの要望により、`AllPhrasesView.jsx`のテーブルから「解説」列を削除した（詳細画面・結果表示等、個別の札を確認する画面での解説表示は維持）

## Test plan

- [x] backend: `npx eslint .`エラー0件、`npx vitest run --no-isolate --coverage`全1543件成功（新規: `/get-phrase`のレスポンスにexplanationが含まれることを検証するテスト）
- [x] frontend: `npx eslint .`エラー0件、`npx vitest run --no-file-parallelism`全235件成功（解説列削除に伴うテスト更新・削除、答え列テストに解説列非表示の確認を追加）
- [x] frontend: `npm run build`成功

Closes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_