### PR TITLE
chore(release): v1.56.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.56.0](https://github.com/bamiyanapp/karuta/compare/v1.55.0...v1.56.0) (2026-07-25)
+
+
+### Features
+
+* **lint:** ESLintのcomplexityルール・eslint-plugin-sonarjsを導入する（issue [#806](https://github.com/bamiyanapp/karuta/issues/806)） ([#813](https://github.com/bamiyanapp/karuta/issues/813)) ([29ff6b0](https://github.com/bamiyanapp/karuta/commit/29ff6b031dd9f108edcda49f361e220ae2dae0ba)), closes [bamiyanapp/dev-standards#113](https://github.com/bamiyanapp/dev-standards/issues/113)
+
 # [1.55.0](https://github.com/bamiyanapp/karuta/compare/v1.54.8...v1.55.0) (2026-07-25)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.55.0",
+    "version": "1.56.0",
     "date": "2026/07/25",
+    "body": "### Features\n\n* **lint:** ESLintのcomplexityルール・eslint-plugin-sonarjsを導入する（issue [#806](https://github.com/bamiyanapp/karuta/issues/806)） ([#813](https://github.com/bamiyanapp/karuta/issues/813)) ([29ff6b0](https://github.com/bamiyanapp/karuta/commit/29ff6b031dd9f108edcda49f361e220ae2dae0ba)), closes [bamiyanapp/dev-standards#113](https://github.com/bamiyanapp/dev-standards/issues/113)"
+  },
+  {
+    "version": "1.55.0",
+    "date": "2026/07/25 02:33",
     "body": "### Features\n\n* **ci:** CodeQLによる静的解析を導入する（issue [#808](https://github.com/bamiyanapp/karuta/issues/808)） ([#809](https://github.com/bamiyanapp/karuta/issues/809)) ([4101ac4](https://github.com/bamiyanapp/karuta/commit/4101ac4c5bffed2e11f4d0eaeb65bb01f3f97729))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.55.0",
+  "version": "1.56.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.55.0",
+      "version": "1.56.0",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.55.0"
+  "version": "1.56.0"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。