### PR TITLE
refactor(frontend): クイズ大会モードの管理者・参加者間の重複コードを共通化する（issue #800）

### DIFF
--- a/frontend/src/components/AnswerAndExplanation.jsx
+++ b/frontend/src/components/AnswerAndExplanation.jsx
@@ -1,0 +1,34 @@
+// issue #800: 答え・解説の表示ブロックが、ResultCard.jsx（通常モード・クイズ大会
+// 参加者の結果画面）とQuizRoomBuzzJudgmentModal.jsx（クイズ大会の早押し判定モーダル）
+// の3箇所に同型で存在していたため共通化した。
+// variant="card"（既定）: 所要時間等の他の項目に続けて表示する想定で、見出しに
+// mt-4を付ける（ResultCard.jsx・QuizRoomView.jsxの結果画面）。
+// variant="modal": タイトル直下に表示する想定で見出しにmt-4を付けず、解説には
+// 見出しを出さずボタン等との間隔（mb-4）を確保する（QuizRoomBuzzJudgmentModal.jsx）
+function AnswerAndExplanation({ answer, explanation, variant = "card" }) {
+  const labelClassName = variant === "modal" ? "text-muted mb-2" : "text-muted mt-4 mb-2";
+  const answerClassName = variant === "modal" ? "h4 fw-bold text-dark mb-4" : "h4 fw-bold text-dark";
+
+  return (
+    <>
+      {answer && answer !== "-" && (
+        <>
+          <div className={labelClassName}>答え</div>
+          <div className={answerClassName}>{answer}</div>
+        </>
+      )}
+      {explanation && explanation !== "-" && (
+        variant === "modal" ? (
+          <div className="fs-6 text-dark mb-4">{explanation}</div>
+        ) : (
+          <>
+            <div className="text-muted mt-4 mb-2">解説</div>
+            <div className="fs-6 text-dark">{explanation}</div>
+          </>
+        )
+      )}
+    </>
+  );
+}
+
+export default AnswerAndExplanation;

--- a/frontend/src/components/QuizRoomBuzzJudgmentModal.jsx
+++ b/frontend/src/components/QuizRoomBuzzJudgmentModal.jsx
@@ -1,3 +1,5 @@
+import AnswerAndExplanation from "./AnswerAndExplanation";
+
 // 早押し正誤判定モーダル（issue #546）。管理者が参加者の早押しを正誤判定するための
 // ポップアップで、以前はApp.jsxのゲーム画面のレンダー内にのみ存在していた。
 // ルーム情報画面（QuizRoomInfoView）を開いている間はこの分岐を通らずモーダルが
