### PR TITLE
chore(release): v1.54.4 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.54.4](https://github.com/bamiyanapp/karuta/compare/v1.54.3...v1.54.4) (2026-07-24)
+
+
+### Bug Fixes
+
+* **frontend:** 早押し判定モーダルの解説がはみ出る不具合を修正する（issue [#782](https://github.com/bamiyanapp/karuta/issues/782)） ([#785](https://github.com/bamiyanapp/karuta/issues/785)) ([5d3925a](https://github.com/bamiyanapp/karuta/commit/5d3925a205387b89b6e6da5d864726b1a980c2dd))
+
 ## [1.54.3](https://github.com/bamiyanapp/karuta/compare/v1.54.2...v1.54.3) (2026-07-24)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.54.3",
+    "version": "1.54.4",
     "date": "2026/07/24",
+    "body": "### Bug Fixes\n\n* **frontend:** 早押し判定モーダルの解説がはみ出る不具合を修正する（issue [#782](https://github.com/bamiyanapp/karuta/issues/782)） ([#785](https://github.com/bamiyanapp/karuta/issues/785)) ([5d3925a](https://github.com/bamiyanapp/karuta/commit/5d3925a205387b89b6e6da5d864726b1a980c2dd))"
+  },
+  {
+    "version": "1.54.3",
+    "date": "2026/07/24 12:38",
     "body": "### Bug Fixes\n\n* **frontend:** クイズ大会モードの札めくりブロードキャストを早める（issue [#781](https://github.com/bamiyanapp/karuta/issues/781)） ([#783](https://github.com/bamiyanapp/karuta/issues/783)) ([80707f7](https://github.com/bamiyanapp/karuta/commit/80707f7bfc7369f4939f03edee44c658659a57ba)), closes [#600](https://github.com/bamiyanapp/karuta/issues/600) [#501](https://github.com/bamiyanapp/karuta/issues/501) [#695](https://github.com/bamiyanapp/karuta/issues/695)"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.54.3",
+  "version": "1.54.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.54.3",
+      "version": "1.54.4",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.54.3"
+  "version": "1.54.4"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。