### PR TITLE
chore(release): v1.54.6 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.54.6](https://github.com/bamiyanapp/karuta/compare/v1.54.5...v1.54.6) (2026-07-24)
+
+
+### Bug Fixes
+
+* **frontend:** クイズ大会モードで早押し発生時に管理者自身の読み上げを止める（issue [#788](https://github.com/bamiyanapp/karuta/issues/788)） ([#791](https://github.com/bamiyanapp/karuta/issues/791)) ([f5ef897](https://github.com/bamiyanapp/karuta/commit/f5ef8977a71bd4edc6891c4a7f97f5340d28c459))
+
 ## [1.54.5](https://github.com/bamiyanapp/karuta/compare/v1.54.4...v1.54.5) (2026-07-24)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.54.5",
+    "version": "1.54.6",
     "date": "2026/07/24",
+    "body": "### Bug Fixes\n\n* **frontend:** クイズ大会モードで早押し発生時に管理者自身の読み上げを止める（issue [#788](https://github.com/bamiyanapp/karuta/issues/788)） ([#791](https://github.com/bamiyanapp/karuta/issues/791)) ([f5ef897](https://github.com/bamiyanapp/karuta/commit/f5ef8977a71bd4edc6891c4a7f97f5340d28c459))"
+  },
+  {
+    "version": "1.54.5",
+    "date": "2026/07/24 13:40",
     "body": "### Bug Fixes\n\n* **frontend:** クイズ大会モードの参加者側で最初の太鼓の音を再生する（issue [#786](https://github.com/bamiyanapp/karuta/issues/786)） ([#789](https://github.com/bamiyanapp/karuta/issues/789)) ([ec7e36e](https://github.com/bamiyanapp/karuta/commit/ec7e36e6931818b171e0980963c9df03d4fab0c1))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.54.5",
+  "version": "1.54.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.54.5",
+      "version": "1.54.6",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.54.5"
+  "version": "1.54.6"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。