### PR TITLE
chore(release): v1.54.2 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.54.2](https://github.com/bamiyanapp/karuta/compare/v1.54.1...v1.54.2) (2026-07-24)
+
+
+### Bug Fixes
+
+* **frontend:** PWA更新通知の表示位置を画面最上部へ変更する（issue [#776](https://github.com/bamiyanapp/karuta/issues/776)） ([#777](https://github.com/bamiyanapp/karuta/issues/777)) ([1ca9e48](https://github.com/bamiyanapp/karuta/commit/1ca9e4880b2a1ae153ed6181675c4a9cbac6f035))
+
 ## [1.54.1](https://github.com/bamiyanapp/karuta/compare/v1.54.0...v1.54.1) (2026-07-24)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.54.1",
+    "version": "1.54.2",
     "date": "2026/07/24",
+    "body": "### Bug Fixes\n\n* **frontend:** PWA更新通知の表示位置を画面最上部へ変更する（issue [#776](https://github.com/bamiyanapp/karuta/issues/776)） ([#777](https://github.com/bamiyanapp/karuta/issues/777)) ([1ca9e48](https://github.com/bamiyanapp/karuta/commit/1ca9e4880b2a1ae153ed6181675c4a9cbac6f035))"
+  },
+  {
+    "version": "1.54.1",
+    "date": "2026/07/24 10:04",
     "body": "### Bug Fixes\n\n* **backend:** oslsのバージョン固定ルールに下限を明示する（issue [#611](https://github.com/bamiyanapp/karuta/issues/611)） ([#775](https://github.com/bamiyanapp/karuta/issues/775)) ([fa1fabe](https://github.com/bamiyanapp/karuta/commit/fa1fabea3994b74df607fbef619b4f83ad33721c))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.54.1",
+  "version": "1.54.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.54.1",
+      "version": "1.54.2",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.54.1"
+  "version": "1.54.2"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。