### PR TITLE
fix(frontend): 参加者側で太鼓の音と読み上げが重ならないよう、太鼓の後に読み上げを開始する（issue #796）

### DIFF
--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -1262,7 +1262,7 @@ describe('useQuizRoomAdmin (via App)', () => {
     // 別々のAudioインスタンスを使っていると、解錠の効果が実際の再生に及ばずSafari等で
     // ブロックされ続けてしまう
     const participantWs = MockWebSocket.instances[MockWebSocket.instances.length - 1];
-    await act(async () => {
+    act(() => {
       participantWs.onmessage?.({
         data: JSON.stringify({
           type: 'state',
@@ -1270,11 +1270,14 @@ describe('useQuizRoomAdmin (via App)', () => {
           role: 'participant',
         }),
       });
-      await Promise.resolve();
-      await Promise.resolve();
     });
 
-    expect(unlockedInstance.src).toBe('data:audio/mp3;base64,DUMMY');
+    // issue #796: 読み上げ本編の再生は太鼓の音の再生完了（onended）を待ってから始まる。
+    // このモックのonendedは`set src`内のsetTimeout(0)を2段（oncanplaythrough確認→onended）
+    // 経て発火する実タイマーのため、固定時間のawaitではなくwaitForで待つ
+    await waitFor(() => {
+      expect(unlockedInstance.src).toBe('data:audio/mp3;base64,DUMMY');
+    }, { timeout: 10000 });
     // sharedAudio（読み上げ用）+ buzz/correct/incorrect/introの効果音用
     // （issue #613, #786）で計5要素
     expect(window.Audio).toHaveBeenCalledTimes(5);

--- a/frontend/src/utils/audioUnlock.js
+++ b/frontend/src/utils/audioUnlock.js
@@ -20,8 +20,8 @@ let sharedAudio = null;
 // issue #613: 早押し関連の効果音（回答ボタン/正解/不正解）は、読み上げ音声
 // （sharedAudio）が再生中でも同時に鳴らす必要があるため、sharedAudioとは別に
 // 名前ごとの共有<audio>要素を持つ（同じ理由でシングルトン・解錠が必要）。
-// "intro"は参加者側のイントロ音（太鼓の音、issue #786）用。同じ理由（読み札本編の
-// 音声取得・再生と重なっても止めずに鳴らしたい、fire-and-forgetで使う）でここに含める
+// "intro"は参加者側のイントロ音（太鼓の音、issue #786）用。sharedAudio（本編音声）とは
+// 別の要素が必要な理由は同じ（本編音声の取得と並行して鳴らしたいため、issue #796）
 const sharedSfxAudio = {};
 const QUIZ_SFX_NAMES = ["buzz", "correct", "incorrect", "intro"];
 
@@ -74,12 +74,38 @@ export function stopSharedAudio() {
 }
 
 // issue #613: 早押し関連の効果音（回答ボタン/正解/不正解）を再生する。
-// nameは"buzz"|"correct"|"incorrect"のいずれか
+// nameは"buzz"|"correct"|"incorrect"|"intro"のいずれか
 export function playQuizSfx(name, src) {
   const audio = getSharedSfxAudio(name);
   audio.pause();
   audio.src = src;
   return audio.play();
+}
+
+// issue #796: イントロ音（太鼓の音）の再生完了を待てるバージョン。play()が返す
+// Promiseは再生「開始」時点で解決されるため（完了を待つには別途onendedの監視が必要、
+// useKarutaReading.jsのplayAudioと同じ理由）、参加者側で「太鼓の音の後に読み上げを
+// 始める」（管理者側と同じ順序にする）ために使う。onended/onerrorのどちらも発火せず
+// ハングする環境向けに、上限時間で強制的に諦めて先へ進める（同じ理由でuseKarutaReading.js
+// のplayAudioにも上限時間がある。太鼓の音は短い効果音のため、本編音声用の15秒より
+// 短い上限にする）
+const INTRO_SFX_TIMEOUT_MS = 5000;
+export function playQuizSfxAndWait(name, src) {
+  const audio = getSharedSfxAudio(name);
+  audio.pause();
+  audio.src = src;
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      resolve();
+    };
+    const timeoutId = setTimeout(settle, INTRO_SFX_TIMEOUT_MS);
+    audio.onended = settle;
+    audio.play().catch(settle);
+  });
 }
 
 // テスト専用: モジュールスコープのシングルトンをテスト間で共有してしまわないようにリセットする

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuizRoomSync, CONNECTION_STATUS_LABEL } from "../hooks/useQuizRoomSync";
 import { useLocalStorageState } from "../hooks/useLocalStorageState";
 import { API_BASE_URL } from "../config";
-import { unlockAudioPlayback, playSharedAudio, playQuizSfx, stopSharedAudio } from "../utils/audioUnlock";
+import { unlockAudioPlayback, playSharedAudio, playQuizSfx, playQuizSfxAndWait, stopSharedAudio } from "../utils/audioUnlock";
 import { mergeParticipantsWithPoints } from "../utils/quizRoomParticipants";
 
 // クイズ大会モード（issue #470）の参加者用入口（閲覧専用）。
@@ -380,10 +380,12 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
     // イントロ音（太鼓の音、issue #786）: 管理者は次の札ごとにwadodon.mp3を再生してから
     // 読み上げを始める（useKarutaReading.jsのplayIntroSound）が、参加者側には従来この
     // 演出が無かった。早押し効果音（issue #613）と同じ仕組みの共有<audio>要素を使い、
-    // 読み札本編の音声取得・再生とは別に鳴らす。完了を待たないfire-and-forgetにするのは、
-    // 厳密に待って直列化すると参加者側の音声再生開始が管理者よりさらに遅れてしまい、
-    // issue #781で縮めた体感タイミングのズレを再び広げてしまうため
-    playQuizSfx("intro", "wadodon.mp3").catch(() => {});
+    // 読み札本編の音声取得・再生とは別に鳴らす。
+    // issue #796: 太鼓の音の再生完了を待たずに本編音声の取得・再生を始めていたため、
+    // 太鼓の音と読み上げが重なって聞こえてしまっていた。本編音声の「取得」は太鼓の音の
+    // 再生と並行して進め（余計な遅延を増やさないため）、「再生開始」だけを太鼓の音の
+    // 完了後まで遅らせることで、管理者側（太鼓の音の後に読み上げを始める）と同じ順序にする
+    const introPromise = playQuizSfxAndWait("intro", "wadodon.mp3");
 
     let cancelled = false;
     (async () => {
@@ -395,6 +397,10 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
         }
         const data = await response.json();
         if (cancelled || !data.audioData) {
+          return;
+        }
+        await introPromise;
+        if (cancelled) {
           return;
         }
         await playSharedAudio(data.audioData);

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -106,7 +106,18 @@ let audioPlayImpl = () => Promise.resolve();
 // App.test.jsxと同様の理由でアロー関数ではなく通常の関数式を使う（newで呼び出すため）
 window.Audio = vi.fn().mockImplementation(function (src) {
   this.src = src;
-  this.play = vi.fn(() => audioPlayImpl());
+  this.play = vi.fn(() => {
+    const result = audioPlayImpl();
+    // issue #796: playQuizSfxAndWait（audioUnlock.js）はonendedの発火を待って解決する。
+    // 実際のHTMLAudioElementは再生開始（play()の解決）後、再生し終えてからended相当が
+    // 発火するが、テストでは再生時間を待てないため、play()の解決に続けて即座にonendedも
+    // 発火させて模倣する。onendedはこの呼び出し時点のものを束縛しておく（このplay()より後に
+    // 別の再生でonendedが上書きされても、この再生自身の完了通知が新しい方を誤って
+    // 呼んでしまわないようにするため）
+    const onendedAtCallTime = this.onended;
+    result.then(() => onendedAtCallTime?.()).catch(() => {});
+    return result;
+  });
   this.pause = vi.fn();
   audioInstances.push(this);
 });
@@ -967,6 +978,46 @@ describe('QuizRoomView', () => {
       emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
 
       expect(audioInstances.find((a) => a.src === 'wadodon.mp3')).toBeUndefined();
+    });
+
+    it('waits for the intro sound to finish before starting the narration, instead of playing them at the same time (issue #796)', async () => {
+      fetch.mockResolvedValue({ ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,NEWDATA' }) });
+      window.history.pushState({}, '', '?roomId=ABC123');
+      render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+      confirmName();
+
+      // 「決定」ボタンのクリックによる解錠（unlockAudioPlayback）はここまでの
+      // デフォルトのaudioPlayImplで解決済み。ここから先、太鼓の音の再生完了を
+      // 手動で制御できるようにする
+      let resolveIntroPlayback;
+      audioPlayImpl = () => new Promise((resolve) => { resolveIntroPlayback = resolve; });
+
+      emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+
+      const narrationAudio = audioInstances[0];
+      const introAudio = audioInstances.find((a) => a.src === 'wadodon.mp3');
+      expect(introAudio).toBeDefined();
+
+      // フレーズ取得（/get-phrase）自体は太鼓の音の再生と並行して進む
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(audioFetchCalls().length).toBeGreaterThan(0);
+      // 太鼓の音がまだ鳴り終わっていないため、読み上げ本編（narrationAudio）はまだ
+      // 差し替わっていない（解錠時の無音データのまま）
+      expect(narrationAudio.src).toBe('data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=');
+
+      // 太鼓の音の再生完了（onended相当）を発火させる
+      await act(async () => {
+        resolveIntroPlayback();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(narrationAudio.src).toBe('data:audio/mp3;base64,NEWDATA');
     });
   });
 });


### PR DESCRIPTION
## Summary
- issue #786対応後、参加者側で太鼓の音（wadodon.mp3）は鳴るようになったが、完了を待たずに読み札本編の音声を再生していたため、太鼓の音と読み上げが重なって聞こえてしまっていた
- `audioUnlock.js`に完了（onended）を待てる`playQuizSfxAndWait`を追加し、本編音声の**取得**は太鼓の音の再生と並行して進めつつ、**再生開始**だけを太鼓の音の完了後まで遅らせるようにした（管理者側と同じ順序になる）

## Test plan
- [x] `cd frontend && npx eslint .` エラー0件
- [x] `cd frontend && npx vitest run` 238件成功（太鼓の音の完了を待ってから読み上げが始まることを検証する新規テストを含む）
- [x] `cd backend && npx eslint . && npx vitest run` 1543件成功

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_