### PR TITLE
fix(frontend): E2Eの更新履歴画面スクリーンショットが長くなりすぎる問題を修正する（issue #795）

### DIFF
--- a/frontend/e2e/app-flows.spec.js
+++ b/frontend/e2e/app-flows.spec.js
@@ -74,7 +74,9 @@ test('normal read-aloud flow (category select -> phrase -> result), then browses
     // （例: 本機能自体の追加を記録したエントリ）、getByTextでは複数要素にマッチして
     // strict mode violationになる。見出し要素に限定する
     await expect(page.getByRole('heading', { name: '更新履歴' })).toBeVisible();
-    await captureScreenshot(page, testInfo, 'changelog-view', '更新履歴画面');
+    // issue #795: エントリの増加でページ全体の縦幅が際限なく長くなるため、
+    // 画面上部（ビューポート内）のみを撮影する
+    await captureScreenshot(page, testInfo, 'changelog-view', '更新履歴画面', { fullPage: false });
     await page.getByText('← 戻る').click();
     await expect(page.getByText('こども向け')).toBeVisible();
 

--- a/frontend/e2e/screenshot.js
+++ b/frontend/e2e/screenshot.js
@@ -15,9 +15,12 @@ export const SCREENSHOT_DIR = path.resolve(__dirname, '..', 'e2e-screenshots');
 // 添付、(2) CI側が公開できるようSCREENSHOT_DIRへのファイル書き出し、の両方を行う。
 // nameはファイル名（URLの一部になるため引き続きASCII安全な識別子を渡すこと）、
 // captionはPRコメント・Job Summaryの見出しに使われる日本語の説明文（issue #601）。
-// captionを省略した場合はCI側（dev-standards）がnameをそのまま見出しとして使う
-export async function captureScreenshot(page, testInfo, name, caption) {
-  const body = await page.screenshot({ fullPage: true });
+// captionを省略した場合はCI側（dev-standards）がnameをそのまま見出しとして使う。
+// issue #795: 既定はfullPage: true（ページ全体）だが、更新履歴画面のように
+// エントリの増加でページが際限なく長くなっていく画面では、fullPage: falseを
+// 明示的に渡すことでビューポート内（画面上部）だけを撮影できるようにする
+export async function captureScreenshot(page, testInfo, name, caption, { fullPage = true } = {}) {
+  const body = await page.screenshot({ fullPage });
   await testInfo.attach(name, { body, contentType: 'image/png' });
   fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
   fs.writeFileSync(path.join(SCREENSHOT_DIR, `${name}.png`), body);


### PR DESCRIPTION
## Summary
- 更新履歴画面のエントリ増加により、E2Eで撮影しているスクリーンショット（`changelog-view.png`）が`fullPage: true`のため縦に際限なく長くなり、PRコメント・Job Summaryで見づらくなっていた
- `captureScreenshot`に`fullPage`オプションを追加（デフォルトは`true`のまま後方互換）し、更新履歴画面の撮影呼び出しのみ`{ fullPage: false }`（ビューポート内・画面上部のみ）を渡すようにした

## Test plan
- [x] `cd frontend && npx eslint .` エラー0件
- [x] `cd frontend && npx vitest run` 250件成功（`e2e/`はvitestの対象外のため、実際の見た目確認はCIのE2E実行で行われる）
- [x] `cd backend && npx eslint . && npx vitest run` 1543件成功

Closes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_