### PR TITLE
fix: PWA更新通知の表示位置を画面最上部へ変更する（issue #776）

### DIFF
--- a/frontend/src/PwaUpdatePrompt.css
+++ b/frontend/src/PwaUpdatePrompt.css
@@ -1,11 +1,12 @@
 .pwa-update-prompt {
   position: fixed;
   /* 画面下部固定だと、入力欄フォーカスでソフトウェアキーボードが表示された際に
-     隠れて操作できなくなる（issue #759）ため、キーボードに覆われにくい
-     画面中央よりやや上の位置に固定する */
-  top: 40%;
+     隠れて操作できなくなる（issue #759）。画面中央よりやや上への変更（issue #759）
+     は中途半端な位置だったため、キーボードに隠れず座りも良い最上部へ固定する
+     （issue #776） */
+  top: 1rem;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translateX(-50%);
   z-index: 1000;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

issue #759でPWA更新通知（`.pwa-update-prompt`）の表示位置を画面下部からキーボードに隠れにくい画面中央よりやや上（`top: 40%`、`transform: translate(-50%, -50%)`）へ変更したが、この位置は中途半端で座りが悪いとの指摘があった。

画面最上部（`top: 1rem`）へ固定し、横方向のみ`translateX(-50%)`で中央寄せする形に変更した。最上部であればキーボード表示時にも隠れず、かつ中途半端な高さにもならない。

## Test plan

- [x] frontend: `npx eslint .` エラー0件
- [x] frontend: `npx vitest run src/PwaUpdatePrompt.test.jsx` で9件全て成功
- [x] backend: `npx eslint .` エラー0件（今回未変更だが対象パッケージとして確認）

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_