### PR TITLE
fix(frontend): クイズ大会モードの参加者側で最初の太鼓の音を再生する（issue #786）

### DIFF
--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -1198,8 +1198,9 @@ describe('useQuizRoomAdmin (via App)', () => {
     });
 
     expect(unlockedInstance.src).toBe('data:audio/mp3;base64,DUMMY');
-    // sharedAudio（読み上げ用）+ buzz/correct/incorrectの効果音用（issue #613）で計4要素
-    expect(window.Audio).toHaveBeenCalledTimes(4);
+    // sharedAudio（読み上げ用）+ buzz/correct/incorrect/introの効果音用
+    // （issue #613, #786）で計5要素
+    expect(window.Audio).toHaveBeenCalledTimes(5);
   });
 
   it('does not show the open-room list section when there are no open quiz rooms', async () => {

--- a/frontend/src/utils/audioUnlock.js
+++ b/frontend/src/utils/audioUnlock.js
@@ -19,9 +19,11 @@ const SILENT_AUDIO_DATA_URI = "data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAA
 let sharedAudio = null;
 // issue #613: 早押し関連の効果音（回答ボタン/正解/不正解）は、読み上げ音声
 // （sharedAudio）が再生中でも同時に鳴らす必要があるため、sharedAudioとは別に
-// 名前ごとの共有<audio>要素を持つ（同じ理由でシングルトン・解錠が必要）
+// 名前ごとの共有<audio>要素を持つ（同じ理由でシングルトン・解錠が必要）。
+// "intro"は参加者側のイントロ音（太鼓の音、issue #786）用。同じ理由（読み札本編の
+// 音声取得・再生と重なっても止めずに鳴らしたい、fire-and-forgetで使う）でここに含める
 const sharedSfxAudio = {};
-const QUIZ_SFX_NAMES = ["buzz", "correct", "incorrect"];
+const QUIZ_SFX_NAMES = ["buzz", "correct", "incorrect", "intro"];
 
 function getSharedAudio() {
   if (!sharedAudio) {

--- a/frontend/src/utils/audioUnlock.test.js
+++ b/frontend/src/utils/audioUnlock.test.js
@@ -23,8 +23,8 @@ describe('audioUnlock', () => {
   it('unlockAudioPlayback creates the shared narration element plus one shared element per quiz sound effect, and plays a silent clip on each', () => {
     unlockAudioPlayback();
 
-    // sharedAudio（読み上げ用）+ buzz/correct/incorrectの効果音用（issue #613）
-    expect(audioInstances).toHaveLength(4);
+    // sharedAudio（読み上げ用）+ buzz/correct/incorrect/introの効果音用（issue #613, #786）
+    expect(audioInstances).toHaveLength(5);
     for (const instance of audioInstances) {
       expect(instance.src).toMatch(/^data:audio\/wav/);
       expect(instance.play).toHaveBeenCalled();
@@ -35,7 +35,7 @@ describe('audioUnlock', () => {
     unlockAudioPlayback();
     unlockAudioPlayback();
 
-    expect(audioInstances).toHaveLength(4);
+    expect(audioInstances).toHaveLength(5);
   });
 
   it('playSharedAudio reuses the element that was already unlocked, pausing it and swapping the src, instead of creating a new Audio (issue #514)', async () => {
@@ -44,7 +44,7 @@ describe('audioUnlock', () => {
 
     await playSharedAudio('data:audio/mp3;base64,DUMMY');
 
-    expect(audioInstances).toHaveLength(4);
+    expect(audioInstances).toHaveLength(5);
     expect(audioInstances[0]).toBe(unlockedInstance);
     expect(unlockedInstance.pause).toHaveBeenCalled();
     expect(unlockedInstance.src).toBe('data:audio/mp3;base64,DUMMY');
@@ -69,7 +69,7 @@ describe('audioUnlock', () => {
     resetSharedAudioForTests();
     unlockAudioPlayback();
 
-    expect(audioInstances).toHaveLength(8);
+    expect(audioInstances).toHaveLength(10);
   });
 
   describe('stopSharedAudio (issue #696)', () => {
@@ -96,7 +96,7 @@ describe('audioUnlock', () => {
 
       await playQuizSfx('buzz', '/quiz-buzz.mp3');
 
-      expect(audioInstances).toHaveLength(4);
+      expect(audioInstances).toHaveLength(5);
       expect(audioInstances[1]).toBe(unlockedBuzzInstance);
       expect(unlockedBuzzInstance.src).toBe('/quiz-buzz.mp3');
     });

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -377,6 +377,14 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
       return;
     }
 
+    // イントロ音（太鼓の音、issue #786）: 管理者は次の札ごとにwadodon.mp3を再生してから
+    // 読み上げを始める（useKarutaReading.jsのplayIntroSound）が、参加者側には従来この
+    // 演出が無かった。早押し効果音（issue #613）と同じ仕組みの共有<audio>要素を使い、
+    // 読み札本編の音声取得・再生とは別に鳴らす。完了を待たないfire-and-forgetにするのは、
+    // 厳密に待って直列化すると参加者側の音声再生開始が管理者よりさらに遅れてしまい、
+    // issue #781で縮めた体感タイミングのズレを再び広げてしまうため
+    playQuizSfx("intro", "wadodon.mp3").catch(() => {});
+
     let cancelled = false;
     (async () => {
       try {

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -703,9 +703,10 @@ describe('QuizRoomView', () => {
     expect(requestedUrl).toContain('speechRate=70%25');
     expect(requestedUrl).toContain('voiceId=Takumi');
     expect(requestedUrl).toContain('announceCategory=true');
-    // sharedAudio（読み上げ用）+ buzz/correct/incorrectの効果音用（issue #613）で計4要素。
-    // 「決定」ボタンのクリックが共有<audio>要素の解錠（issue #497/#514）を引き起こすため
-    expect(audioInstances).toHaveLength(4);
+    // sharedAudio（読み上げ用）+ buzz/correct/incorrect/introの効果音用
+    // （issue #613, #786）で計5要素。「決定」ボタンのクリックが共有<audio>要素の
+    // 解錠（issue #497/#514）を引き起こすため
+    expect(audioInstances).toHaveLength(5);
     expect(audioInstances[0].src).toBe('data:audio/mp3;base64,DUMMY');
     expect(audioInstances[0].play).toHaveBeenCalled();
   });
@@ -752,8 +753,9 @@ describe('QuizRoomView', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    // sharedAudio（読み上げ用）+ buzz/correct/incorrectの効果音用（issue #613）で計4要素
-    expect(audioInstances).toHaveLength(4);
+    // sharedAudio（読み上げ用）+ buzz/correct/incorrect/introの効果音用
+    // （issue #613, #786）で計5要素
+    expect(audioInstances).toHaveLength(5);
     expect(audioInstances[0].src).toBe('data:audio/mp3;base64,DUMMY1');
 
     emitState({ type: 'phrase', content: { id: 'p2', category: 'Cat1', phrase: '読み札2', level: '3' } });
@@ -764,7 +766,7 @@ describe('QuizRoomView', () => {
 
     // 新しいAudioインスタンスを作るのではなく、同じ（ユーザー操作で解錠済みの）要素を
     // 使い回すことで、非同期文脈からの再生でもSafari等でブロックされないようにしている
-    expect(audioInstances).toHaveLength(4);
+    expect(audioInstances).toHaveLength(5);
     expect(audioInstances[0].pause).toHaveBeenCalled();
     expect(audioInstances[0].src).toBe('data:audio/mp3;base64,DUMMY2');
   });
@@ -787,7 +789,8 @@ describe('QuizRoomView', () => {
       await Promise.resolve();
     });
 
-    // sharedAudio（読み上げ用）+ buzz/correct/incorrectの効果音用（issue #613）で計4要素
+    // sharedAudio（読み上げ用）+ buzz/correct/incorrect/introの効果音用
+    // （issue #613, #786）で計5要素
     const narrationAudio = audioInstances[0];
     narrationAudio.pause.mockClear();
 
@@ -817,16 +820,16 @@ describe('QuizRoomView', () => {
     // 名前を確定しても、確定前から進行中だった同じラウンドの音声が遡って
     // 再生されることはない（「次の札」からの再生という要望どおりの挙動）。
     // 「決定」ボタンのクリック自体が共有<audio>要素の解錠（issue #497/#514）を
-    // 引き起こすため、audioInstancesは（sharedAudio+buzz/correct/incorrectの計）4件に
-    // なるが、フレーズの取得（fetch）は行われておらず、再生される音声も無音の
-    // 解錠用データのままであることを確認する
+    // 引き起こすため、audioInstancesは（sharedAudio+buzz/correct/incorrect/introの計、
+    // issue #786）5件になるが、フレーズの取得（fetch）は行われておらず、再生される
+    // 音声も無音の解錠用データのままであることを確認する
     confirmName();
     await act(async () => {
       await Promise.resolve();
       await Promise.resolve();
     });
     expect(audioFetchCalls()).toHaveLength(0);
-    expect(audioInstances).toHaveLength(4);
+    expect(audioInstances).toHaveLength(5);
     expect(audioInstances[0].src).toBe('data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=');
 
     // 名前確定後に届いた次の札からは通常どおり再生される（同じ共有要素のsrcが
@@ -837,7 +840,7 @@ describe('QuizRoomView', () => {
       await Promise.resolve();
     });
     expect(audioFetchCalls()).toHaveLength(1);
-    expect(audioInstances).toHaveLength(4);
+    expect(audioInstances).toHaveLength(5);
     expect(audioInstances[0].src).toBe('data:audio/mp3;base64,DUMMY');
   });
 
@@ -870,7 +873,7 @@ describe('QuizRoomView', () => {
       await Promise.resolve();
     });
 
-    expect(audioInstances).toHaveLength(4);
+    expect(audioInstances).toHaveLength(5);
     expect(screen.queryByText('🔊 タップして音声を有効にする')).not.toBeInTheDocument();
     expect(screen.queryByText('🔊 音声ON')).not.toBeInTheDocument();
   });
@@ -883,8 +886,9 @@ describe('QuizRoomView', () => {
 
     fireEvent.click(document.body);
 
-    // sharedAudio（読み上げ用）+ buzz/correct/incorrectの効果音用（issue #613）で計4要素
-    expect(audioInstances).toHaveLength(4);
+    // sharedAudio（読み上げ用）+ buzz/correct/incorrect/introの効果音用
+    // （issue #613, #786）で計5要素
+    expect(audioInstances).toHaveLength(5);
     expect(audioInstances[0].play).toHaveBeenCalled();
   });
 
@@ -894,7 +898,7 @@ describe('QuizRoomView', () => {
     fireEvent.change(screen.getByPlaceholderText('ルームコード'), { target: { value: 'xyz789' } });
     fireEvent.click(screen.getByText('参加する'));
 
-    expect(audioInstances).toHaveLength(4);
+    expect(audioInstances).toHaveLength(5);
     expect(audioInstances[0].play).toHaveBeenCalled();
   });
 
@@ -942,6 +946,27 @@ describe('QuizRoomView', () => {
       const incorrectAudio = audioInstances.find((a) => a.src === 'quiz-incorrect.mp3');
       expect(incorrectAudio).toBeDefined();
       expect(incorrectAudio.play).toHaveBeenCalled();
+    });
+
+    it('plays the intro sound (wadodon.mp3) when a new phrase is broadcast, mirroring the admin\'s own reading flow (issue #786)', () => {
+      window.history.pushState({}, '', '?roomId=ABC123');
+      render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+      confirmName();
+
+      emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+
+      const introAudio = audioInstances.find((a) => a.src === 'wadodon.mp3');
+      expect(introAudio).toBeDefined();
+      expect(introAudio.play).toHaveBeenCalled();
+    });
+
+    it('does not play the intro sound while still on the name entry screen (issue #530と同じ理由)', () => {
+      window.history.pushState({}, '', '?roomId=ABC123');
+      render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+
+      emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+
+      expect(audioInstances.find((a) => a.src === 'wadodon.mp3')).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- クイズ大会モードで、管理者側は次の札ごとにwadodon.mp3（太鼓の音）を再生してから読み上げを始めるが、参加者側には従来この演出が無く、前触れなく読み上げが始まっていた（issue #786）
- 早押し効果音（issue #613）と同じ「読み札本編の音声取得・再生と重なっても止めずに鳴らす」共有`<audio>`要素の仕組みを流用し、参加者側でも太鼓の音を再生するようにした
- 完了を待たないfire-and-forget方式を採用（直列化するとissue #781で縮めたタイミングのズレが再び広がるため）

## Test plan
- [x] `cd frontend && npx eslint .` エラー0件
- [x] `cd frontend && npx vitest run` 236件成功（太鼓の音再生を検証する新規テスト2件を含む）
- [x] `cd backend && npx eslint . && npx vitest run` 1543件成功

Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_