### PR TITLE
feat(ci): CodeQLによる静的解析を導入する

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,22 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    # コード変更が無い期間もCodeQLのクエリセット自体の更新を検知するための定期実行
+    - cron: "0 3 * * 1"
+
+permissions:
+  # SARIFをGitHub Securityタブへアップロードするためにreusable-codeql.yml側が要求する権限。
+  # 呼び出し元（このワークフロー）で明示しない場合、リポジトリ既定のGITHUB_TOKEN権限
+  # （securityevents:writeを含まない）が上限になりアップロードが失敗するため必須
+  security-events: write
+  actions: read
+  contents: read
+
+jobs:
+  codeql:
+    uses: bamiyanapp/dev-standards/.github/workflows/reusable-codeql.yml@v1.8.0

--- a/docs/cicd-pipeline-specification.md
+++ b/docs/cicd-pipeline-specification.md
@@ -20,7 +20,7 @@ graph TD
 
 semantic-releaseの実行は`main`へのpush後（CD側の`release`ジョブ）で行われる。以前はPRの作業ブランチ上でマージ前に実行する方式だったが、GitHub Actionsの`pull_request`イベントで自動設定される`GITHUB_REF`（ワークフローYAMLの`env:`では上書き不可）により常にリリースが発行されない不具合があったため、`main`への実pushイベント上で実行する方式に修正した（[dev-standards#43](https://github.com/bamiyanapp/dev-standards/pull/43)）。
 
-karutaの`main`は「変更は必ずPR経由」のリポジトリルールで保護されているため、`release`ジョブによる`main`への直接pushはそのままではGH013エラーで拒否される。この問題に対応するため、直接pushが失敗した場合はローカルに作成済みのリリースコミットを新しいブランチへpushし、`main`へのPRを作成してAPI経由でsquash mergeするフォールバックが追加されている（[dev-standards#44](https://github.com/bamiyanapp/dev-standards/pull/44)、タグ名の導出方法の修正が[dev-standards#45](https://github.com/bamiyanapp/dev-standards/pull/45)、GitHub Release作成の冪等化が[dev-standards#46](https://github.com/bamiyanapp/dev-standards/pull/46)）。karuta運用者が意識する必要がある手順の違いはなく、`release`ジョブの結果として`new_release_published`が正しく出力されればデプロイジョブは通常どおり実行される。詳細は[dev-standards側ドキュメント](../dev-standards/docs/cicd-pipeline-specification.md#3-リリース運用)を参照。
+karutaの`main`は「変更は必ずPR経由」のリポジトリルールで保護されているため、`release`ジョブによる`main`への直接pushはそのままではGH013エラーで拒否される。この問題に対応するため、直接pushが失敗した場合はローカルに作成済みのリリースコミットを新しいブランチへpushし、`main`へのPRを作成してAPI経由でsquash mergeするフォールバックが追加されている（[dev-standards#44](https://github.com/bamiyanapp/dev-standards/pull/44)、タグ名の導出方法の修正が[dev-standards#45](https://github.com/bamiyanapp/dev-standards/pull/45)、GitHub Release作成の冪等化が[dev-standards#46](https://github.com/bamiyanapp/dev-standards/pull/46)）。karuta運用者が意識する必要がある手順の違いはなく、`release`ジョブの結果として`new_release_published`が正しく出力されればデプロイジョブは通常どおり実行される。詳細は[dev-standards側ドキュメント](../dev-standards/docs/cicd-pipeline-specification.md#4-リリース運用)を参照。
 
 ## E2Eテスト（`ci.yml` 固有）
 
@@ -58,6 +58,13 @@ E2Eテスト実行中に読み込まれたJS（フロントエンドのビルド
 ルートの`.gitignore`は`standards-check`の`copies`対象（dev-standards側と内容が完全一致している必要がある）。GitHubの制約上symlinkにできないため、dev-standards側の`.gitignore`が更新された場合はこのファイルを手動で同期する必要がある。
 
 **プロジェクト固有のignoreルールはルートの`.gitignore`に追加せず、`frontend/.gitignore`・`backend/.gitignore`等、対象ディレクトリのgitignoreに追加すること**（gitのネストされた`.gitignore`は親ディレクトリのルールより優先されるため、`!`による打ち消しも問題なく機能する）。ルートに直接追記すると`standards-check`が内容乾離として検知し、CIが失敗する（issue #461で実際に`!.env.example`がルートに直接追記されており、これが原因でCIが失敗する状態になっていたため、`frontend/.gitignore`側へ移設した）。
+
+## CodeQLワークフロー（`codeql.yml`固有、issue #808）
+
+`.github/workflows/codeql.yml`（karuta固有、`reusable-ci.yml`/`reusable-cd.yml`とは別のトップレベルワークフローファイル）から dev-standards の `reusable-codeql.yml` を呼び出し、frontend/backend（いずれもJavaScript）を対象にCodeQLによる静的解析を行う。結果はGitHub Securityタブへ表示され、スマートフォンのブラウザからも閲覧できる（「開発環境の制約（スマホオンリー）」参照）。
+
+- **トリガー**: `push`（`main`）・`pull_request`・`schedule`（毎週月曜日 03:00 UTC）。`schedule`はコード変更が無い期間もCodeQLのクエリセット更新を検知するために設定している
+- **`reusable-ci.yml`との関係**: 独立したワークフローであり、`merge` jobのマージ可否ゲートには関与しない。必須チェックにするかどうかはリポジトリのブランチ保護設定側で判断する（本ドキュメント作成時点では未設定）
 
 ## デプロイジョブ（`cd.yml` 固有）
 


### PR DESCRIPTION
## Summary
- dev-standardsに新設したreusable workflow（`reusable-codeql.yml@v1.8.0`、bamiyanapp/dev-standards#112）を呼び出す `.github/workflows/codeql.yml` を新規追加し、frontend/backend（JavaScript）を対象にCodeQLによる静的解析（脆弱性・データフロー解析）を導入
- トリガーは `push`（main）・`pull_request`・`schedule`（毎週月曜03:00 UTC、コード変更が無い期間もクエリセット更新を検知するため）
- `reusable-ci.yml`の`merge` job（PRマージ可否ゲート）とは独立させ、CodeQLの実行結果・実行時間がPRマージに直結しないようにした
- SARIFのGitHub Securityタブへのアップロードに必要な`security-events: write`等のpermissionsを呼び出し元ワークフローで明示
- `docs/cicd-pipeline-specification.md`に「CodeQLワークフロー」節を追加。あわせて、dev-standards側のドキュメント節番号繰り下げ（3.リリース運用→4.リリース運用）に追従し、既存のアンカーリンクを修正

## Test plan
- [x] `cd frontend && npx eslint .`（エラー0件）
- [x] `cd frontend && npx vitest run`（250件成功）
- [x] `cd backend && npx eslint . && npx vitest run`（1543件成功）
- [x] dev-standardsのactionlintでcodeql.ymlを含むワークフローファイルを検証し問題なし
- [ ] このPRのCI（`ci.yml`）が成功することをGitHub上で確認
- [ ] マージ後、GitHub Security タブ（スマートフォンのブラウザからも閲覧可能）にCodeQLの解析結果が表示されることを確認

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_