### PR TITLE
chore(release): v1.54.8 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.54.8](https://github.com/bamiyanapp/karuta/compare/v1.54.7...v1.54.8) (2026-07-25)
+
+
+### Bug Fixes
+
+* **frontend:** E2Eの更新履歴画面スクリーンショットが長くなりすぎる問題を修正する（issue [#795](https://github.com/bamiyanapp/karuta/issues/795)） ([#802](https://github.com/bamiyanapp/karuta/issues/802)) ([d20bdad](https://github.com/bamiyanapp/karuta/commit/d20bdad2988bc2c54bdbc5f6396bc9d297cb5b15))
+
 ## [1.54.7](https://github.com/bamiyanapp/karuta/compare/v1.54.6...v1.54.7) (2026-07-24)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
+    "version": "1.54.8",
+    "date": "2026/07/25",
+    "body": "### Bug Fixes\n\n* **frontend:** E2Eの更新履歴画面スクリーンショットが長くなりすぎる問題を修正する（issue [#795](https://github.com/bamiyanapp/karuta/issues/795)） ([#802](https://github.com/bamiyanapp/karuta/issues/802)) ([d20bdad](https://github.com/bamiyanapp/karuta/commit/d20bdad2988bc2c54bdbc5f6396bc9d297cb5b15))"
+  },
+  {
     "version": "1.54.7",
-    "date": "2026/07/24",
+    "date": "2026/07/24 22:33",
     "body": "### Bug Fixes\n\n* **frontend:** 参加者側で太鼓の音と読み上げが重ならないよう、太鼓の後に読み上げを開始する（issue [#796](https://github.com/bamiyanapp/karuta/issues/796)） ([#797](https://github.com/bamiyanapp/karuta/issues/797)) ([0f20c71](https://github.com/bamiyanapp/karuta/commit/0f20c7126b1b20917ae9261453c124a2d04f45b4))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.54.7",
+  "version": "1.54.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.54.7",
+      "version": "1.54.8",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.54.7"
+  "version": "1.54.8"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。