### PR TITLE
fix: oslsのバージョン固定ルールに下限を明示する（issue #611）

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,7 @@
     },
     {
       "matchPackageNames": ["osls"],
-      "allowedVersions": "<4.0.0",
+      "allowedVersions": ">=3.0.0 <4.0.0",
       "description": "Serverless Framework v4以降はCLI起動時にSaaSへのサインインが必須になりCIでのデプロイが失敗するため、サインイン不要なOSSフォークosls（oss-serverless/serverless、issue #611）へ移行した。osls自体もv4系はServerless Framework v4向けの破壊的変更を含むため、serverless.ymlがv3形式のままの間はosls v3系（ドロップイン互換）に固定する"
     },
     {


### PR DESCRIPTION
## Summary

issue #611でServerless Framework v3をOSSフォークoslsへ移行した際（PR #774）、`renovate.json`のosls向けルールを`allowedVersions: "<4.0.0"`としたが、上限のみで下限が無く、Renovateが理論上3.0.0未満のバージョンを提案し得る状態だった。ドロップイン互換が保証されるv3系（3.0.0以上）に範囲を絞り込み、意図を明確にする。

## 補足（重要）

PR #774（`chore(backend): ...`）はこのリポジトリのsemantic-releaseルール上`chore:`がリリース対象外のため、マージ後のCDで`deploy-backend`ジョブがスキップされ、oslsでの実デプロイが未検証のままだった。本PRを`fix:`とすることでリリースを発行させ、`deploy-backend`ジョブを実際に実行してAWSへのデプロイ成功を確認する。

## Test plan

- [x] `renovate.json`がvalid JSONであることを確認
- [x] backend: `npx eslint .` エラー0件（今回未変更だが対象パッケージとして確認）
- [x] frontend: `npx eslint .` エラー0件（今回未変更だが対象パッケージとして確認）
- [ ] 実際のosls経由でのAWSデプロイ成功は、本コミットによるリリース発行後のCD実行（`deploy-backend`ジョブ）で確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_