### PR TITLE
chore(release): v1.54.7 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.54.7](https://github.com/bamiyanapp/karuta/compare/v1.54.6...v1.54.7) (2026-07-24)
+
+
+### Bug Fixes
+
+* **frontend:** 参加者側で太鼓の音と読み上げが重ならないよう、太鼓の後に読み上げを開始する（issue [#796](https://github.com/bamiyanapp/karuta/issues/796)） ([#797](https://github.com/bamiyanapp/karuta/issues/797)) ([0f20c71](https://github.com/bamiyanapp/karuta/commit/0f20c7126b1b20917ae9261453c124a2d04f45b4))
+
 ## [1.54.6](https://github.com/bamiyanapp/karuta/compare/v1.54.5...v1.54.6) (2026-07-24)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.54.6",
+    "version": "1.54.7",
     "date": "2026/07/24",
+    "body": "### Bug Fixes\n\n* **frontend:** 参加者側で太鼓の音と読み上げが重ならないよう、太鼓の後に読み上げを開始する（issue [#796](https://github.com/bamiyanapp/karuta/issues/796)） ([#797](https://github.com/bamiyanapp/karuta/issues/797)) ([0f20c71](https://github.com/bamiyanapp/karuta/commit/0f20c7126b1b20917ae9261453c124a2d04f45b4))"
+  },
+  {
+    "version": "1.54.6",
+    "date": "2026/07/24 20:37",
     "body": "### Bug Fixes\n\n* **frontend:** クイズ大会モードで早押し発生時に管理者自身の読み上げを止める（issue [#788](https://github.com/bamiyanapp/karuta/issues/788)） ([#791](https://github.com/bamiyanapp/karuta/issues/791)) ([f5ef897](https://github.com/bamiyanapp/karuta/commit/f5ef8977a71bd4edc6891c4a7f97f5340d28c459))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.54.6",
+  "version": "1.54.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.54.6",
+      "version": "1.54.7",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.54.6"
+  "version": "1.54.7"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。