@@ -20,15 +22,7 @@ function QuizRoomBuzzJudgmentModal({ buzzedBy, answer, explanation, onJudge }) {
         <div className="modal-content rounded-4 border-0 shadow">
           <div className="modal-body p-5 text-center">
             <h3 className="h5 mb-4 fw-bold">🔔 {buzzedBy.name} さんが回答中</h3>
-            {answer && answer !== "-" && (
-              <>
-                <div className="text-muted mb-2">答え</div>
-                <div className="h4 fw-bold text-dark mb-4">{answer}</div>
-              </>
-            )}
-            {explanation && explanation !== "-" && (
-              <div className="fs-6 text-dark mb-4">{explanation}</div>
-            )}
+            <AnswerAndExplanation answer={answer} explanation={explanation} variant="modal" />
             <div className="d-flex gap-2 justify-content-center">
               <button onClick={() => onJudge(true)} className="btn btn-primary btn-lg px-4 rounded-pill shadow-sm fs-6">正解</button>
               <button onClick={() => onJudge(false)} className="btn btn-outline-secondary btn-lg px-4 rounded-pill fs-6">不正解</button>

--- a/frontend/src/components/QuizRoomParticipantTable.jsx
+++ b/frontend/src/components/QuizRoomParticipantTable.jsx
@@ -1,0 +1,49 @@
+import { mergeParticipantsWithPoints } from "../utils/quizRoomParticipants";
+
+// issue #800: 参加者一覧テーブル（名前・接続・回答数・正答数）が、管理者側
+// （QuizRoomInfoView.jsx）と参加者側（QuizRoomView.jsx）にほぼ同一の実装で
+// 重複していたため共通化した。
+// - highlightName: 自分の名前（参加者側のみ）。一致する行を太字にする
+// - className: ラッパーの余白（管理者側は"mt-5"、参加者側は"mt-4"）
+// - footer: テーブルの下に続けて表示する内容（管理者側の「ポイントをリセット」ボタン等）
+// issue #545/#599: まだ得点していない参加者も0ptとして含めた1つのリストに統合し、
+// ポイント降順（同点は名前昇順）で表示する。issue #599/#602: 切断済みでも得点・回答数は
+// 保持したまま「切断済み」表示に切り替える。issue #698: 回答数（attempts）・正答数（points）は
+// 別カラムで表示する
+function QuizRoomParticipantTable({ participantNames, points, answerCounts, highlightName, className = "mt-4", footer }) {
+  const participantList = mergeParticipantsWithPoints(participantNames, points, answerCounts);
+  if (participantList.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={`mx-auto text-start ${className}`} style={{ maxWidth: "360px" }}>
+      <p className="text-muted small mb-2">参加者一覧</p>
+      <table className="table table-sm table-bordered bg-white mb-0">
+        <thead>
+          <tr>
+            <th scope="col">名前</th>
+            <th scope="col">接続</th>
+            <th scope="col" className="text-end">回答数</th>
+            <th scope="col" className="text-end">正答数</th>
+          </tr>
+        </thead>
+        <tbody>
+          {participantList.map(({ name, points: pt, attempts, connected }) => (
+            <tr key={name}>
+              <td className={`notranslate ${name === highlightName ? "fw-bold" : ""}`}>{name}</td>
+              <td className={connected ? "text-success" : "text-muted"}>
+                {connected ? "接続中" : "切断済み"}
+              </td>
+              <td className="text-end">{attempts}</td>
+              <td className="text-end">{pt}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {footer}
+    </div>
+  );
+}
+
+export default QuizRoomParticipantTable;

--- a/frontend/src/components/QuizRoomParticipantTable.test.jsx
+++ b/frontend/src/components/QuizRoomParticipantTable.test.jsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import QuizRoomParticipantTable from './QuizRoomParticipantTable';
+
+// issue #800: 管理者側（QuizRoomInfoView.jsx）・参加者側（QuizRoomView.jsx）に
+// 重複していた参加者一覧テーブルのテストを、この共通コンポーネントのテストへ統合した
+
+describe('QuizRoomParticipantTable', () => {
+  it('renders nothing when there are no participants', () => {
+    const { container } = render(
+      <QuizRoomParticipantTable participantNames={[]} points={{}} answerCounts={{}} />
+    );
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('参加者一覧')).not.toBeInTheDocument();
+  });
+
+  it('shows the participant list as a table, sorted by points descending (0pt participants included, ties broken by name) (issue #545, #587, #599)', () => {
+    render(
+      <QuizRoomParticipantTable
+        participantNames={['たろう', 'はなこ', 'じろう']}
+        points={{ たろう: 3 }}
+        answerCounts={{}}
+      />
+    );
+
+    expect(screen.getByText('参加者一覧')).toBeInTheDocument();
+    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
+    // たろう(3pt)がまだ得点していないじろう・はなこ(0pt)より先（降順、同点は名前昇順）
+    expect(rows).toEqual(['たろう接続中03', 'じろう接続中00', 'はなこ接続中00']);
+  });
+
+  it('shows a participant as disconnected once they leave the connected-participants list, while keeping their earned points visible (issue #599, #602)', () => {
+    render(
+      <QuizRoomParticipantTable
+        participantNames={['はなこ']}
+        points={{ たろう: 2 }}
+        answerCounts={{}}
+      />
+    );
+
+    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
+    expect(rows).toEqual(['たろう切断済み02', 'はなこ接続中00']);
+  });
+
+  it('shows the attempt count (回答数) and correct count (正答数) as separate columns, keeping them after a participant disconnects (issue #698)', () => {
+    render(
+      <QuizRoomParticipantTable
+        participantNames={['はなこ']}
+        points={{ たろう: 2 }}
+        answerCounts={{ たろう: { attempts: 3, correct: 2 }, はなこ: { attempts: 1, correct: 0 } }}
+      />
+    );
+
+    expect(screen.getByText('回答数')).toBeInTheDocument();
+    expect(screen.getByText('正答数')).toBeInTheDocument();
+    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
+    expect(rows).toEqual(['たろう切断済み32', 'はなこ接続中10']);
+  });
+
+  it('bolds the row matching highlightName (the participant\'s own name), leaving others unstyled (issue #545)', () => {
+    render(
+      <QuizRoomParticipantTable
+        participantNames={['たろう', 'はなこ']}
+        points={{}}
+        answerCounts={{}}
+        highlightName="はなこ"
+      />
+    );
+
+    expect(screen.getByText('はなこ', { selector: 'td.fw-bold' })).toBeInTheDocument();
+    expect(screen.getByText('たろう').className).not.toContain('fw-bold');
+  });
+
+  it('does not bold any row when highlightName is not provided (admin usage)', () => {
+    render(
+      <QuizRoomParticipantTable
+        participantNames={['たろう']}
+        points={{}}
+        answerCounts={{}}
+      />
+    );
+
+    expect(screen.getByText('たろう').className).not.toContain('fw-bold');
+  });
+
+  it('renders the optional footer below the table (e.g. the admin\'s "ポイントをリセット" button)', () => {
+    render(
+      <QuizRoomParticipantTable
+        participantNames={['たろう']}
+        points={{}}
+        answerCounts={{}}
+        footer={<button onClick={vi.fn()}>ポイントをリセット</button>}
+      />
+    );
+
+    expect(screen.getByText('ポイントをリセット')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ResultCard.jsx
+++ b/frontend/src/components/ResultCard.jsx
@@ -1,3 +1,5 @@
+import AnswerAndExplanation from "./AnswerAndExplanation";
+
 // 1札の読み上げ結果画面。App.jsxのdisplayContent.type === 'result'時に表示する
 // （issue #607: App.jsx肥大化解消のためコンポーネントとして切り出し）
 function ResultCard({ result, division }) {
@@ -21,19 +23,7 @@ function ResultCard({ result, division }) {
           </>
         )}
 
-        {result.answer && result.answer !== "-" && (
-          <>
-            <div className="text-muted mt-4 mb-2">答え</div>
-            <div className="h4 fw-bold text-dark">{result.answer}</div>
-          </>
-        )}
-
-        {result.explanation && result.explanation !== "-" && (
-          <>
-            <div className="text-muted mt-4 mb-2">解説</div>
-            <div className="fs-6 text-dark">{result.explanation}</div>
-          </>
-        )}
+        <AnswerAndExplanation answer={result.answer} explanation={result.explanation} />
       </div>
     </div>
   );

--- a/frontend/src/hooks/useKarutaReading.js
+++ b/frontend/src/hooks/useKarutaReading.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { API_BASE_URL } from "../config";
+import { phraseKey } from "../utils/phraseKey";
 
 // 未読み札から次に読み上げる1件を選ぶ（プリフェッチと実際の選択で同じロジックを使う）
 const pickTargetPhrase = (unreadPhrases, sortOrder) => {
@@ -65,8 +66,8 @@ export function useKarutaReading({
   // この最後の1枚を読み上げている間だけ「次の札」を無効化する
   const isReadingLastPhrase = useMemo(() => {
     if (!isReading) return false;
-    const readKeys = new Set(currentHistory.map(p => `${p.category}:${p.id}`));
-    return allPhrasesForCategory.every(p => readKeys.has(`${p.category}:${p.id}`));
+    const readKeys = new Set(currentHistory.map(phraseKey));
+    return allPhrasesForCategory.every(p => readKeys.has(phraseKey(p)));
   }, [isReading, currentHistory, allPhrasesForCategory]);
 
   useEffect(() => {
@@ -239,8 +240,8 @@ export function useKarutaReading({
       return;
     }
 
-    const readKeys = new Set(currentHistory.map(p => `${p.category}:${p.id}`));
-    const unreadPhrases = allPhrasesForCategory.filter(p => !readKeys.has(`${p.category}:${p.id}`));
+    const readKeys = new Set(currentHistory.map(phraseKey));
+    const unreadPhrases = allPhrasesForCategory.filter(p => !readKeys.has(phraseKey(p)));
     if (unreadPhrases.length === 0) {
       return;
     }
@@ -367,8 +368,8 @@ export function useKarutaReading({
     if (selectedCategories.length === 0 || allPhrasesForCategory.length === 0) return;
 
     try {
-      const readKeys = new Set(currentHistory.map(p => `${p.category}:${p.id}`));
-      let unreadPhrases = allPhrasesForCategory.filter(p => !readKeys.has(`${p.category}:${p.id}`));
+      const readKeys = new Set(currentHistory.map(phraseKey));
+      let unreadPhrases = allPhrasesForCategory.filter(p => !readKeys.has(phraseKey(p)));
 
       if (unreadPhrases.length === 0) {
         setIsAllRead(true);

--- a/frontend/src/hooks/useQuizRoomAdmin.js
+++ b/frontend/src/hooks/useQuizRoomAdmin.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { API_BASE_URL, WS_BASE_URL } from "../config";
 import { useQuizRoomSync } from "./useQuizRoomSync";
+import { useValueChange } from "./useValueChange";
 import { unlockAudioPlayback, playQuizSfx, playJudgmentSfx } from "../utils/audioUnlock";
 import { phraseKey } from "../utils/phraseKey";
 import { setRoomIdParam } from "../utils/quizRoomUrl";
@@ -79,10 +80,9 @@ export function useQuizRoomAdmin({
   // トップページ下部に表示する、開設中のクイズ大会ルーム一覧（issue #489）
   const [openQuizRooms, setOpenQuizRooms] = useState([]);
   // 早押し機能（issue #510）: 現在のラウンドで最初に回答した参加者名。次の札が
-  // 出題されたらリセットする（下記のブロードキャストeffect内。quizRoomBuzzRoundKeyは
-  // QuizRoomView.jsxのbuzzRoundKeyと同じ考え方で、resultの間はリセットしない）
+  // 出題されたらリセットする（下記のquizRoomBuzzRoundKey判定。QuizRoomView.jsxの
+  // buzzRoundKeyと同じ考え方で、resultの間はリセットしない）
   const [quizRoomBuzzedBy, setQuizRoomBuzzedBy] = useState(null);
-  const [quizRoomBuzzRoundKey, setQuizRoomBuzzRoundKey] = useState(null);
   // ポイント制（issue #519）: 名前→累計ポイントのマップ。管理者には参加者ごとの
   // ポイントを一覧表示する
   const [quizRoomPoints, setQuizRoomPoints] = useState({});
@@ -188,17 +188,12 @@ export function useQuizRoomAdmin({
   // 管理者セッション復帰（issue #697）: switchToAdminModeで保存済みトークンを使った
   // 復帰を試みている間、接続が確立できれば復帰成功とみなして監視を終了する。
   // 逆に接続がエラーになった場合は、トークンが無効（ルーム失効・削除済み等）と
-  // 判断し、保存済みトークンを破棄したうえで通常の参加者フローへフォールバックする。
-  // レンダー中のstate調整パターン（QuizRoomView.jsxのbuzzRoundKey判定と同じ考え方）で、
-  // 副作用を伴わないstate更新はuseEffectを介さずレンダー中に直接行う
-  // （react-hooks/set-state-in-effect対策）
-  const [lastRestoreCheckedStatus, setLastRestoreCheckedStatus] = useState(quizRoomConnectionStatus);
-  if (quizRoomConnectionStatus !== lastRestoreCheckedStatus) {
-    setLastRestoreCheckedStatus(quizRoomConnectionStatus);
+  // 判断し、保存済みトークンを破棄したうえで通常の参加者フローへフォールバックする
+  useValueChange(quizRoomConnectionStatus, (nextStatus) => {
     if (isRestoringAdminSession) {
-      if (quizRoomConnectionStatus === "connected") {
+      if (nextStatus === "connected") {
         setIsRestoringAdminSession(false);
-      } else if (quizRoomConnectionStatus === "error") {
+      } else if (nextStatus === "error") {
         setIsRestoringAdminSession(false);
         clearStoredAdminSession();
         setAdminSessionRoomId(null);
@@ -209,7 +204,7 @@ export function useQuizRoomAdmin({
         setView("quiz-room");
       }
     }
-  }
+  });
 
   // 早押し正誤判定（issue #546）: 「正解」「不正解」を選んだら判定結果をサーバーへ
   // 送信し、モーダルはローカルで即座に閉じる（roundResetのブロードキャストは
@@ -239,16 +234,12 @@ export function useQuizRoomAdmin({
   // broadcastPhraseは次の札が出題されるたびに更新され、resetReadingState（ゲームリセット・
   // カテゴリ選び直し）でnullへ戻るため、これだけでresult表示中の保持・リセット時のクリアの
   // 両方が自然に成り立つ（displayContentの型を個別に見る必要がない）
-  // レンダー中のstate調整パターン（QuizRoomView.jsxのbuzzRoundKey判定と同じ考え方）で、
-  // 副作用を伴わないstate更新はuseEffectを介さずレンダー中に直接行う
-  // （react-hooks/set-state-in-effect対策）
-  const nextQuizRoomBuzzRoundKey = quizRoom && broadcastPhrase
+  const quizRoomBuzzRoundKey = quizRoom && broadcastPhrase
     ? phraseKey(broadcastPhrase.content)
     : null;
-  if (nextQuizRoomBuzzRoundKey !== quizRoomBuzzRoundKey) {
-    setQuizRoomBuzzRoundKey(nextQuizRoomBuzzRoundKey);
+  useValueChange(quizRoomBuzzRoundKey, () => {
     setQuizRoomBuzzedBy(null);
-  }
+  });
 
   // 次の札のブロードキャスト（issue #781）: 管理者自身の画面演出（イントロ音声＋3秒待ち＋
   // フェード、useKarutaReading.js）を待たず、次の札が確定した時点（broadcastPhraseの

--- a/frontend/src/hooks/useQuizRoomAdmin.js
+++ b/frontend/src/hooks/useQuizRoomAdmin.js
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
 import { API_BASE_URL, WS_BASE_URL } from "../config";
 import { useQuizRoomSync } from "./useQuizRoomSync";
-import { unlockAudioPlayback, playQuizSfx } from "../utils/audioUnlock";
+import { unlockAudioPlayback, playQuizSfx, playJudgmentSfx } from "../utils/audioUnlock";
+import { phraseKey } from "../utils/phraseKey";
+import { setRoomIdParam } from "../utils/quizRoomUrl";
 
 // クイズ大会モード（issue #470）でuseQuizRoomSyncにonStateを渡す際の既定値。
 // 管理者側は自身のゲーム状態が唯一の正であり、サーバーから送り返される状態を
@@ -146,10 +148,7 @@ export function useQuizRoomAdmin({
     onState: noop,
     onBuzz: (buzzedBy) => {
       // issue #613: 参加者の早押しを管理者側にも音で通知する
-      // issue #679: base: "./"（vite.config.js）でサブパス配下にデプロイされるため、
-      // 絶対パス（先頭スラッシュ）だとドメインルート宛になり音声ファイルが見つからず
-      // NotSupportedErrorになる。favicon.png等と同じ相対パスにする
-      playQuizSfx("buzz", "quiz-buzz.mp3").catch(() => {});
+      playQuizSfx("buzz").catch(() => {});
       // issue #788: 参加者側（issue #696のstopSharedAudio）と同様、早押し発生時点で
       // 管理者自身の読み上げ音声・演出も止める。止めないと、参加者の誰かが早押しした
       // 後も管理者の本編音声・3秒待ち・フェード演出がそのまま進行し続けてしまう。
@@ -226,7 +225,7 @@ export function useQuizRoomAdmin({
     // issue #613: 正誤判定した瞬間に管理者側でも結果を音で確認できるようにする。
     // ボタン押下という実際のユーザー操作の中で呼ぶため、事前のunlockAudioPlayback()
     // なしでも再生できる
-    playQuizSfx(correct ? "correct" : "incorrect", correct ? "quiz-correct.mp3" : "quiz-incorrect.mp3").catch(() => {});
+    playJudgmentSfx(correct).catch(() => {});
     if (correct) {
       await revealCurrentResult(winner);
     }
@@ -244,7 +243,7 @@ export function useQuizRoomAdmin({
   // 副作用を伴わないstate更新はuseEffectを介さずレンダー中に直接行う
   // （react-hooks/set-state-in-effect対策）
   const nextQuizRoomBuzzRoundKey = quizRoom && broadcastPhrase
-    ? `${broadcastPhrase.content.category}:${broadcastPhrase.content.id}`
+    ? phraseKey(broadcastPhrase.content)
     : null;
   if (nextQuizRoomBuzzRoundKey !== quizRoomBuzzRoundKey) {
     setQuizRoomBuzzRoundKey(nextQuizRoomBuzzRoundKey);
@@ -340,9 +339,7 @@ export function useQuizRoomAdmin({
     // ブラウザの自動再生ポリシー対策（issue #497）: この参加操作（クリック）に
     // 便乗して無音再生しておき、参加後の自動再生が通りやすくする
     unlockAudioPlayback();
-    const params = new URLSearchParams(window.location.search);
-    params.set("roomId", roomId);
-    window.history.pushState({}, "", `?${params.toString()}`);
+    setRoomIdParam(roomId);
     setView("quiz-room");
   };
 

--- a/frontend/src/hooks/useValueChange.js
+++ b/frontend/src/hooks/useValueChange.js
@@ -1,0 +1,18 @@
+import { useState } from "react";
+
+// issue #800: 「前回レンダー時の値と比較し、変わっていれば副作用の無いstate更新を
+// 同期的に行う」という「レンダー中のstate調整」パターン（useEffect内での
+// 無条件setStateがreact-hooks/set-state-in-effectに抵触するのを避けるため、
+// Reactが推奨する代替手段）が、早押しラウンドキーの判定・接続状態の監視・
+// roomId変更の検知などに同型で繰り返し現れていたため共通化した。
+// onChangeは副作用を伴わない同期的なstate更新のみを行うこと（レンダー中に
+// 呼ばれるため、fetch等の非同期処理やDOM操作はuseEffectに書くこと）。
+// value自体の導出ロジック（前回値への依存を含む複雑な分岐等）はこのhookの
+// 対象外とし、呼び出し側に委ねる
+export function useValueChange(value, onChange) {
+  const [previous, setPrevious] = useState(value);
+  if (value !== previous) {
+    setPrevious(value);
+    onChange(value, previous);
+  }
+}

--- a/frontend/src/hooks/useValueChange.test.js
+++ b/frontend/src/hooks/useValueChange.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useValueChange } from './useValueChange';
+
+describe('useValueChange', () => {
+  it('does not call onChange on the initial render', () => {
+    const onChange = vi.fn();
+    renderHook(() => useValueChange('a', onChange));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('calls onChange with the new and previous values when the value changes between renders', () => {
+    const onChange = vi.fn();
+    const { rerender } = renderHook(({ value }) => useValueChange(value, onChange), {
+      initialProps: { value: 'a' },
+    });
+
+    rerender({ value: 'b' });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('b', 'a');
+  });
+
+  it('does not call onChange again on a re-render with the same value', () => {
+    const onChange = vi.fn();
+    const { rerender } = renderHook(({ value }) => useValueChange(value, onChange), {
+      initialProps: { value: 'a' },
+    });
+
+    rerender({ value: 'a' });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('treats null and other falsy values as valid, distinct values', () => {
+    const onChange = vi.fn();
+    const { rerender } = renderHook(({ value }) => useValueChange(value, onChange), {
+      initialProps: { value: 'key-1' },
+    });
+
+    rerender({ value: null });
+
+    expect(onChange).toHaveBeenCalledWith(null, 'key-1');
+  });
+});

--- a/frontend/src/utils/audioUnlock.js
+++ b/frontend/src/utils/audioUnlock.js
@@ -23,7 +23,20 @@ let sharedAudio = null;
 // "intro"は参加者側のイントロ音（太鼓の音、issue #786）用。sharedAudio（本編音声）とは
 // 別の要素が必要な理由は同じ（本編音声の取得と並行して鳴らしたいため、issue #796）
 const sharedSfxAudio = {};
-const QUIZ_SFX_NAMES = ["buzz", "correct", "incorrect", "intro"];
+// issue #800: 論理名とファイル名の対応を1箇所にまとめる。以前は呼び出し側
+// （playQuizSfx(name, ファイル名)）が毎回両方を手書きしており、ファイル名を
+// 変える際（issue #679の相対パス修正等）に全呼び出し箇所を漏れなく直す必要が
+// あった。
+// issue #679: base: "./"（vite.config.js）でサブパス配下にデプロイされるため、
+// 絶対パス（先頭スラッシュ）だとドメインルート宛になり音声ファイルが見つからず
+// NotSupportedErrorになる。favicon.png等と同じ相対パスにする
+const QUIZ_SFX_SOURCES = {
+  buzz: "quiz-buzz.mp3",
+  correct: "quiz-correct.mp3",
+  incorrect: "quiz-incorrect.mp3",
+  intro: "wadodon.mp3",
+};
+const QUIZ_SFX_NAMES = Object.keys(QUIZ_SFX_SOURCES);
 
 function getSharedAudio() {
   if (!sharedAudio) {
@@ -74,12 +87,21 @@ export function stopSharedAudio() {
 }
 
 // issue #613: 早押し関連の効果音（回答ボタン/正解/不正解）を再生する。
-// nameは"buzz"|"correct"|"incorrect"|"intro"のいずれか
-export function playQuizSfx(name, src) {
+// nameは"buzz"|"correct"|"incorrect"|"intro"のいずれか。再生するファイルは
+// QUIZ_SFX_SOURCESから引く
+export function playQuizSfx(name) {
   const audio = getSharedSfxAudio(name);
   audio.pause();
-  audio.src = src;
+  audio.src = QUIZ_SFX_SOURCES[name];
   return audio.play();
+}
+
+// issue #800: 早押し正誤判定の効果音（correct/incorrect）は、管理者側
+// （judgeQuizRoomBuzz）・参加者側（handleRoundReset/showCelebration）の
+// どちらも「correctかどうかのbooleanから対応する効果音名を選んでplayQuizSfxを
+// 呼ぶ」という同型の呼び出しだったため、ヘルパーとしてまとめる
+export function playJudgmentSfx(correct) {
+  return playQuizSfx(correct ? "correct" : "incorrect");
 }
 
 // issue #796: イントロ音（太鼓の音）の再生完了を待てるバージョン。play()が返す
@@ -90,10 +112,10 @@ export function playQuizSfx(name, src) {
 // のplayAudioにも上限時間がある。太鼓の音は短い効果音のため、本編音声用の15秒より
 // 短い上限にする）
 const INTRO_SFX_TIMEOUT_MS = 5000;
-export function playQuizSfxAndWait(name, src) {
+export function playQuizSfxAndWait(name) {
   const audio = getSharedSfxAudio(name);
   audio.pause();
-  audio.src = src;
+  audio.src = QUIZ_SFX_SOURCES[name];
   return new Promise((resolve) => {
     let settled = false;
     const settle = () => {

--- a/frontend/src/utils/audioUnlock.test.js
+++ b/frontend/src/utils/audioUnlock.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { unlockAudioPlayback, playSharedAudio, playQuizSfx, stopSharedAudio, resetSharedAudioForTests } from './audioUnlock';
+import { unlockAudioPlayback, playSharedAudio, playQuizSfx, playJudgmentSfx, playQuizSfxAndWait, stopSharedAudio, resetSharedAudioForTests } from './audioUnlock';
 
 const audioInstances = [];
 let audioPlayImpl = () => Promise.resolve();
@@ -7,7 +7,15 @@ let audioPlayImpl = () => Promise.resolve();
 // App.test.jsxと同様の理由でアロー関数ではなく通常の関数式を使う（newで呼び出すため）
 window.Audio = vi.fn().mockImplementation(function (src) {
   this.src = src;
-  this.play = vi.fn(() => audioPlayImpl());
+  this.play = vi.fn(() => {
+    const result = audioPlayImpl();
+    // issue #796: playQuizSfxAndWaitはonendedの発火を待って解決するため、play()の
+    // 解決に続けて即座にonendedも発火させて模倣する。onendedはこの呼び出し時点の
+    // ものを束縛しておく（QuizRoomView.test.jsxと同じ理由）
+    const onendedAtCallTime = this.onended;
+    result.then(() => onendedAtCallTime?.()).catch(() => {});
+    return result;
+  });
   this.pause = vi.fn();
   audioInstances.push(this);
 });
@@ -87,38 +95,91 @@ describe('audioUnlock', () => {
     });
   });
 
-  describe('playQuizSfx (issue #613)', () => {
-    it('reuses the element that was already unlocked for the given name, pausing it and swapping the src', async () => {
+  describe('playQuizSfx (issue #613, #800)', () => {
+    it('reuses the element that was already unlocked for the given name, pausing it and swapping the src (issue #800: ファイル名はQUIZ_SFX_SOURCESから引く)', async () => {
       unlockAudioPlayback();
       // unlockAudioPlayback内ではsharedAudio(narration)の直後にbuzz/correct/incorrectの
       // 順で生成されるため、audioInstances[1]が"buzz"の共有要素になる
       const unlockedBuzzInstance = audioInstances[1];
 
-      await playQuizSfx('buzz', '/quiz-buzz.mp3');
+      await playQuizSfx('buzz');
 
       expect(audioInstances).toHaveLength(5);
       expect(audioInstances[1]).toBe(unlockedBuzzInstance);
-      expect(unlockedBuzzInstance.src).toBe('/quiz-buzz.mp3');
+      expect(unlockedBuzzInstance.src).toBe('quiz-buzz.mp3');
     });
 
     it('lazily creates a shared element per name if unlockAudioPlayback was never called', async () => {
-      await playQuizSfx('correct', '/quiz-correct.mp3');
+      await playQuizSfx('correct');
 
       expect(audioInstances).toHaveLength(1);
-      expect(audioInstances[0].src).toBe('/quiz-correct.mp3');
+      expect(audioInstances[0].src).toBe('quiz-correct.mp3');
       expect(audioInstances[0].play).toHaveBeenCalled();
     });
 
     it('keeps buzz/correct/incorrect on separate elements so playing one does not touch another', async () => {
-      await playQuizSfx('buzz', '/quiz-buzz.mp3');
-      await playQuizSfx('correct', '/quiz-correct.mp3');
+      await playQuizSfx('buzz');
+      await playQuizSfx('correct');
 
       // 名前ごとに別要素が作られ、互いのsrc/play呼び出し回数に影響しないこと
       expect(audioInstances).toHaveLength(2);
-      expect(audioInstances[0].src).toBe('/quiz-buzz.mp3');
+      expect(audioInstances[0].src).toBe('quiz-buzz.mp3');
       expect(audioInstances[0].play).toHaveBeenCalledTimes(1);
-      expect(audioInstances[1].src).toBe('/quiz-correct.mp3');
+      expect(audioInstances[1].src).toBe('quiz-correct.mp3');
       expect(audioInstances[1].play).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('playJudgmentSfx (issue #800)', () => {
+    it('plays the correct sound effect when correct is true', async () => {
+      await playJudgmentSfx(true);
+
+      expect(audioInstances).toHaveLength(1);
+      expect(audioInstances[0].src).toBe('quiz-correct.mp3');
+    });
+
+    it('plays the incorrect sound effect when correct is false', async () => {
+      await playJudgmentSfx(false);
+
+      expect(audioInstances).toHaveLength(1);
+      expect(audioInstances[0].src).toBe('quiz-incorrect.mp3');
+    });
+  });
+
+  describe('playQuizSfxAndWait (issue #796)', () => {
+    it('resolves once the audio finishes playing (onended), not merely once playback starts', async () => {
+      let resolvePlay;
+      audioPlayImpl = () => new Promise((resolve) => { resolvePlay = resolve; });
+
+      let settled = false;
+      const promise = playQuizSfxAndWait('intro').then(() => { settled = true; });
+
+      expect(audioInstances).toHaveLength(1);
+      expect(audioInstances[0].src).toBe('wadodon.mp3');
+      // まだ再生完了（onended相当）していないので解決していない
+      expect(settled).toBe(false);
+
+      resolvePlay();
+      await promise;
+
+      expect(settled).toBe(true);
+    });
+
+    it('falls back to resolving after a timeout if onended never fires', async () => {
+      vi.useFakeTimers();
+      try {
+        // onendedもonerrorも発火しない（play()が解決も拒否もしない）環境を模倣する
+        audioPlayImpl = () => new Promise(() => {});
+
+        let settled = false;
+        playQuizSfxAndWait('intro').then(() => { settled = true; });
+
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(settled).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/frontend/src/utils/phraseKey.js
+++ b/frontend/src/utils/phraseKey.js
@@ -1,0 +1,7 @@
+// issue #800: 札を一意に識別するキー（`${category}:${id}`）の生成が、既読判定
+// （useKarutaReading.js）・早押しラウンドキーの判定（useQuizRoomAdmin.js、
+// QuizRoomView.jsx）に散在していた。フォーマットの暗黙の一致（片方だけ変えると
+// 既読判定や早押しリセットが壊れる）を1箇所へ集約する
+export function phraseKey(phrase) {
+  return `${phrase.category}:${phrase.id}`;
+}

--- a/frontend/src/utils/quizRoomUrl.js
+++ b/frontend/src/utils/quizRoomUrl.js
@@ -1,0 +1,20 @@
+// issue #800: クイズ大会モードの?roomId=クエリパラメータの読み書きが、
+// QuizRoomView.jsx（goBack/retryRoomCode、削除方向）とuseQuizRoomAdmin.js
+// （joinQuizRoom、設定方向）にそれぞれ手書きで重複していたため集約する。
+// 他のクエリパラメータ（?view=等）は保持したまま操作する
+
+// roomIdを?roomId=として設定する
+export function setRoomIdParam(roomId) {
+  const params = new URLSearchParams(window.location.search);
+  params.set("roomId", roomId);
+  window.history.pushState({}, "", `?${params.toString()}`);
+}
+
+// ?roomId=を取り除く。他のクエリパラメータが残っていれば維持し、無ければ
+// クエリ自体を取り除く
+export function clearRoomIdParam() {
+  const params = new URLSearchParams(window.location.search);
+  params.delete("roomId");
+  const query = params.toString();
+  window.history.pushState({}, "", query ? `?${query}` : window.location.pathname);
+}

--- a/frontend/src/views/QuizRoomInfoView.jsx
+++ b/frontend/src/views/QuizRoomInfoView.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import QRCode from "qrcode";
-import { mergeParticipantsWithPoints } from "../utils/quizRoomParticipants";
+import QuizRoomParticipantTable from "../components/QuizRoomParticipantTable";
 
 // クイズ大会モード（issue #470）の管理者向けルーム情報画面（issue #547）。
 // 以前は通常のゲーム画面にインラインで展開する折りたたみパネル
@@ -19,12 +19,6 @@ function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoom
       .then(setQrDataUrl)
       .catch((error) => console.error("Failed to generate QR code:", error));
   }, [inviteUrl]);
-
-  // 参加者一覧（issue #545）: まだ得点していない参加者も0ptとして含めた1つのリストに
-  // 統合して表示する。以前は通常のゲーム画面にインラインで表示していたが、ルーム情報
-  // 画面（この画面）の下部へ移動し、表形式に変更した（issue #587）。
-  // 回答数（issue #698）: 早押しして正誤判定された累計回数（attempts）も併せて表示する
-  const participantList = mergeParticipantsWithPoints(quizRoomParticipants, quizRoomPoints, quizRoomAnswerCounts);
 
   // ポイントリセット（issue #615）: 同じルームで2ゲーム目を始める際、前のゲームの
   // ポイントを引き継がずに再スタートしたい場合に管理者が明示的に実行する。取り消せない
@@ -80,38 +74,19 @@ function QuizRoomInfoView({ setView, roomId, quizRoomParticipants = [], quizRoom
           </button>
         </div>
       </div>
-      {participantList.length > 0 && (
-        <div className="mx-auto mt-5 text-start" style={{ maxWidth: "360px" }}>
-          <p className="text-muted small mb-2">参加者一覧</p>
-          <table className="table table-sm table-bordered bg-white mb-0">
-            <thead>
-              <tr>
-                <th scope="col">名前</th>
-                <th scope="col">接続</th>
-                <th scope="col" className="text-end">回答数</th>
-                <th scope="col" className="text-end">正答数</th>
-              </tr>
-            </thead>
-            <tbody>
-              {participantList.map(({ name, points, attempts, connected }) => (
-                <tr key={name}>
-                  <td className="notranslate">{name}</td>
-                  <td className={connected ? "text-success" : "text-muted"}>
-                    {connected ? "接続中" : "切断済み"}
-                  </td>
-                  <td className="text-end">{attempts}</td>
-                  <td className="text-end">{points}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+      <QuizRoomParticipantTable
+        participantNames={quizRoomParticipants}
+        points={quizRoomPoints}
+        answerCounts={quizRoomAnswerCounts}
+        className="mt-5"
+        footer={(
           <div className="text-end mt-2">
             <button type="button" onClick={handleResetPoints} className="btn btn-sm btn-outline-danger">
               ポイントをリセット
             </button>
           </div>
-        </div>
-      )}
+        )}
+      />
       <div className="mt-5">
         <button type="button" onClick={handleCloseRoom} className="btn btn-sm btn-outline-danger rounded-pill px-3">
           ルームを閉じる

--- a/frontend/src/views/QuizRoomInfoView.test.jsx
+++ b/frontend/src/views/QuizRoomInfoView.test.jsx
@@ -27,52 +27,21 @@ describe('QuizRoomInfoView', () => {
     expect(urlInput).toBeInTheDocument();
   });
 
-  it('shows the participant list as a table at the bottom of the screen, sorted by points descending, with a connection status column (issue #587, #599)', () => {
+  // 参加者一覧テーブルの並び順・接続状態・回答数/正答数の詳細な検証は
+  // QuizRoomParticipantTable.test.jsx（issue #800で共通化）に集約した。ここでは
+  // 「この画面がテーブルへ正しくpropsを渡していること」だけを薄く確認する
+  it('shows the participant list as a table at the bottom of the screen (issue #587, #599)', () => {
     render(
       <QuizRoomInfoView
         setView={vi.fn()}
         roomId="ABC123"
-        quizRoomParticipants={['たろう', 'はなこ', 'じろう']}
+        quizRoomParticipants={['たろう']}
         quizRoomPoints={{ たろう: 3 }}
       />
     );
 
     expect(screen.getByText('参加者一覧')).toBeInTheDocument();
-    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
-    // たろう(3pt)がまだ得点していないじろう・はなこ(0pt)より先（降順、同点は名前昇順）
-    expect(rows).toEqual(['たろう接続中03', 'じろう接続中00', 'はなこ接続中00']);
-  });
-
-  it('shows a participant as disconnected when they are no longer in the connected-participants list, while keeping their earned points visible (issue #599, #602)', () => {
-    render(
-      <QuizRoomInfoView
-        setView={vi.fn()}
-        roomId="ABC123"
-        quizRoomParticipants={['はなこ']}
-        quizRoomPoints={{ たろう: 2 }}
-      />
-    );
-
-    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
-    expect(rows).toEqual(['たろう切断済み02', 'はなこ接続中00']);
-  });
-
-  it('shows the attempt count (回答数) and correct count (正答数) as separate columns, keeping them after a participant disconnects (issue #698)', () => {
-    render(
-      <QuizRoomInfoView
-        setView={vi.fn()}
-        roomId="ABC123"
-        quizRoomParticipants={['はなこ']}
-        quizRoomPoints={{ たろう: 2 }}
-        quizRoomAnswerCounts={{ たろう: { attempts: 3, correct: 2 }, はなこ: { attempts: 1, correct: 0 } }}
-      />
-    );
-
-    expect(screen.getByText('回答数')).toBeInTheDocument();
-    expect(screen.getByText('正答数')).toBeInTheDocument();
-    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
-    // たろうは切断済みでも回答数・正答数がpointsと同様に保持され続ける
-    expect(rows).toEqual(['たろう切断済み32', 'はなこ接続中10']);
+    expect(screen.getByText('たろう')).toBeInTheDocument();
   });
 
   it('does not show the participant list section when there are no participants yet', () => {

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuizRoomSync, CONNECTION_STATUS_LABEL } from "../hooks/useQuizRoomSync";
 import { useLocalStorageState } from "../hooks/useLocalStorageState";
+import { useValueChange } from "../hooks/useValueChange";
 import { API_BASE_URL } from "../config";
 import { unlockAudioPlayback, playSharedAudio, playQuizSfx, playQuizSfxAndWait, playJudgmentSfx, stopSharedAudio } from "../utils/audioUnlock";
 import { phraseKey } from "../utils/phraseKey";
@@ -132,14 +133,10 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
   };
 
   // ルームコードの事前確認（issue #616）: joinRoomIdが変わるたびに、前回の
-  // 「存在しない」判定を持ち越さないようリセットする。レンダー中のstate調整
-  // パターン（下記のcurrentBuzzRoundKey判定と同じ考え方）で行い、useEffect内での
-  // 無条件setState（react-hooks/set-state-in-effect）を避ける
-  const [lastCheckedRoomId, setLastCheckedRoomId] = useState(joinRoomId);
-  if (joinRoomId !== lastCheckedRoomId) {
-    setLastCheckedRoomId(joinRoomId);
+  // 「存在しない」判定を持ち越さないようリセットする
+  useValueChange(joinRoomId, () => {
     setRoomInvalid(false);
-  }
+  });
 
   // 実際にWebSocket接続を試みる前にGET /quiz-roomで存在確認する
   useEffect(() => {
@@ -228,7 +225,11 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
   // - それ以外（"initial"等）: ラウンドなし（null）とし、管理者がゲームをリセットした
   //   場合等に、古い回答者情報が次のラウンドへ持ち越されないようにする
   // レンダー中に前回値と比較して直接更新する、Reactが推奨する「レンダー中のstate調整」
-  // パターン（useEffect内でのsetStateはeslintのreact-hooks/set-state-in-effectに抵触するため使わない）
+  // パターン（useEffect内でのsetStateはeslintのreact-hooks/set-state-in-effectに抵触するため使わない）。
+  // issue #800: 同種のパターンはuseValueChangeへ共通化したが、このキーの導出自体が
+  // 「直前のラウンドキー（lastBuzzRoundKey）を参照して"result"中は維持する」という
+  // 前回値への依存を持つため、値の変化だけを検知するuseValueChangeにはそのまま乗らず、
+  // ここでは個別に扱う
   let currentBuzzRoundKey = lastBuzzRoundKey;
   if (roomState?.type === "phrase" && roomState.content?.id) {
     currentBuzzRoundKey = phraseKey(roomState.content);

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -3,9 +3,10 @@ import { useQuizRoomSync, CONNECTION_STATUS_LABEL } from "../hooks/useQuizRoomSy
 import { useLocalStorageState } from "../hooks/useLocalStorageState";
 import { API_BASE_URL } from "../config";
 import { unlockAudioPlayback, playSharedAudio, playQuizSfx, playQuizSfxAndWait, playJudgmentSfx, stopSharedAudio } from "../utils/audioUnlock";
-import { mergeParticipantsWithPoints } from "../utils/quizRoomParticipants";
 import { phraseKey } from "../utils/phraseKey";
 import { clearRoomIdParam } from "../utils/quizRoomUrl";
+import AnswerAndExplanation from "../components/AnswerAndExplanation";
+import QuizRoomParticipantTable from "../components/QuizRoomParticipantTable";
 
 // クイズ大会モード（issue #470）の参加者用入口（閲覧専用）。
 // ルームコードの直接入力、または招待URL（?roomId=...）からの参加に対応する。
@@ -49,18 +50,7 @@ function renderParticipantContent(roomState) {
           )}
           <div className="text-muted mb-2">所要時間</div>
           <div className="display-4 fw-bold text-dark mb-2">{r.time?.toFixed(2)}<span className="fs-4">秒</span></div>
-          {r.answer && r.answer !== "-" && (
-            <>
-              <div className="text-muted mt-4 mb-2">答え</div>
-              <div className="h4 fw-bold text-dark">{r.answer}</div>
-            </>
-          )}
-          {r.explanation && r.explanation !== "-" && (
-            <>
-              <div className="text-muted mt-4 mb-2">解説</div>
-              <div className="fs-6 text-dark">{r.explanation}</div>
-            </>
-          )}
+          <AnswerAndExplanation answer={r.answer} explanation={r.explanation} />
         </div>
       </div>
     );
@@ -549,40 +539,16 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
             </button>
           </div>
         )}
-        {(() => {
-          // 参加者一覧（issue #545）: まだ得点していない参加者も0ptとして含めた
-          // 1つのリストに統合して表示する（管理者画面と同じ並び順）。
-          // 表形式・接続ステータス表示、回答ボタンより下への配置はissue #599で対応。
-          // 回答数（issue #698）: 早押しして正誤判定された累計回数（attempts）も併せて表示する
-          const participantList = mergeParticipantsWithPoints(participants, points, answerCounts);
-          return participantList.length > 0 && (
-            <div className="mx-auto mt-4 text-start" style={{ maxWidth: "360px" }}>
-              <p className="text-muted small mb-2">参加者一覧</p>
-              <table className="table table-sm table-bordered bg-white mb-0">
-                <thead>
-                  <tr>
-                    <th scope="col">名前</th>
-                    <th scope="col">接続</th>
-                    <th scope="col" className="text-end">回答数</th>
-                    <th scope="col" className="text-end">正答数</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {participantList.map(({ name, points: pt, attempts, connected }) => (
-                    <tr key={name}>
-                      <td className={`notranslate ${name === confirmedName ? "fw-bold" : ""}`}>{name}</td>
-                      <td className={connected ? "text-success" : "text-muted"}>
-                        {connected ? "接続中" : "切断済み"}
-                      </td>
-                      <td className="text-end">{attempts}</td>
-                      <td className="text-end">{pt}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          );
-        })()}
+        {/* 参加者一覧（issue #545）: まだ得点していない参加者も0ptとして含めた1つのリストに
+            統合して表示する（管理者画面と同じ並び順）。表形式・接続ステータス表示、回答ボタン
+            より下への配置はissue #599で対応。回答数（issue #698）: 早押しして正誤判定された
+            累計回数（attempts）も併せて表示する */}
+        <QuizRoomParticipantTable
+          participantNames={participants}
+          points={points}
+          answerCounts={answerCounts}
+          highlightName={confirmedName}
+        />
         {phraseHistory.length > 0 && (
           <div className="mx-auto mt-4 text-center" style={{ maxWidth: "480px" }}>
             <button

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -2,8 +2,10 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuizRoomSync, CONNECTION_STATUS_LABEL } from "../hooks/useQuizRoomSync";
 import { useLocalStorageState } from "../hooks/useLocalStorageState";
 import { API_BASE_URL } from "../config";
-import { unlockAudioPlayback, playSharedAudio, playQuizSfx, playQuizSfxAndWait, stopSharedAudio } from "../utils/audioUnlock";
+import { unlockAudioPlayback, playSharedAudio, playQuizSfx, playQuizSfxAndWait, playJudgmentSfx, stopSharedAudio } from "../utils/audioUnlock";
 import { mergeParticipantsWithPoints } from "../utils/quizRoomParticipants";
+import { phraseKey } from "../utils/phraseKey";
+import { clearRoomIdParam } from "../utils/quizRoomUrl";
 
 // クイズ大会モード（issue #470）の参加者用入口（閲覧専用）。
 // ルームコードの直接入力、または招待URL（?roomId=...）からの参加に対応する。
@@ -125,10 +127,7 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
   // ルームコード入力画面ではなく以前のルームへ入室しようとする画面になってしまう。
   // そのため離脱時に明示的にクエリから取り除く（他のクエリパラメータは保持する）
   const goBack = () => {
-    const params = new URLSearchParams(window.location.search);
-    params.delete("roomId");
-    const query = params.toString();
-    window.history.pushState({}, "", query ? `?${query}` : window.location.pathname);
+    clearRoomIdParam();
     setView("game");
   };
 
@@ -136,10 +135,7 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
   // goBackと同様にURLの?roomId=を取り除きつつ、通常のゲーム画面へは戻らず
   // この画面のルームコード入力欄に留まる
   const retryRoomCode = () => {
-    const params = new URLSearchParams(window.location.search);
-    params.delete("roomId");
-    const query = params.toString();
-    window.history.pushState({}, "", query ? `?${query}` : window.location.pathname);
+    clearRoomIdParam();
     setRoomInvalid(false);
     setJoinRoomId(null);
     setManualRoomId("");
@@ -191,10 +187,7 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
   const handleRoundReset = ({ excludedName, answerCounts: nextAnswerCounts }) => {
     // issue #613: 不正解の判定結果を参加者全員に音で伝える（除外された本人以外にとっては
     // 「次に早押しできるようになった」合図でもあるが、判定内容自体は不正解のため同じ音を使う）
-    // issue #679: base: "./"（vite.config.js）でサブパス配下にデプロイされるため、
-    // 絶対パス（先頭スラッシュ）だとドメインルート宛になり音声ファイルが見つからず
-    // NotSupportedErrorになる。favicon.png等と同じ相対パスにする
-    playQuizSfx("incorrect", "quiz-incorrect.mp3").catch(() => {});
+    playJudgmentSfx(false).catch(() => {});
     // issue #680: 除外された本人はbuzzedByを残したままにするとexcludedThisRoundが
     // trueになっても表示分岐（下記JSX）でbuzzedByが優先され、「〇〇さんが回答中」の
     // 表示が次の札が届くまで残り続けてしまう。自分自身が不正解と判定されたことを
@@ -217,7 +210,12 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
     onState: setRoomState,
     onBuzz: (buzzedByParam) => {
       // issue #613: 早押し発生（自分・他の参加者いずれの場合も）を音で通知する
-      playQuizSfx("buzz", "quiz-buzz.mp3").catch(() => {});
+      playQuizSfx("buzz").catch(() => {});
+      // issue #800: 従来はhandleBuzz（自分が押した場合のみ）でしか読み上げを
+      // 止めておらず、他の参加者が早押ししてもこの端末の読み上げは流れ続けて
+      // いた。管理者側（issue #788、誰の早押しでも止める）と揃え、早押しの
+      // ブロードキャストを受け取った時点（自分・他の参加者いずれも）で止める
+      stopSharedAudio();
       setBuzzedBy(buzzedByParam);
     },
     onPoints: (nextPoints, nextAnswerCounts) => {
@@ -243,7 +241,7 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
   // パターン（useEffect内でのsetStateはeslintのreact-hooks/set-state-in-effectに抵触するため使わない）
   let currentBuzzRoundKey = lastBuzzRoundKey;
   if (roomState?.type === "phrase" && roomState.content?.id) {
-    currentBuzzRoundKey = `${roomState.content.category}:${roomState.content.id}`;
+    currentBuzzRoundKey = phraseKey(roomState.content);
   } else if (roomState?.type !== "result") {
     currentBuzzRoundKey = null;
   }
@@ -267,7 +265,10 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
   // 後から届くbuzzブロードキャスト（自分の勝ち・他の参加者の勝ちいずれも）が
   // この仮の値を正しい値で上書きする
   const handleBuzz = () => {
-    // issue #696: 読み上げ中に回答ボタンが押された場合、読み上げを中断する
+    // issue #696: 読み上げ中に回答ボタンが押された場合、読み上げを中断する。
+    // サーバーへのbuzz送信・ブロードキャスト受信（onBuzz、issue #800で追加）を
+    // 待たず、押した瞬間に即座に止めるためここでも呼ぶ（onBuzz側の呼び出しと
+    // 二重になるがstopSharedAudioは冪等なので問題ない）
     stopSharedAudio();
     setBuzzedBy({ name: confirmedName });
     buzz();
@@ -301,7 +302,7 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
   // なった瞬間にだけ再生されるようdepsをshowCelebrationのみにする
   useEffect(() => {
     if (showCelebration) {
-      playQuizSfx("correct", "quiz-correct.mp3").catch(() => {});
+      playQuizSfx("correct").catch(() => {});
     }
   }, [showCelebration]);
 
@@ -363,7 +364,7 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
       return;
     }
     const { id, category, repeatCount, speechRate, lang, voiceId, announceCategory } = roomState.content;
-    const key = `${category}:${id}`;
+    const key = phraseKey(roomState.content);
     if (lastPlayedKeyRef.current === key) {
       return;
     }
@@ -385,7 +386,7 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
     // 太鼓の音と読み上げが重なって聞こえてしまっていた。本編音声の「取得」は太鼓の音の
     // 再生と並行して進め（余計な遅延を増やさないため）、「再生開始」だけを太鼓の音の
     // 完了後まで遅らせることで、管理者側（太鼓の音の後に読み上げを始める）と同じ順序にする
-    const introPromise = playQuizSfxAndWait("intro", "wadodon.mp3");
+    const introPromise = playQuizSfxAndWait("intro");
 
     let cancelled = false;
     (async () => {

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -811,6 +811,33 @@ describe('QuizRoomView', () => {
     expect(buzzMock).toHaveBeenCalled();
   });
 
+  it('also stops the currently-playing narration audio when a different participant buzzes in, not only when this participant buzzes (issue #800)', async () => {
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('/quiz-room?')) {
+        return { ok: true, json: async () => ({ exists: true }) };
+      }
+      return { ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }) };
+    });
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const narrationAudio = audioInstances[0];
+    narrationAudio.pause.mockClear();
+
+    // 自分ではなく他の参加者が早押しした場合
+    emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
+
+    expect(narrationAudio.pause).toHaveBeenCalled();
+  });
+
   it('does not play audio for a phrase that was already in progress when joining, while still on the name entry screen, and does not play it retroactively once the name is confirmed (issue #530)', async () => {
     fetch.mockResolvedValue({ ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }) });
     window.history.pushState({}, '', '?roomId=ABC123');

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -530,49 +530,21 @@ describe('QuizRoomView', () => {
     expect(screen.getByText('獲得ポイント: 2')).toBeInTheDocument();
   });
 
-  it('shows a combined participant list as a table (including 0pt participants), highlighting the confirmed participant\'s own name (issue #545, #599)', () => {
-    window.history.pushState({}, '', '?roomId=ABC123');
-    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
-    confirmName('はなこ');
-
-    emitParticipants(['はなこ', 'たろう', 'じろう']);
-    emitPoints({ たろう: 5 });
-
-    expect(screen.getByText('参加者一覧')).toBeInTheDocument();
-    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
-    expect(rows).toEqual(['たろう接続中05', 'じろう接続中00', 'はなこ接続中00']);
-
-    const ownEntry = screen.getByText('はなこ', { selector: 'td.fw-bold' });
-    expect(ownEntry).toBeInTheDocument();
-  });
-
-  it('shows a participant as disconnected once they leave, while keeping their earned points visible (issue #599, #602)', () => {
+  // 参加者一覧テーブルの並び順・接続状態・回答数/正答数の詳細な検証は
+  // QuizRoomParticipantTable.test.jsx（issue #800で共通化）に集約した。ここでは
+  // 「この画面がテーブルへ正しくpropsを渡していること」（自分の名前がhighlightNameとして
+  // 渡り太字になること）だけを確認する
+  it('shows a combined participant list as a table, highlighting the confirmed participant\'s own name (issue #545, #599)', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
     render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
     confirmName('はなこ');
 
     emitParticipants(['はなこ', 'たろう']);
-    emitPoints({ たろう: 2 });
 
-    // たろうが切断（participants一覧から名前が消える）。得点は残る
-    emitParticipants(['はなこ']);
-
-    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
-    expect(rows).toEqual(['たろう切断済み02', 'はなこ接続中00']);
-  });
-
-  it('shows the attempt count (回答数) and correct count (正答数) as separate columns in the participant list, keeping them after a participant disconnects (issue #698)', () => {
-    window.history.pushState({}, '', '?roomId=ABC123');
-    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
-    confirmName('はなこ');
-
-    emitParticipants(['はなこ']);
-    emitPoints({ たろう: 2 }, { たろう: { attempts: 3, correct: 2 }, はなこ: { attempts: 1, correct: 0 } });
-
-    expect(screen.getByText('回答数')).toBeInTheDocument();
-    expect(screen.getByText('正答数')).toBeInTheDocument();
-    const rows = screen.getAllByRole('row').slice(1).map((row) => row.textContent);
-    expect(rows).toEqual(['たろう切断済み32', 'はなこ接続中10']);
+    expect(screen.getByText('参加者一覧')).toBeInTheDocument();
+    const ownEntry = screen.getByText('はなこ', { selector: 'td.fw-bold' });
+    expect(ownEntry).toBeInTheDocument();
+    expect(screen.getByText('たろう').className).not.toContain('fw-bold');
   });
 
   it('sends the participant back to the name entry screen with an error when the server rejects a duplicate name (issue #519)', () => {


### PR DESCRIPTION
## Summary
issue #800の調査で見つかった、クイズ大会モードの管理者側（`useQuizRoomAdmin.js`等）と参加者側（`QuizRoomView.jsx`）の重複ロジックを共通化した。

- 早押し停止の非対称を解消: 管理者は誰の早押しでも読み上げを止める（issue #788）が、参加者は自分が押した場合のみだった（issue #696）。参加者側も他の参加者の早押しで止まるようにした
- 効果音のファイル名対応表（`QUIZ_SFX_SOURCES`）と`playJudgmentSfx(correct)`ヘルパーを追加し、5箇所の同型呼び出しを簡略化
- `${category}:${id}`のキー生成を`phraseKey()`に集約（6箇所）
- `?roomId=`クエリ操作を`utils/quizRoomUrl.js`に集約（完全重複していた4行 × 2）
- 答え・解説の表示ブロック（`ResultCard.jsx`・`QuizRoomView.jsx`・`QuizRoomBuzzJudgmentModal.jsx`の3箇所）を`<AnswerAndExplanation>`として共通化
- 参加者一覧テーブル（管理者側`QuizRoomInfoView.jsx`・参加者側`QuizRoomView.jsx`）を`<QuizRoomParticipantTable>`として共通化し、重複していたテストも新設コンポーネントのテストへ統合
- 「レンダー中のstate調整」パターン（早押しラウンドキー判定・接続状態監視・roomId変更検知）を`useValueChange`フックへ共通化（値の導出ロジック自体は各呼び出し側に残す方針。参加者側のラウンドキー判定は導出自体が直前値に依存するため対象外とした）

## Test plan
- [x] `cd frontend && npx eslint .` エラー0件
- [x] `cd frontend && npx vitest run` 250件成功（新規テスト：`QuizRoomParticipantTable.test.jsx`、`useValueChange.test.js`、効果音・早押し停止の非対称解消に関するテストを含む）
- [x] `cd backend && npx eslint . && npx vitest run` 1543件成功

Closes #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_