### PR TITLE
feat: 自動読み上げモード（自動で次へ）を廃止する（issue #729）

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -100,8 +100,6 @@ function App() {
   const [lang, setLang] = useLocalStorageState("lang", "ja");
   const [voiceId, setVoiceId] = useLocalStorageState("voiceId", "Mizuki");
   const [sortOrder, setSortOrder] = useLocalStorageState("sortOrder", "random");
-  const [autoAdvance, setAutoAdvance] = useLocalStorageState("autoAdvance", false, (v) => v === "true");
-  const [autoAdvanceInterval, setAutoAdvanceInterval] = useLocalStorageState("autoAdvanceInterval", 10, (v) => parseInt(v, 10));
   const [themeSetting, setThemeSetting] = useLocalStorageState("theme", "system");
   const [systemPrefersDark, setSystemPrefersDark] = useState(() => {
     return window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
@@ -132,7 +130,6 @@ function App() {
   const currentAudioRef = useRef(null);
   const stopRequestedRef = useRef(false);
   const prefetchedNextRef = useRef(null);
-  const autoAdvanceTimeoutRef = useRef(null);
   // 「次の札」連打対策（issue #590）: loadingは処理の後半（フェードアウト待ち完了後）に
   // ならないとtrueにならず、押下直後の連打を防げないため、押下と同時に同期的に
   // 立てられる再入防止用のrefを別途持つ
@@ -500,11 +497,11 @@ function App() {
     return new Promise((resolve, reject) => {
       const audio = new Audio(audioData);
       let settled = false;
-      // モバイルブラウザでは、ユーザー操作を伴わない呼び出し（自動で次への
-      // setTimeout起点）でaudio.play()のPromiseが拒否も解決もされないまま
-      // 待機し続けることがある（issue #729）。onended/onerrorのどちらも発火せず
-      // ハングすると、これを直列でawaitしている読み上げ進行全体（次の札の表示・
-      // 読み上げ）が永久に止まってしまうため、上限時間で強制的に諦めて先へ進める。
+      // モバイルブラウザ等の環境によっては、audio.play()のPromiseが拒否も解決も
+      // されないまま待機し続けることがある（issue #729）。onended/onerrorの
+      // どちらも発火せずハングすると、これを直列でawaitしている読み上げ進行全体
+      // （次の札の表示・読み上げ）が永久に止まってしまうため、上限時間で強制的に
+      // 諦めて先へ進める。
       // stopReading()がcurrentAudioRef.current.resolve()を直接呼ぶ経路も
       // このsettleResolve経由にし、タイマー解除とsettledフラグを確実に揃える
       const AUDIO_TIMEOUT_MS = 15000;
@@ -834,56 +831,6 @@ function App() {
       playKarutaInFlightRef.current = false;
     }
   };
-
-  // 自動読み上げモード：札の読み上げが完了し「次の札」を待っている状態
-  // （手動なら次の札ボタンを押すタイミング）で一定時間経過したら自動で次へ進む。
-  // このアプリでは「次の札」への1回の操作が、直前の札の結果表示と次の札の
-  // 読み上げ開始を両方まとめて行う設計になっているため、result表示中ではなく
-  // 直前の札のphrase表示中（読み上げ完了後の待機状態）を起点にする。
-  useEffect(() => {
-    if (autoAdvanceTimeoutRef.current) {
-      clearTimeout(autoAdvanceTimeoutRef.current);
-      autoAdvanceTimeoutRef.current = null;
-    }
-
-    if (!autoAdvance || isAllRead || isReading || loading || displayContent.type !== "phrase") {
-      return;
-    }
-
-    autoAdvanceTimeoutRef.current = setTimeout(() => {
-      autoAdvanceTimeoutRef.current = null;
-      playKaruta();
-    }, autoAdvanceInterval * 1000);
-
-    return () => {
-      if (autoAdvanceTimeoutRef.current) {
-        clearTimeout(autoAdvanceTimeoutRef.current);
-        autoAdvanceTimeoutRef.current = null;
-      }
-    };
-    // playKarutaは毎レンダーで再生成される関数であり、選択カテゴリや読み上げ設定
-    // （sortOrder/repeatCount/speechRate/lang等）をクロージャで参照している。
-    // playKaruta自体を依存配列に含めると無関係な再レンダーでもタイマーが
-    // 再設定されてしまうため、代わりにplayKarutaが参照する状態を依存配列に
-    // 列挙する（プリフェッチ用useEffectと同じ考え方）。これにより待機中に
-    // 設定が変わった場合も最新の設定でタイマーが張り直される
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    autoAdvance,
-    autoAdvanceInterval,
-    displayContent,
-    isReading,
-    loading,
-    isAllRead,
-    selectedCategories,
-    allPhrasesForCategory,
-    currentHistory,
-    sortOrder,
-    repeatCount,
-    speechRate,
-    lang,
-    isMultiCategorySelection,
-  ]);
 
   const repeatPhrase = async () => {
     const target = detailPhrase || currentPhrase;
@@ -1622,26 +1569,12 @@ function App() {
               <button onClick={() => setSpeechRate("100%")} className={`btn ${speechRate === "100%" ? 'btn-dark' : 'btn-outline-dark'}`}>はやい</button>
             </div>
           </div>
-          <div className="mb-3 d-flex align-items-center justify-content-center gap-3 border-bottom pb-2">
+          <div className="d-flex align-items-center justify-content-center gap-3">
             <span className="fw-bold text-dark small">回数:</span>
             <div className="btn-group btn-group-sm" role="group">
               <button onClick={() => setRepeatCount(1)} className={`btn ${repeatCount === 1 ? 'btn-dark' : 'btn-outline-dark'}`}>1回</button>
               <button onClick={() => setRepeatCount(2)} className={`btn ${repeatCount === 2 ? 'btn-dark' : 'btn-outline-dark'}`}>2回</button>
             </div>
-          </div>
-          <div className="d-flex align-items-center justify-content-center gap-3 flex-wrap">
-            <span className="fw-bold text-dark small">自動で次へ:</span>
-            <div className="btn-group btn-group-sm" role="group">
-              <button onClick={() => setAutoAdvance(false)} className={`btn ${!autoAdvance ? 'btn-dark' : 'btn-outline-dark'}`}>オフ</button>
-              <button onClick={() => setAutoAdvance(true)} className={`btn ${autoAdvance ? 'btn-dark' : 'btn-outline-dark'}`}>オン</button>
-            </div>
-            {autoAdvance && (
-              <div className="btn-group btn-group-sm" role="group">
-                <button onClick={() => setAutoAdvanceInterval(10)} className={`btn ${autoAdvanceInterval === 10 ? 'btn-dark' : 'btn-outline-dark'}`}>10秒</button>
-                <button onClick={() => setAutoAdvanceInterval(20)} className={`btn ${autoAdvanceInterval === 20 ? 'btn-dark' : 'btn-outline-dark'}`}>20秒</button>
-                <button onClick={() => setAutoAdvanceInterval(30)} className={`btn ${autoAdvanceInterval === 30 ? 'btn-dark' : 'btn-outline-dark'}`}>30秒</button>
-              </div>
-            )}
           </div>
         </section>
       <div className="d-flex flex-wrap gap-2 justify-content-center mb-4">

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1595,19 +1595,6 @@ describe('App', () => {
 
     fireEvent.click(screen.getByText('はやい'));
     expect(localStorage.getItem('speechRate')).toBe('100%');
-
-    // 自動で次への設定はデフォルトでオフで、間隔ボタンは表示されない
-    expect(screen.queryByText('10秒')).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByText('オン'));
-    expect(localStorage.getItem('autoAdvance')).toBe('true');
-
-    fireEvent.click(await screen.findByText('20秒'));
-    expect(localStorage.getItem('autoAdvanceInterval')).toBe('20');
-
-    // 後続のテストに自動読み上げ設定が引き継がれないようにする
-    localStorage.removeItem('autoAdvance');
-    localStorage.removeItem('autoAdvanceInterval');
   });
 
   it('shows the voice selector only for Japanese, updates the setting, and includes voiceId in the phrase request (issue #217)', async () => {
@@ -1665,56 +1652,6 @@ describe('App', () => {
     randomSpy.mockRestore();
   });
 
-  it('automatically advances to the next phrase after the configured interval when auto-advance is on', async () => {
-    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
-    // UIが提示する最短の間隔（10秒）だと実時間のかかるテストになってしまうため、
-    // 実際のUIには無い短い間隔をlocalStorageに直接設定して機構自体を検証する
-    localStorage.setItem('autoAdvance', 'true');
-    localStorage.setItem('autoAdvanceInterval', '1');
-
-    fetch.mockImplementation(async (url) => {
-      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
-      if (url.includes('get-phrases-list')) {
-        return {
-          ok: true,
-          json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }, { id: 'p2', category: 'Cat1' }] }),
-        };
-      }
-      if (url.includes('/get-phrase?')) {
-        const id = new URL(url).searchParams.get('id');
-        return { ok: true, json: async () => ({ id, category: 'Cat1', phrase: `読み札${id}`, audioData: 'dummy' }) };
-      }
-      return { ok: false };
-    });
-
-    await act(async () => {
-      render(<App />);
-    });
-
-    fireEvent.click(await screen.findByText('こども向け'));
-    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
-
-    await waitFor(() => screen.getByText('次の札'));
-    fireEvent.click(screen.getByText('次の札'));
-
-    // p1の読み上げが完了し「次の札」を待つ状態（自動読み上げの起点）になるまで待つ
-    // （プリフェッチ機能によりp2のget-phraseはこの時点で既に裏で呼ばれ得るため、
-    // 実際にp2の読み上げまで進むかどうかで自動読み上げ自体を検証する）
-    await waitFor(() => {
-      expect(screen.getByText('読み札p1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
-    }, { timeout: 20000 });
-
-    // 「次の札」ボタンを一切押さずに、設定した間隔後の自動読み上げでp2の読み上げに進むのを待つ
-    await waitFor(() => {
-      expect(screen.getByText('読み札p2', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
-    }, { timeout: 20000 });
-
-    randomSpy.mockRestore();
-    // 後続のテストに自動読み上げ設定が引き継がれないようにする
-    localStorage.removeItem('autoAdvance');
-    localStorage.removeItem('autoAdvanceInterval');
-  }, 40000);
-
   it('recovers and advances to the next phrase even if audio.play() never settles (issue #729)', async () => {
     const originalAudio = window.Audio;
     // モバイルブラウザのオートプレイポリシー等により、audio.play()のPromiseが
@@ -1733,8 +1670,6 @@ describe('App', () => {
     });
 
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
-    localStorage.setItem('autoAdvance', 'true');
-    localStorage.setItem('autoAdvanceInterval', '1');
 
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
@@ -1769,15 +1704,15 @@ describe('App', () => {
         expect(screen.getByText('読み札p1', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
       }, { timeout: 45000 });
 
-      // 「次の札」ボタンを一切押さずに、自動読み上げでp2まで進むことを確認する
-      // （p1と同様にp2側もaudio.play()がハングするため、さらにタイムアウト分待つ）
+      // 「次の札」ボタンを押してp2まで進めても、同様にハングから復帰することを確認する
+      await waitFor(() => screen.getByText('次の札'), { timeout: 45000 });
+      fireEvent.click(screen.getByText('次の札'));
+
       await waitFor(() => {
         expect(screen.getByText('読み札p2', { selector: '.yomifuda-phrase' })).toBeInTheDocument();
       }, { timeout: 45000 });
 
       randomSpy.mockRestore();
-      localStorage.removeItem('autoAdvance');
-      localStorage.removeItem('autoAdvanceInterval');
     } finally {
       window.Audio = originalAudio;
     }


### PR DESCRIPTION
## Summary

issue #729（自動読み上げモードで読み上げ・「次の札」ボタンの両方が途中で止まる不具合）に対応。audio.play()のタイムアウトによる復帰処理（issue #729由来の既存対応、PR #743）を入れた後も再発する報告があり、かつ本機能自体が必須ではないという判断から、**追加調査・修正ではなく機能自体を廃止**することで問題の発生源を無くし、issue #729をクローズする。

- 削除: `autoAdvance`/`autoAdvanceInterval`のstate・localStorage永続化、一定時間経過後に自動で次の札へ進むuseEffect、設定フッターの「自動で次へ」UI（オン/オフ・間隔ボタン）
- 維持: audio.play()自体がハングした場合に強制的に諦めて先へ進むタイムアウト処理（`playAudio`内）。これは自動読み上げに限らず手動の「次の札」操作でも有効な汎用的な保護のため残し、コメントのみ自動読み上げ前提の記述を除去した
- 上記以外の読み上げフロー（手動での「次の札」操作）に変更はない

## Test plan

- [x] frontend: `npx eslint .` エラー0件
- [x] frontend: `npx vitest run src/App.test.jsx`（単独実行）で65件全て成功
- [x] frontend: `npx vitest run --no-isolate`は本変更前のコードでも`QuizRoomView.test.jsx`等で同様の大量の失敗が再現することを確認済みで、本PRの変更とは無関係な既存のテスト分離（`--no-isolate`によるモック状態の汚染）の問題と判断
- [x] backend: `npx eslint .` エラー0件（今回未変更だが対象パッケージとして確認）

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_