### PR TITLE
fix(frontend): クイズ大会モードで早押し発生時に管理者自身の読み上げを止める（issue #788）

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -549,6 +549,7 @@ function App() {
     isMultiCategorySelection,
     setView,
     revealCurrentResult,
+    stopReading,
   });
 
   useEffect(() => {

--- a/frontend/src/hooks/useKarutaReading.js
+++ b/frontend/src/hooks/useKarutaReading.js
@@ -439,7 +439,14 @@ export function useKarutaReading({
     setAudioQueue(prev => [...prev, { phraseData: null, audioData }]);
   };
 
-  const stopReading = () => {
+  // keepElapsedTime: クイズ大会モードで早押しが発生した際（issue #788）に
+  // useQuizRoomAdminのonBuzzから呼ぶ場合はtrueにする。早押しは読み上げの中断
+  // ではなく一時停止（judgeQuizRoomBuzzが正解と判定すればrevealCurrentResultで
+  // 経過時間を確定し、不正解ならそのまま「次の札」まで計測を続ける）であり、
+  // startTimeRef.currentを消してしまうとどちらの経路でも経過時間が確定できなくなる。
+  // 通常の「停止」ボタン（読み上げ自体を打ち切る操作）ではfalseのまま、
+  // 中断された計測を次回の記録に持ち越さないようにする
+  const stopReading = ({ keepElapsedTime = false } = {}) => {
     if (!isReading) return;
 
     // playNextInQueue内のawaitチェーンを、次の工程（本編読み上げ・フェード）に
@@ -463,8 +470,10 @@ export function useKarutaReading({
       animationResolveRef.current = null;
     }
 
-    // 中断された読み上げの計測を、次回の記録に誤って持ち越さないようにする
-    startTimeRef.current = null;
+    if (!keepElapsedTime) {
+      // 中断された読み上げの計測を、次回の記録に誤って持ち越さないようにする
+      startTimeRef.current = null;
+    }
 
     // 停止は音声・タイマーの中断のみを行い、画面表示は変更しない（issue #755）。
     // 以前はここで表示を強制的にinitial（準備完了画面）へ戻していたが、読み上げ中の

--- a/frontend/src/hooks/useQuizRoomAdmin.js
+++ b/frontend/src/hooks/useQuizRoomAdmin.js
@@ -58,6 +58,7 @@ export function useQuizRoomAdmin({
   isMultiCategorySelection,
   setView,
   revealCurrentResult,
+  stopReading,
 }) {
   // 管理者としてルームを開設した場合のみ設定される
   const [quizRoom, setQuizRoom] = useState(null); // { roomId, adminToken } | null
@@ -149,6 +150,14 @@ export function useQuizRoomAdmin({
       // 絶対パス（先頭スラッシュ）だとドメインルート宛になり音声ファイルが見つからず
       // NotSupportedErrorになる。favicon.png等と同じ相対パスにする
       playQuizSfx("buzz", "quiz-buzz.mp3").catch(() => {});
+      // issue #788: 参加者側（issue #696のstopSharedAudio）と同様、早押し発生時点で
+      // 管理者自身の読み上げ音声・演出も止める。止めないと、参加者の誰かが早押しした
+      // 後も管理者の本編音声・3秒待ち・フェード演出がそのまま進行し続けてしまう。
+      // keepElapsedTime: trueは必須。早押しは読み上げの中断ではなく一時停止であり、
+      // 正解判定時のrevealCurrentResult（issue #600）・不正解時に「次の札」まで続く
+      // 経過時間計測のどちらも、経過時間の起点（startTimeRef.current）が消えずに
+      // 残っていることを前提にしている
+      stopReading({ keepElapsedTime: true });
       setQuizRoomBuzzedBy(buzzedBy);
     },
     onPoints: (points, answerCounts) => {

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -646,6 +646,83 @@ describe('useQuizRoomAdmin (via App)', () => {
     }, { timeout: 20000 });
   }, 40000);
 
+  it('stops the admin\'s own reading progression when a participant buzzes in, without discarding the elapsed-time measurement needed for the next 次の札 press (issue #788)', async () => {
+    class MockWebSocket {
+      constructor(url) {
+        this.url = url;
+        this.readyState = 0;
+        this.sent = [];
+        MockWebSocket.instances.push(this);
+      }
+      send(data) {
+        this.sent.push(data);
+      }
+      close() {}
+    }
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket;
+
+    fetch.mockImplementation(async (url, options) => {
+      if (url.includes('/quiz-room') && options?.method === 'POST') {
+        return { ok: true, json: async () => ({ roomId: 'ABC123', adminToken: 'token-1' }) };
+      }
+      if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
+      if (url.includes('get-phrases-list')) return { ok: true, json: async () => ({ phrases: [{ id: 'p1', category: 'Cat1' }] }) };
+      if (url.includes('/get-phrase?')) {
+        return { ok: true, json: async () => ({ id: 'p1', category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '-', answer: '答え1', audioData: 'dummy' }) };
+      }
+      if (url.includes('/record-time')) return { ok: true, json: async () => ({}) };
+      return { ok: false };
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByText('こども向け'));
+    fireEvent.click(await screen.findByRole('button', { name: /Cat1/ }));
+    await waitFor(() => screen.getByText('次の札'));
+
+    fireEvent.click(screen.getByText('クイズ大会のルームを作成する'));
+    await screen.findByText('ルーム情報を表示（クイズ大会モード）');
+
+    const ws = MockWebSocket.instances[0];
+    act(() => {
+      ws.readyState = MockWebSocket.OPEN;
+      ws.onopen?.();
+    });
+
+    fireEvent.click(screen.getByText('次の札'));
+    await waitFor(() => {
+      expect(ws.sent.find((msg) => msg.includes('"type":"phrase"'))).toBeDefined();
+    }, { timeout: 20000 });
+
+    act(() => {
+      ws.onmessage?.({ data: JSON.stringify({ type: 'buzz', name: 'はなこ', connectionId: 'conn-2' }) });
+    });
+
+    // issue #788: 早押し発生時点で管理者自身の読み上げ（本編音声の再生・3秒待ちの
+    // フェード演出）が打ち切られ、isReadingがfalseに戻る。この時点ではまだ
+    // 演出中の3秒待ちタイマー（実タイマー）は経過していないため、打ち切られて
+    // いなければ「次の札」ボタンはisReadingLastPhrase（issue #721）によって
+    // まだ無効化されたままのはず
+    fireEvent.click(screen.getByText('不正解'));
+
+    expect(screen.getByText('次の札').closest('button')).not.toBeDisabled();
+
+    // 不正解のため経過時間の確定（revealCurrentResult）は行われないが、計測自体は
+    // 打ち切られていない。もしstopReadingがstartTimeRef.currentを消してしまうと、
+    // 次に「次の札」を押した時にrevealCurrentResultが何もせず、この札の所要時間の
+    // 記録（record-time）が失われてしまう
+    fireEvent.click(screen.getByText('次の札'));
+
+    await waitFor(() => {
+      const recordTimeCall = fetch.mock.calls.find(([callUrl]) => callUrl.includes('/record-time'));
+      expect(recordTimeCall).toBeDefined();
+    }, { timeout: 20000 });
+  }, 40000);
+
   it('broadcasts isAllRead:true once the selected category\'s last phrase has been read, so the top-page room list can show a "終了" status (issue #501)', async () => {
     class MockWebSocket {
       constructor(url) {


### PR DESCRIPTION
## Summary
- クイズ大会モードで参加者が早押しボタンを押すと、参加者自身の読み上げ音声は止まる（issue #696）が、管理者画面側の読み上げ（本編音声・演出）は止まらずそのまま進行し続けていた（issue #788）
- `useQuizRoomAdmin.js`の`onBuzz`から`useKarutaReading.js`の`stopReading`を呼び出せるよう配線した
- `stopReading`をそのまま流用すると内部で経過時間計測の起点（`startTimeRef.current`）が消え、早押し正解時の結果確定（issue #600）や不正解後の「次の札」押下時の経過時間記録が失われてしまうため、`stopReading`に`keepElapsedTime`オプションを追加し、早押し発生時は起点を保持したまま音声・演出のみを止めるようにした

## Test plan
- [x] `cd frontend && npx eslint .` エラー0件
- [x] `cd frontend && npx vitest run` 237件成功（早押し時の読み上げ停止と、その後の経過時間記録を検証する新規テストを含む。fix適用前の状態でこの新規テストが失敗することも確認済み）
- [x] `cd backend && npx eslint . && npx vitest run` 1543件成功

Closes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_