### PR TITLE
fix(frontend): クイズ大会モードの札めくりブロードキャストを早める（issue #781）

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -142,6 +142,7 @@ function App() {
   // useKarutaReadingへ切り出した（issue #607）
   const {
     currentPhrase,
+    broadcastPhrase,
     displayContent,
     isFadingOut,
     isReading,
@@ -539,6 +540,7 @@ function App() {
     view,
     selectedCategories,
     displayContent,
+    broadcastPhrase,
     isAllRead,
     repeatCount,
     speechRate,

--- a/frontend/src/hooks/useKarutaReading.js
+++ b/frontend/src/hooks/useKarutaReading.js
@@ -33,6 +33,11 @@ export function useKarutaReading({
   isMultiCategorySelection,
 }) {
   const [currentPhrase, setCurrentPhrase] = useState(null);
+  // クイズ大会モード（issue #781）: 参加者への「次の札」ブロードキャストを、管理者自身の
+  // 画面演出（イントロ音声＋3秒待ち＋フェード）を待たずに行えるよう、その演出が始まる前の
+  // 時点（currentPhraseの更新と同時）で確定する値を別途保持する。displayContentの更新を
+  // 待つと、演出時間の分だけ参加者側の表示が管理者より遅れてしまっていた
+  const [broadcastPhrase, setBroadcastPhrase] = useState(null);
   const [displayContent, setDisplayContent] = useState({ type: "initial" });
   const [isFadingOut, setIsFadingOut] = useState(false);
   const nextContentRef = useRef(null);
@@ -171,6 +176,15 @@ export function useKarutaReading({
       if (phraseData) {
         // 読み上げ開始タイミングで計測開始（リピート再生時は計測中の開始点を上書きしない）
         startTimeRef.current = Date.now();
+
+        // クイズ大会モード（issue #781）: 参加者へのブロードキャストはここ（本編読み上げ・
+        // 経過時間計測の開始と同時）で確定する。setCurrentPhraseと同時（イントロ音声より前）
+        // に確定すると、revealCurrentResult()がstartTimeRef.currentを前提にしている
+        // （未設定なら早押し正解の即時結果確定が無視される）ため、参加者がイントロ音声の
+        // 再生中に早押しした場合に正解処理が効かなくなってしまう。startTimeRef.currentの
+        // 設定と同じタイミングにすることで、ブロードキャストを受け取った時点では常に
+        // 経過時間計測が開始済みであることを保証する
+        setBroadcastPhrase({ content: phraseData, playbackSettings });
 
         if (flipTimeoutRef.current) {
           clearTimeout(flipTimeoutRef.current);
@@ -465,6 +479,7 @@ export function useKarutaReading({
   // 必要な、このhookが持つ読み上げ進行状態のリセット
   const resetReadingState = () => {
     setCurrentPhrase(null);
+    setBroadcastPhrase(null);
     setDisplayContent({ type: "initial" });
     setIsAllRead(false);
     setIsFadingOut(false);
@@ -472,6 +487,7 @@ export function useKarutaReading({
 
   return {
     currentPhrase,
+    broadcastPhrase,
     displayContent,
     isFadingOut,
     isReading,

--- a/frontend/src/hooks/useQuizRoomAdmin.js
+++ b/frontend/src/hooks/useQuizRoomAdmin.js
@@ -49,6 +49,7 @@ export function useQuizRoomAdmin({
   view,
   selectedCategories,
   displayContent,
+  broadcastPhrase,
   isAllRead,
   repeatCount,
   speechRate,
@@ -223,51 +224,59 @@ export function useQuizRoomAdmin({
   };
 
   // 早押し機能（issue #510）: 新しい札が出題されたら、前のラウンドの回答者表示をリセット
-  // する（サーバー側もこの同じタイミングで早押し状態をリセットしている）。ラウンドキーで
-  // 判定するのは、設定変更等で同じ札が再ブロードキャストされた際に既に記録済みの回答者
-  // 表示を誤って消さないようにするため（resultの間はリセットしない）。
+  // する（サーバー側もこの同じタイミングで早押し状態をリセットしている）。
+  // issue #781: ラウンドキーの確定はdisplayContentではなくbroadcastPhrase（管理者自身の
+  // 画面演出より前に確定する値）を基準にする。これにより、管理者の画面がまだ演出中でも
+  // 参加者は新しい札に対して早押しできるようになる（下のブロードキャストと同じタイミング）。
+  // broadcastPhraseは次の札が出題されるたびに更新され、resetReadingState（ゲームリセット・
+  // カテゴリ選び直し）でnullへ戻るため、これだけでresult表示中の保持・リセット時のクリアの
+  // 両方が自然に成り立つ（displayContentの型を個別に見る必要がない）
   // レンダー中のstate調整パターン（QuizRoomView.jsxのbuzzRoundKey判定と同じ考え方）で、
   // 副作用を伴わないstate更新はuseEffectを介さずレンダー中に直接行う
   // （react-hooks/set-state-in-effect対策）
-  let nextQuizRoomBuzzRoundKey = quizRoomBuzzRoundKey;
-  if (quizRoom) {
-    if (displayContent.type === "phrase" && displayContent.content) {
-      nextQuizRoomBuzzRoundKey = `${displayContent.content.category}:${displayContent.content.id}`;
-    } else if (displayContent.type !== "result") {
-      nextQuizRoomBuzzRoundKey = null;
-    }
-  }
+  const nextQuizRoomBuzzRoundKey = quizRoom && broadcastPhrase
+    ? `${broadcastPhrase.content.category}:${broadcastPhrase.content.id}`
+    : null;
   if (nextQuizRoomBuzzRoundKey !== quizRoomBuzzRoundKey) {
     setQuizRoomBuzzRoundKey(nextQuizRoomBuzzRoundKey);
     setQuizRoomBuzzedBy(null);
   }
 
-  // 表示中の札・結果画面が変わるたびクイズ大会モードの参加者へ状態をブロードキャストする。
-  // audioData等の重量級フィールドは送らず、表示に必要な項目だけを抜き出す
-  // （サーバー側の状態サイズ上限にも抵触しないようにする）
+  // 次の札のブロードキャスト（issue #781）: 管理者自身の画面演出（イントロ音声＋3秒待ち＋
+  // フェード、useKarutaReading.js）を待たず、次の札が確定した時点（broadcastPhraseの
+  // 更新）で参加者へ先行してブロードキャストする。以前はdisplayContentの更新（演出完了後）
+  // を待っていたため、その分だけ参加者側の表示が管理者より遅れていた
   useEffect(() => {
-    if (!quizRoom) {
+    if (!quizRoom || !broadcastPhrase) {
       return;
     }
-    if (displayContent.type === "phrase" && displayContent.content) {
-      const p = displayContent.content;
-      // 読み上げ設定（issue #498）は、ブロードキャスト時点の最新設定ではなく、この札の
-      // 音声を実際に取得した時点の設定（playbackSettings）を使う。読み上げ開始まで数秒の
-      // 遅延があり、その間に管理者が設定を変更すると、最新設定を読んでしまうと「管理者が
-      // 実際に聞いている音声」とズレるため
-      const settings = displayContent.playbackSettings
-        ?? { repeatCount, speechRate, lang, voiceId, announceCategory: isMultiCategorySelection };
-      broadcastQuizRoomState({
-        type: "phrase",
-        content: {
-          // idを含めるのは、参加者側（issue #490）が自分自身で/get-phraseを呼び直し、
-          // 同じ札の音声を取得・再生できるようにするため
-          id: p.id, category: p.category, kana: p.kana, phrase: p.phrase, level: p.level, answer: p.answer,
-          repeatCount: settings.repeatCount, speechRate: settings.speechRate, lang: settings.lang,
-          voiceId: settings.voiceId, announceCategory: settings.announceCategory,
-        },
-      });
-    } else if (displayContent.type === "result" && displayContent.content) {
+    const p = broadcastPhrase.content;
+    // 読み上げ設定（issue #498）は、ブロードキャスト時点の最新設定ではなく、この札の
+    // 音声を実際に取得した時点の設定（playbackSettings）を使う。読み上げ開始まで数秒の
+    // 遅延があり、その間に管理者が設定を変更すると、最新設定を読んでしまうと「管理者が
+    // 実際に聞いている音声」とズレるため
+    const settings = broadcastPhrase.playbackSettings
+      ?? { repeatCount, speechRate, lang, voiceId, announceCategory: isMultiCategorySelection };
+    broadcastQuizRoomState({
+      type: "phrase",
+      content: {
+        // idを含めるのは、参加者側（issue #490）が自分自身で/get-phraseを呼び直し、
+        // 同じ札の音声を取得・再生できるようにするため
+        id: p.id, category: p.category, kana: p.kana, phrase: p.phrase, level: p.level, answer: p.answer,
+        repeatCount: settings.repeatCount, speechRate: settings.speechRate, lang: settings.lang,
+        voiceId: settings.voiceId, announceCategory: settings.announceCategory,
+      },
+    });
+  }, [quizRoom, broadcastPhrase, broadcastQuizRoomState, repeatCount, speechRate, lang, voiceId, isMultiCategorySelection]);
+
+  // 結果画面・準備画面への切り替わりをクイズ大会モードの参加者へブロードキャストする。
+  // 「次の札」への切り替わり（"phrase"）は上のbroadcastPhrase側で既により早いタイミングで
+  // 処理済みのため、ここでは扱わない
+  useEffect(() => {
+    if (!quizRoom || displayContent.type === "phrase") {
+      return;
+    }
+    if (displayContent.type === "result" && displayContent.content) {
       const r = displayContent.content;
       broadcastQuizRoomState({
         type: "result",
@@ -283,7 +292,7 @@ export function useQuizRoomAdmin({
     } else {
       broadcastQuizRoomState({ type: "initial" });
     }
-  }, [quizRoom, displayContent, isAllRead, broadcastQuizRoomState, repeatCount, speechRate, lang, voiceId, isMultiCategorySelection]);
+  }, [quizRoom, displayContent, isAllRead, broadcastQuizRoomState]);
 
   // クイズ大会モード（issue #470）: 通常のかるた読み上げ画面のフッターから直接ルームを作成する
   const createQuizRoom = async () => {

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -700,6 +700,15 @@ describe('useQuizRoomAdmin (via App)', () => {
       expect(ws.sent.find((msg) => msg.includes('"type":"phrase"'))).toBeDefined();
     }, { timeout: 20000 });
 
+    // issue #781: 参加者へのブロードキャストが管理者自身のイントロ音声＋3秒待ち＋
+    // フェード演出より前に発生するようになったため、上のブロードキャスト到達を
+    // 待つだけでは読み上げ演出がまだ完了していない。「次の札」ボタンは残り1枚
+    // （最後の1枚）を読み上げている間disabledになる（issue #721）ため、
+    // 実際のユーザーと同様にボタンが再度押せる状態になるまで待ってから押す
+    await waitFor(() => {
+      expect(screen.getByText('次の札')).not.toBeDisabled();
+    }, { timeout: 20000 });
+
     // もう一度「次の札」を押すと、未読の札が無いため全て読了したと判定される
     fireEvent.click(screen.getByText('次の札'));
 


### PR DESCRIPTION
## Summary

issue #781（クイズ大会モードで管理者の「めくり」と参加者の表示タイミングがズレている）への対応。

- 管理者が「次の札」を押してから参加者の画面が切り替わるまでのタイミングのズレを解消した。従来は`useQuizRoomAdmin.js`のブロードキャストが`displayContent`（イントロ音声＋3秒待ち＋フェード、合計数秒の演出完了後）の更新を待っていたため、その演出時間の分だけ参加者側の表示が管理者より遅れていた
- `useKarutaReading.js`に新しいstate `broadcastPhrase` を追加した。次の札が出題され、本編の経過時間計測（`startTimeRef.current`）を開始するのと同じタイミング（イントロ音声再生後・演出開始前）で確定する値で、`displayContent`の演出完了を待たずに参加者へ先行してブロードキャストできる
- `useQuizRoomAdmin.js`の早押しラウンドキー（`quizRoomBuzzRoundKey`）・「次の札」ブロードキャストを、`displayContent`ではなく`broadcastPhrase`基準に変更した
- 「結果画面・準備画面」への切り替わりのブロードキャストは、従来どおり`displayContent`ベースのまま別のeffectに残した

### 実装中に判明・修正した不具合

`broadcastPhrase`を最も早い時点（`currentPhrase`と同時、イントロ音声より前）で確定する初期実装では、`revealCurrentResult()`（早押し正解時の即時結果確定、issue #600）が`startTimeRef.current`の設定を前提にしているため、参加者がイントロ音声再生中に早押しした場合に正解処理が無視されてしまう不具合があった。`broadcastPhrase`の確定タイミングを`startTimeRef.current`の設定と同じ地点（イントロ音声再生後）に揃えることで解消した。

この過程で既存テスト4件（issue #600, #501, #695, #698）が一時的に失敗することを確認したが、上記修正により解消した。issue #501のテストのみ、「次の札」ボタンが最後の1枚読み上げ中disabledになる（issue #721）実際の挙動とテストの待機条件のズレがあったため、ボタンが再度有効になるのを待ってから押すよう`useQuizRoomAdmin.test.jsx`を修正した。

## Test plan

- [x] frontend: `npx eslint .` エラー0件、`npx vitest run` 全234件成功
- [x] backend: `npx eslint .` エラー0件、`npx vitest run` 全1543件成功（今回未変更だが対象パッケージとして確認）
- [ ] E2Eでの実際の体感遅延の改善はこの開発環境からは検証できないため、CI（`frontend-e2e-test`ジョブ、実際のAWSバックエンドに対して実行）の既存クイズ大会関連テストが引き続き通ることで確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_