### PR TITLE
refactor: frontend/backend全体の重複コードのうち最優先5項目を共通化する

### DIFF
--- a/backend/efudaPdfHandler.js
+++ b/backend/efudaPdfHandler.js
@@ -4,6 +4,7 @@ const { LambdaClient, InvokeCommand } = require("@aws-sdk/client-lambda");
 const { S3Client, PutObjectCommand, HeadObjectCommand, GetObjectCommand } = require("@aws-sdk/client-s3");
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
 const { docClient, resolveAllowedOrigin, streamToBuffer } = require("./handler");
+const { jsonResponse, badRequest, serverError } = require("./httpResponse");
 // @sparticuz/chromium・puppeteer-coreはESM専用パッケージ（"type": "module"）のため、
 // このファイル（CommonJS）からはrequire()できず、使用箇所（renderEfudaPdfWorker内）で
 // 動的import()する
@@ -51,11 +52,7 @@ exports.generateEfudaPdf = async (event) => {
     const categories = parseCategoryParam(categoryParam);
 
     if (categories.length === 0 || (side !== "front" && side !== "back")) {
-      return {
-        statusCode: 400,
-        headers: { "Access-Control-Allow-Origin": allowedOrigin },
-        body: JSON.stringify({ message: "Invalid input" }),
-      };
+      return badRequest(allowedOrigin, "Invalid input");
     }
 
     // クライアント側（App.jsxのMAX_EFUDA_PRINT_CARDS）でも上限チェックしているが、
@@ -65,13 +62,10 @@ exports.generateEfudaPdf = async (event) => {
     const totalCount = counts.reduce((sum, count) => sum + count, 0);
 
     if (totalCount > MAX_EFUDA_PRINT_CARDS_SERVER) {
-      return {
-        statusCode: 400,
-        headers: { "Access-Control-Allow-Origin": allowedOrigin },
-        body: JSON.stringify({
-          message: `選択された読み札数（${totalCount}枚）が上限（${MAX_EFUDA_PRINT_CARDS_SERVER}枚）を超えています`,
-        }),
-      };
+      return badRequest(
+        allowedOrigin,
+        `選択された読み札数（${totalCount}枚）が上限（${MAX_EFUDA_PRINT_CARDS_SERVER}枚）を超えています`
+      );
     }
 
     const jobId = crypto.randomUUID();
@@ -84,18 +78,9 @@ exports.generateEfudaPdf = async (event) => {
       Payload: JSON.stringify({ jobId, categoryParam, side }),
     }));
 
-    return {
-      statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ jobId }),
-    };
+    return jsonResponse(allowedOrigin, 200, { jobId });
   } catch (error) {
-    console.error(error);
-    return {
-      statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
-    };
+    return serverError(allowedOrigin, error, { includeMessage: true });
   }
 };
 
@@ -175,11 +160,7 @@ exports.getEfudaPdfStatus = async (event) => {
     const { jobId, categoryLabel, side } = params;
 
     if (!jobId) {
-      return {
-        statusCode: 400,
-        headers: { "Access-Control-Allow-Origin": allowedOrigin },
-        body: JSON.stringify({ message: "Invalid input" }),
-      };
+      return badRequest(allowedOrigin, "Invalid input");
     }
 
     try {
@@ -201,11 +182,7 @@ exports.getEfudaPdfStatus = async (event) => {
         { expiresIn: 300 }
       );
 
-      return {
-        statusCode: 200,
-        headers: { "Access-Control-Allow-Origin": allowedOrigin },
-        body: JSON.stringify({ status: "DONE", url }),
-      };
+      return jsonResponse(allowedOrigin, 200, { status: "DONE", url });
     } catch (headError) {
       if (!isNotFoundError(headError)) {
         throw headError;
@@ -220,28 +197,15 @@ exports.getEfudaPdfStatus = async (event) => {
       const errorBuffer = await streamToBuffer(errorObject.Body);
       const parsedError = JSON.parse(errorBuffer.toString("utf-8"));
 
-      return {
-        statusCode: 200,
-        headers: { "Access-Control-Allow-Origin": allowedOrigin },
-        body: JSON.stringify({ status: "FAILED", message: parsedError.message }),
-      };
+      return jsonResponse(allowedOrigin, 200, { status: "FAILED", message: parsedError.message });
     } catch (getError) {
       if (!isNotFoundError(getError)) {
         throw getError;
       }
     }
 
-    return {
-      statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ status: "IN_PROGRESS" }),
-    };
+    return jsonResponse(allowedOrigin, 200, { status: "IN_PROGRESS" });
   } catch (error) {
-    console.error(error);
-    return {
-      statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
-    };
+    return serverError(allowedOrigin, error, { includeMessage: true });
   }
 };

--- a/backend/handler.js
+++ b/backend/handler.js
@@ -1,6 +1,7 @@
 const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
 const { DynamoDBDocumentClient, ScanCommand, GetCommand, PutCommand, UpdateCommand, QueryCommand } = require("@aws-sdk/lib-dynamodb");
 const { PollyClient, SynthesizeSpeechCommand } = require("@aws-sdk/client-polly");
+const { jsonResponse, badRequest, notFound, serverError } = require("./httpResponse");
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -119,11 +120,7 @@ exports.recordTime = async (event) => {
       time <= 0 ||
       time > MAX_ELAPSED_SECONDS
     ) {
-      return {
-        statusCode: 400,
-        headers: { "Access-Control-Allow-Origin": allowedOrigin },
-        body: JSON.stringify({ message: "Invalid input" }),
-      };
+      return badRequest(allowedOrigin, "Invalid input");
     }
 
     let updateExpression = "ADD readCount :one, totalTime :time";
@@ -148,27 +145,14 @@ exports.recordTime = async (event) => {
       }));
     } catch (error) {
       if (error.name === "ConditionalCheckFailedException") {
-        return {
-          statusCode: 404,
-          headers: { "Access-Control-Allow-Origin": allowedOrigin },
-          body: JSON.stringify({ message: "Phrase not found" }),
-        };
+        return notFound(allowedOrigin, "Phrase not found");
       }
       throw error;
     }
 
-    return {
-      statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ message: "Time recorded successfully" }),
-    };
+    return jsonResponse(allowedOrigin, 200, { message: "Time recorded successfully" });
   } catch (error) {
-    console.error(error);
-    return {
-      statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ message: "Internal Server Error" }),
-    };
+    return serverError(allowedOrigin, error);
   }
 }
 
@@ -187,11 +171,7 @@ exports.postComment = async (event) => {
       typeof comment !== 'string' ||
       comment.length > MAX_COMMENT_LENGTH
     ) {
-      return {
-        statusCode: 400,
-        headers: { "Access-Control-Allow-Origin": allowedOrigin },
-        body: JSON.stringify({ message: "Invalid input" }),
-      };
+      return badRequest(allowedOrigin, "Invalid input");
     }
 
     const item = {
@@ -208,18 +188,9 @@ exports.postComment = async (event) => {
       Item: item,
     }));
 
-    return {
-      statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ message: "Comment posted successfully" }),
-    };
+    return jsonResponse(allowedOrigin, 200, { message: "Comment posted successfully" });
   } catch (error) {
-    console.error(error);
-    return {
-      statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ message: "Internal Server Error" }),
-    };
+    return serverError(allowedOrigin, error);
   }
 };
 
@@ -234,18 +205,9 @@ exports.getComments = async (event) => {
 
     items.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
 
-    return {
-      statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ comments: items }),
-    };
+    return jsonResponse(allowedOrigin, 200, { comments: items });
   } catch (error) {
-    console.error(error);
-    return {
-      statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ message: "Internal Server Error" }),
-    };
+    return serverError(allowedOrigin, error);
   }
 };
 
@@ -276,23 +238,14 @@ exports.getCongratulationAudio = async (event) => {
     const audioBuffer = await streamToBuffer(pollyResponse.AudioStream);
     const base64Audio = audioBuffer.toString("base64");
 
-    return {
-      statusCode: 200,
-      headers: {
-        "Access-Control-Allow-Origin": allowedOrigin,
-        "Access-Control-Allow-Credentials": true,
-      },
-      body: JSON.stringify({
-        audioData: `data:audio/mp3;base64,${base64Audio}`,
-      }),
-    };
+    return jsonResponse(
+      allowedOrigin,
+      200,
+      { audioData: `data:audio/mp3;base64,${base64Audio}` },
+      { credentials: true }
+    );
   } catch (error) {
-    console.error(error);
-    return {
-      statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
-    };
+    return serverError(allowedOrigin, error, { includeMessage: true });
   }
 };
 
@@ -350,11 +303,7 @@ exports.getPhrase = async (event) => {
     }
 
     if (!selectedItem) {
-      return {
-        statusCode: 404,
-        headers: { "Access-Control-Allow-Origin": allowedOrigin },
-        body: JSON.stringify({ message: "Phrase not found" }),
-      };
+      return notFound(allowedOrigin, "Phrase not found");
     }
 
     targetId = selectedItem.id;
@@ -443,21 +392,9 @@ exports.getPhrase = async (event) => {
       averageDifficulty: stats.averageDifficulty || 0,
     };
 
-    return {
-      statusCode: 200,
-      headers: {
-        "Access-Control-Allow-Origin": allowedOrigin,
-        "Access-Control-Allow-Credentials": true,
-      },
-      body: JSON.stringify(responseBody),
-    };
+    return jsonResponse(allowedOrigin, 200, responseBody, { credentials: true });
   } catch (error) {
-    console.error(error);
-    return {
-      statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
-    };
+    return serverError(allowedOrigin, error, { includeMessage: true });
   }
 };
 
@@ -493,18 +430,9 @@ exports.getPhrasesList = async (event) => {
       items = scanResult.Items || [];
     }
 
-    return {
-      statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ phrases: items.map(computePhraseStats) }),
-    };
+    return jsonResponse(allowedOrigin, 200, { phrases: items.map(computePhraseStats) });
   } catch (error) {
-    console.error(error);
-    return {
-      statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ message: "Internal Server Error" }),
-    };
+    return serverError(allowedOrigin, error);
   }
 };
 
@@ -556,21 +484,9 @@ exports.getCategories = async (event) => {
       categories = [{ name: "大ピンチずかん", group: "kids", requiresPossessionCheck: true, count: 0, readCount: 0 }];
     }
 
-    return {
-      statusCode: 200,
-      headers: {
-        "Access-Control-Allow-Origin": allowedOrigin,
-        "Access-Control-Allow-Credentials": true,
-      },
-      body: JSON.stringify({ categories }),
-    };
+    return jsonResponse(allowedOrigin, 200, { categories }, { credentials: true });
   } catch (error) {
-    console.error(error);
-    return {
-      statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
-    };
+    return serverError(allowedOrigin, error, { includeMessage: true });
   }
 };
 

--- a/backend/httpResponse.js
+++ b/backend/httpResponse.js
@@ -1,0 +1,37 @@
+// API Gateway REST（HTTP）ハンドラ向けの共通CORSレスポンス生成ヘルパー。
+// WebSocketハンドラ（quizRoomHandlerの$connect/$disconnect/カスタムルート群）は
+// プレーンテキストのbody・CORSヘッダー無しで別形状のため対象外（issue #804 2で別途対応）。
+//
+// 500応答のbodyにerror.messageを含めるかはハンドラごとに元々揺れており（issue #804 1）、
+// 統一するとレスポンス本文が変わりテストが落ちる可能性があるため、この移行では
+// 既存の揺れをそのまま維持する（serverErrorのincludeMessageオプションで呼び出し側が選ぶ）。
+
+function jsonResponse(origin, statusCode, body, { credentials = false } = {}) {
+  const headers = { "Access-Control-Allow-Origin": origin };
+  if (credentials) {
+    headers["Access-Control-Allow-Credentials"] = true;
+  }
+  return {
+    statusCode,
+    headers,
+    body: JSON.stringify(body),
+  };
+}
+
+function badRequest(origin, message) {
+  return jsonResponse(origin, 400, { message });
+}
+
+function notFound(origin, message) {
+  return jsonResponse(origin, 404, { message });
+}
+
+function serverError(origin, error, { includeMessage = false } = {}) {
+  console.error(error);
+  const body = includeMessage
+    ? { message: "Internal Server Error", error: error.message }
+    : { message: "Internal Server Error" };
+  return jsonResponse(origin, 500, body);
+}
+
+module.exports = { jsonResponse, badRequest, notFound, serverError };

--- a/backend/quizRoomHandler.js
+++ b/backend/quizRoomHandler.js
@@ -1,7 +1,18 @@
 const crypto = require("crypto");
-const { GetCommand, PutCommand, UpdateCommand, DeleteCommand, QueryCommand, ScanCommand } = require("@aws-sdk/lib-dynamodb");
-const { ApiGatewayManagementApiClient, PostToConnectionCommand, DeleteConnectionCommand } = require("@aws-sdk/client-apigatewaymanagementapi");
+const { GetCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } = require("@aws-sdk/lib-dynamodb");
+const { DeleteConnectionCommand } = require("@aws-sdk/client-apigatewaymanagementapi");
 const { docClient, resolveAllowedOrigin } = require("./handler");
+const { jsonResponse, badRequest, serverError } = require("./httpResponse");
+const {
+  getConnection,
+  queryRoomConnections,
+  buildManagementApiClient,
+  postToConnection,
+  broadcastToRoom,
+  collectParticipantNames,
+  withRoleGuard,
+  withCatchAll,
+} = require("./quizRoomStore");
 
 // issue #470: クイズ大会モード（管理者ルーム開設＋複数端末同期）の最小構成。
 // 音声の同期再生・参加者一覧表示等は初回リリースのスコープ外とし、
@@ -48,11 +59,9 @@ exports.createQuizRoom = async (event) => {
       }
     }
     if (!roomId) {
-      return {
-        statusCode: 500,
-        headers: { "Access-Control-Allow-Origin": allowedOrigin },
-        body: JSON.stringify({ message: "ルームコードの採番に失敗しました。もう一度お試しください。" }),
-      };
+      return jsonResponse(allowedOrigin, 500, {
+        message: "ルームコードの採番に失敗しました。もう一度お試しください。",
+      });
     }
 
     const adminToken = crypto.randomUUID();
@@ -68,18 +77,9 @@ exports.createQuizRoom = async (event) => {
       },
     }));
 
-    return {
-      statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ roomId, adminToken }),
-    };
+    return jsonResponse(allowedOrigin, 200, { roomId, adminToken });
   } catch (error) {
-    console.error(error);
-    return {
-      statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
-    };
+    return serverError(allowedOrigin, error, { includeMessage: true });
   }
 };
 
@@ -131,13 +131,8 @@ exports.listQuizRooms = async (event) => {
     // 気にしなくてよい利点がある
     const roomsWithAdminPresence = await Promise.all(
       candidates.map(async (room) => {
-        const connections = await docClient.send(new QueryCommand({
-          TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-          IndexName: "roomId-index",
-          KeyConditionExpression: "roomId = :roomId",
-          ExpressionAttributeValues: { ":roomId": room.roomId },
-        }));
-        const hasAdmin = (connections.Items || []).some((conn) => conn.role === "admin");
+        const connections = await queryRoomConnections(room.roomId);
+        const hasAdmin = connections.some((conn) => conn.role === "admin");
         return hasAdmin ? room : null;
       })
     );
@@ -146,18 +141,9 @@ exports.listQuizRooms = async (event) => {
       .filter((room) => room !== null)
       .slice(0, MAX_OPEN_ROOMS_DISPLAYED);
 
-    return {
-      statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ rooms }),
-    };
+    return jsonResponse(allowedOrigin, 200, { rooms });
   } catch (error) {
-    console.error(error);
-    return {
-      statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
-    };
+    return serverError(allowedOrigin, error, { includeMessage: true });
   }
 };
 
@@ -171,11 +157,7 @@ exports.checkQuizRoom = async (event) => {
   try {
     const roomId = event.queryStringParameters?.roomId;
     if (!roomId) {
-      return {
-        statusCode: 400,
-        headers: { "Access-Control-Allow-Origin": allowedOrigin },
-        body: JSON.stringify({ message: "roomId is required" }),
-      };
+      return badRequest(allowedOrigin, "roomId is required");
     }
 
     const room = await docClient.send(new GetCommand({
@@ -187,289 +169,189 @@ exports.checkQuizRoom = async (event) => {
     // 生じ得るため、レコードが残っていてもttlを過ぎていれば存在しない扱いにする
     const exists = !!room.Item && (!room.Item.ttl || room.Item.ttl > now);
 
-    return {
-      statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ exists }),
-    };
+    return jsonResponse(allowedOrigin, 200, { exists });
   } catch (error) {
-    console.error(error);
-    return {
-      statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": allowedOrigin },
-      body: JSON.stringify({ message: "Internal Server Error", error: error.message }),
-    };
+    return serverError(allowedOrigin, error, { includeMessage: true });
   }
 };
 
 // WebSocket $connect。roomId（必須）はクエリパラメータで受け取り、
 // adminTokenの有無・一致で管理者/参加者の役割を判定する
-exports.connectQuizRoom = async (event) => {
-  try {
-    const params = event.queryStringParameters || {};
-    const { roomId, adminToken } = params;
-    if (!roomId) {
-      return { statusCode: 400, body: "roomId is required" };
-    }
-
-    const room = await docClient.send(new GetCommand({
-      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
-      Key: { roomId },
-    }));
-    if (!room.Item) {
-      return { statusCode: 404, body: "Room not found" };
-    }
-
-    let role = "participant";
-    if (adminToken) {
-      if (hashToken(adminToken) !== room.Item.adminTokenHash) {
-        return { statusCode: 403, body: "Invalid admin token" };
-      }
-      role = "admin";
-    }
-
-    const now = Date.now();
-    await docClient.send(new PutCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      Item: {
-        connectionId: event.requestContext.connectionId,
-        roomId,
-        role,
-        connectedAt: now,
-        ttl: Math.floor(now / 1000) + CONNECTION_TTL_SECONDS,
-      },
-    }));
-
-    return { statusCode: 200, body: "Connected" };
-  } catch (error) {
-    console.error(error);
-    return { statusCode: 500, body: "Internal Server Error" };
+exports.connectQuizRoom = withCatchAll(async (event) => {
+  const params = event.queryStringParameters || {};
+  const { roomId, adminToken } = params;
+  if (!roomId) {
+    return { statusCode: 400, body: "roomId is required" };
   }
-};
+
+  const room = await docClient.send(new GetCommand({
+    TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+    Key: { roomId },
+  }));
+  if (!room.Item) {
+    return { statusCode: 404, body: "Room not found" };
+  }
+
+  let role = "participant";
+  if (adminToken) {
+    if (hashToken(adminToken) !== room.Item.adminTokenHash) {
+      return { statusCode: 403, body: "Invalid admin token" };
+    }
+    role = "admin";
+  }
+
+  const now = Date.now();
+  await docClient.send(new PutCommand({
+    TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+    Item: {
+      connectionId: event.requestContext.connectionId,
+      roomId,
+      role,
+      connectedAt: now,
+      ttl: Math.floor(now / 1000) + CONNECTION_TTL_SECONDS,
+    },
+  }));
+
+  return { statusCode: 200, body: "Connected" };
+});
 
 // WebSocket $disconnect
-exports.disconnectQuizRoom = async (event) => {
-  try {
-    const connectionId = event.requestContext.connectionId;
-    const connection = await docClient.send(new GetCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      Key: { connectionId },
-    }));
-    await docClient.send(new DeleteCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      Key: { connectionId },
-    }));
+exports.disconnectQuizRoom = withCatchAll(async (event) => {
+  const connectionId = event.requestContext.connectionId;
+  const connection = await getConnection(connectionId);
+  await docClient.send(new DeleteCommand({
+    TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+    Key: { connectionId },
+  }));
 
-    // 参加者一覧（issue #545）: 切断は参加者一覧からも即座に消す。残りの接続へ
-    // 更新後の一覧をブロードキャストする（削除済みなので自分自身は含まれない）
-    if (connection.Item?.roomId) {
-      const { roomId, name } = connection.Item;
-      // 名前の重複予約（issue #618）を解放し、同じ名前で他の参加者・自分自身の
-      // 再入室が再びできるようにする
-      if (name) {
-        await releaseQuizRoomName(roomId, name);
-      }
-      const connections = await docClient.send(new QueryCommand({
-        TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-        IndexName: "roomId-index",
-        KeyConditionExpression: "roomId = :roomId",
-        ExpressionAttributeValues: { ":roomId": roomId },
-      }));
-      const remaining = connections.Items || [];
-      const participantNames = remaining
-        .filter((conn) => conn.role === "participant" && conn.name)
-        .map((conn) => conn.name);
-      const managementApi = buildManagementApiClient(event);
-      await Promise.allSettled(
-        remaining.map((conn) => postToConnection(managementApi, conn.connectionId, {
-          type: "participants",
-          names: participantNames,
-        }))
-      );
+  // 参加者一覧（issue #545）: 切断は参加者一覧からも即座に消す。残りの接続へ
+  // 更新後の一覧をブロードキャストする（削除済みなので自分自身は含まれない）
+  if (connection?.roomId) {
+    const { roomId, name } = connection;
+    // 名前の重複予約（issue #618）を解放し、同じ名前で他の参加者・自分自身の
+    // 再入室が再びできるようにする
+    if (name) {
+      await releaseQuizRoomName(roomId, name);
     }
-
-    return { statusCode: 200, body: "Disconnected" };
-  } catch (error) {
-    console.error(error);
-    return { statusCode: 500, body: "Internal Server Error" };
+    const remaining = await queryRoomConnections(roomId);
+    const participantNames = collectParticipantNames(remaining);
+    await broadcastToRoom(event, remaining, { type: "participants", names: participantNames });
   }
-};
 
-function buildManagementApiClient(event) {
-  const { domainName, stage } = event.requestContext;
-  return new ApiGatewayManagementApiClient({ endpoint: `https://${domainName}/${stage}` });
-}
-
-// 切断済み接続（GoneException/410）への送信は接続レコードを掃除し、他の接続への
-// ブロードキャストは継続できるよう例外を投げずfalseを返す
-async function postToConnection(managementApi, connectionId, payload) {
-  try {
-    await managementApi.send(new PostToConnectionCommand({
-      ConnectionId: connectionId,
-      Data: Buffer.from(JSON.stringify(payload)),
-    }));
-    return true;
-  } catch (error) {
-    if (error.name === "GoneException" || error.$metadata?.httpStatusCode === 410) {
-      await docClient.send(new DeleteCommand({
-        TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-        Key: { connectionId },
-      }));
-      return false;
-    }
-    throw error;
-  }
-}
+  return { statusCode: 200, body: "Disconnected" };
+});
 
 // WebSocketカスタムルート"sync"（routeSelectionExpression: $request.body.action）。
 // 接続直後にクライアント側から呼ばれ、現在のルーム状態を呼び出し元1件にだけ返す
-exports.syncQuizRoom = async (event) => {
-  try {
-    const connectionId = event.requestContext.connectionId;
-    const connection = await docClient.send(new GetCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      Key: { connectionId },
-    }));
-    if (!connection.Item) {
-      return { statusCode: 200, body: "" };
-    }
-
-    const room = await docClient.send(new GetCommand({
-      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
-      Key: { roomId: connection.Item.roomId },
-    }));
-    if (!room.Item) {
-      return { statusCode: 200, body: "" };
-    }
-
-    const managementApi = buildManagementApiClient(event);
-    await postToConnection(managementApi, connectionId, {
-      type: "state",
-      state: room.Item.state || {},
-      role: connection.Item.role,
-    });
-
-    // 早押し機能（issue #510）: 再接続・遅れて参加した端末でも、現在のラウンドで
-    // 既に誰かが早押し済みであることが分かるようにする
-    if (room.Item.buzz) {
-      await postToConnection(managementApi, connectionId, {
-        type: "buzz",
-        name: room.Item.buzz.name,
-        connectionId: room.Item.buzz.connectionId,
-      });
-    }
-
-    // ポイント制（issue #519）・回答数集計（issue #698）: 再接続・遅れて参加した
-    // 端末にも現在の集計を伝える
-    if (room.Item.points || room.Item.answerCounts) {
-      await postToConnection(managementApi, connectionId, {
-        type: "points",
-        points: room.Item.points || {},
-        answerCounts: room.Item.answerCounts || {},
-      });
-    }
-
-    // 参加者一覧（issue #545）: 再接続・遅れて参加した端末にも現在の参加者一覧を伝える
-    const roomConnections = await docClient.send(new QueryCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      IndexName: "roomId-index",
-      KeyConditionExpression: "roomId = :roomId",
-      ExpressionAttributeValues: { ":roomId": connection.Item.roomId },
-    }));
-    const participantNames = (roomConnections.Items || [])
-      .filter((conn) => conn.role === "participant" && conn.name)
-      .map((conn) => conn.name);
-    await postToConnection(managementApi, connectionId, {
-      type: "participants",
-      names: participantNames,
-    });
-
+exports.syncQuizRoom = withCatchAll(async (event) => {
+  const connectionId = event.requestContext.connectionId;
+  const connection = await getConnection(connectionId);
+  if (!connection) {
     return { statusCode: 200, body: "" };
-  } catch (error) {
-    console.error(error);
-    return { statusCode: 500, body: "Internal Server Error" };
   }
-};
+
+  const room = await docClient.send(new GetCommand({
+    TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+    Key: { roomId: connection.roomId },
+  }));
+  if (!room.Item) {
+    return { statusCode: 200, body: "" };
+  }
+
+  const managementApi = buildManagementApiClient(event);
+  await postToConnection(managementApi, connectionId, {
+    type: "state",
+    state: room.Item.state || {},
+    role: connection.role,
+  });
+
+  // 早押し機能（issue #510）: 再接続・遅れて参加した端末でも、現在のラウンドで
+  // 既に誰かが早押し済みであることが分かるようにする
+  if (room.Item.buzz) {
+    await postToConnection(managementApi, connectionId, {
+      type: "buzz",
+      name: room.Item.buzz.name,
+      connectionId: room.Item.buzz.connectionId,
+    });
+  }
+
+  // ポイント制（issue #519）・回答数集計（issue #698）: 再接続・遅れて参加した
+  // 端末にも現在の集計を伝える
+  if (room.Item.points || room.Item.answerCounts) {
+    await postToConnection(managementApi, connectionId, {
+      type: "points",
+      points: room.Item.points || {},
+      answerCounts: room.Item.answerCounts || {},
+    });
+  }
+
+  // 参加者一覧（issue #545）: 再接続・遅れて参加した端末にも現在の参加者一覧を伝える
+  const roomConnections = await queryRoomConnections(connection.roomId);
+  const participantNames = collectParticipantNames(roomConnections);
+  await postToConnection(managementApi, connectionId, {
+    type: "participants",
+    names: participantNames,
+  });
+
+  return { statusCode: 200, body: "" };
+});
 
 // WebSocketカスタムルート"updateState"。管理者のみが状態を更新でき、
 // 更新後はルーム内の全接続（管理者自身を含む）へブロードキャストする
-exports.updateQuizRoomState = async (event) => {
-  try {
-    const connectionId = event.requestContext.connectionId;
-    const connection = await docClient.send(new GetCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      Key: { connectionId },
-    }));
-    if (!connection.Item || connection.Item.role !== "admin") {
-      return { statusCode: 403, body: "Forbidden" };
-    }
-
-    const body = JSON.parse(event.body || "{}");
-    const newState = body.state;
-    const stateJson = JSON.stringify(newState ?? null);
-    if (!newState || typeof newState !== "object" || Array.isArray(newState) || stateJson.length > MAX_STATE_JSON_LENGTH) {
-      return { statusCode: 400, body: "Invalid state" };
-    }
-
-    const { roomId } = connection.Item;
-
-    const room = await docClient.send(new GetCommand({
-      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
-      Key: { roomId },
-    }));
-
-    // 読み上げ設定の変更等で、ラウンドが進んだわけではなく同じ札のphraseが
-    // 再ブロードキャストされることがある（App.jsxのbroadcast effect参照）。
-    // このケースを新しいラウンドの開始と誤認すると、まだ判定が済んでいない
-    // 早押し記録を消してしまうため、直前の状態と札のidを比較して区別する
-    const isSamePhraseRebroadcast = newState.type === "phrase"
-      && room.Item?.state?.type === "phrase"
-      && room.Item?.state?.content?.id === newState.content?.id;
-
-    // 早押し正誤判定（issue #546）: ポイント付与は管理者の正誤判定
-    // （judgeQuizRoomBuzz）でのみ行う。「次の札」へ進んだ時点でまだ判定されて
-    // いない早押しがあっても加点しない（未判定は無効試行として扱う）。
-    // 新しい札（次の問題）や、ゲームのリセット等で"initial"に戻った場合は、
-    // 前のラウンドの早押し・除外状態をリセットする。result表示中や、同じ札の
-    // 再ブロードキャスト中は、まだそのラウンドの判定を確定させたくないため
-    // リセットしない
-    const resetRound = newState.type !== "result" && !isSamePhraseRebroadcast;
-    const updateExpression = resetRound
-      ? "SET #state = :state, #ttl = :ttl REMOVE buzz, excludedNames"
-      : "SET #state = :state, #ttl = :ttl";
-    await docClient.send(new UpdateCommand({
-      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
-      Key: { roomId },
-      UpdateExpression: updateExpression,
-      ExpressionAttributeNames: { "#state": "state", "#ttl": "ttl" },
-      ExpressionAttributeValues: {
-        ":state": newState,
-        ":ttl": Math.floor(Date.now() / 1000) + ROOM_TTL_SECONDS,
-      },
-    }));
-
-    const connections = await docClient.send(new QueryCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      IndexName: "roomId-index",
-      KeyConditionExpression: "roomId = :roomId",
-      ExpressionAttributeValues: { ":roomId": roomId },
-    }));
-
-    const managementApi = buildManagementApiClient(event);
-    await Promise.allSettled(
-      (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
-        type: "state",
-        state: newState,
-        role: conn.role,
-      }))
-    );
-
-    return { statusCode: 200, body: "" };
-  } catch (error) {
-    console.error(error);
-    return { statusCode: 500, body: "Internal Server Error" };
+exports.updateQuizRoomState = withRoleGuard("admin", async (event, connection) => {
+  const body = JSON.parse(event.body || "{}");
+  const newState = body.state;
+  const stateJson = JSON.stringify(newState ?? null);
+  if (!newState || typeof newState !== "object" || Array.isArray(newState) || stateJson.length > MAX_STATE_JSON_LENGTH) {
+    return { statusCode: 400, body: "Invalid state" };
   }
-};
+
+  const { roomId } = connection;
+
+  const room = await docClient.send(new GetCommand({
+    TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+    Key: { roomId },
+  }));
+
+  // 読み上げ設定の変更等で、ラウンドが進んだわけではなく同じ札のphraseが
+  // 再ブロードキャストされることがある（App.jsxのbroadcast effect参照）。
+  // このケースを新しいラウンドの開始と誤認すると、まだ判定が済んでいない
+  // 早押し記録を消してしまうため、直前の状態と札のidを比較して区別する
+  const isSamePhraseRebroadcast = newState.type === "phrase"
+    && room.Item?.state?.type === "phrase"
+    && room.Item?.state?.content?.id === newState.content?.id;
+
+  // 早押し正誤判定（issue #546）: ポイント付与は管理者の正誤判定
+  // （judgeQuizRoomBuzz）でのみ行う。「次の札」へ進んだ時点でまだ判定されて
+  // いない早押しがあっても加点しない（未判定は無効試行として扱う）。
+  // 新しい札（次の問題）や、ゲームのリセット等で"initial"に戻った場合は、
+  // 前のラウンドの早押し・除外状態をリセットする。result表示中や、同じ札の
+  // 再ブロードキャスト中は、まだそのラウンドの判定を確定させたくないため
+  // リセットしない
+  const resetRound = newState.type !== "result" && !isSamePhraseRebroadcast;
+  const updateExpression = resetRound
+    ? "SET #state = :state, #ttl = :ttl REMOVE buzz, excludedNames"
+    : "SET #state = :state, #ttl = :ttl";
+  await docClient.send(new UpdateCommand({
+    TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+    Key: { roomId },
+    UpdateExpression: updateExpression,
+    ExpressionAttributeNames: { "#state": "state", "#ttl": "ttl" },
+    ExpressionAttributeValues: {
+      ":state": newState,
+      ":ttl": Math.floor(Date.now() / 1000) + ROOM_TTL_SECONDS,
+    },
+  }));
+
+  const connections = await queryRoomConnections(roomId);
+  await broadcastToRoom(event, connections, (conn) => ({
+    type: "state",
+    state: newState,
+    role: conn.role,
+  }));
+
+  return { statusCode: 200, body: "" };
+});
 
 // WebSocketカスタムルート"judgeBuzz"（issue #546）。管理者のみが早押しの正誤を
 // 判定できる。正解の場合はその参加者に1ポイント加点し、buzz/excludedNamesを
@@ -477,135 +359,85 @@ exports.updateQuizRoomState = async (event) => {
 // 不正解の場合はbuzzのみリセットして他の参加者が再度早押しできるようにしつつ、
 // 誤答した本人は今ラウンドの早押し対象から除外し、ルーム内の全接続へ
 // ラウンドリセットを通知する
-exports.judgeQuizRoomBuzz = async (event) => {
-  try {
-    const connectionId = event.requestContext.connectionId;
-    const connection = await docClient.send(new GetCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      Key: { connectionId },
-    }));
-    if (!connection.Item || connection.Item.role !== "admin") {
-      return { statusCode: 403, body: "Forbidden" };
-    }
+exports.judgeQuizRoomBuzz = withRoleGuard("admin", async (event, connection) => {
+  const body = JSON.parse(event.body || "{}");
+  const correct = body.correct === true;
+  const { roomId } = connection;
 
-    const body = JSON.parse(event.body || "{}");
-    const correct = body.correct === true;
-    const { roomId } = connection.Item;
+  const room = await docClient.send(new GetCommand({
+    TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+    Key: { roomId },
+  }));
+  const buzzedName = room.Item?.buzz?.name;
+  if (!buzzedName) {
+    // 判定対象の早押しが既に無い（タイミングのズレ等）。何もしない
+    return { statusCode: 200, body: "" };
+  }
 
-    const room = await docClient.send(new GetCommand({
+  const connections = await queryRoomConnections(roomId);
+
+  // 回答数集計（issue #698）: 早押しして正誤判定された累計回数（attempts）と、
+  // そのうち正解と判定された累計回数（correct）を、正解・不正解いずれの
+  // 判定でも記録する。pointsと同様にDynamoDBのルームアイテムへ保持するため、
+  // 切断・退室後も（pointsと同じ寿命で）残り続ける
+  const updatedAnswerCounts = { ...(room.Item.answerCounts || {}) };
+  const previousCount = updatedAnswerCounts[buzzedName] || { attempts: 0, correct: 0 };
+  updatedAnswerCounts[buzzedName] = {
+    attempts: previousCount.attempts + 1,
+    correct: previousCount.correct + (correct ? 1 : 0),
+  };
+
+  if (correct) {
+    const updatedPoints = { ...(room.Item.points || {}) };
+    updatedPoints[buzzedName] = (updatedPoints[buzzedName] || 0) + 1;
+    await docClient.send(new UpdateCommand({
       TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
       Key: { roomId },
+      UpdateExpression: "SET points = :points, answerCounts = :answerCounts REMOVE buzz, excludedNames",
+      ExpressionAttributeValues: { ":points": updatedPoints, ":answerCounts": updatedAnswerCounts },
     }));
-    const buzzedName = room.Item?.buzz?.name;
-    if (!buzzedName) {
-      // 判定対象の早押しが既に無い（タイミングのズレ等）。何もしない
-      return { statusCode: 200, body: "" };
-    }
-
-    const connections = await docClient.send(new QueryCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      IndexName: "roomId-index",
-      KeyConditionExpression: "roomId = :roomId",
-      ExpressionAttributeValues: { ":roomId": roomId },
+    await broadcastToRoom(event, connections, {
+      type: "points",
+      points: updatedPoints,
+      answerCounts: updatedAnswerCounts,
+    });
+  } else {
+    await docClient.send(new UpdateCommand({
+      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+      Key: { roomId },
+      UpdateExpression: "SET answerCounts = :answerCounts REMOVE buzz ADD excludedNames :names",
+      ExpressionAttributeValues: { ":answerCounts": updatedAnswerCounts, ":names": new Set([buzzedName]) },
     }));
-    const managementApi = buildManagementApiClient(event);
-
-    // 回答数集計（issue #698）: 早押しして正誤判定された累計回数（attempts）と、
-    // そのうち正解と判定された累計回数（correct）を、正解・不正解いずれの
-    // 判定でも記録する。pointsと同様にDynamoDBのルームアイテムへ保持するため、
-    // 切断・退室後も（pointsと同じ寿命で）残り続ける
-    const updatedAnswerCounts = { ...(room.Item.answerCounts || {}) };
-    const previousCount = updatedAnswerCounts[buzzedName] || { attempts: 0, correct: 0 };
-    updatedAnswerCounts[buzzedName] = {
-      attempts: previousCount.attempts + 1,
-      correct: previousCount.correct + (correct ? 1 : 0),
-    };
-
-    if (correct) {
-      const updatedPoints = { ...(room.Item.points || {}) };
-      updatedPoints[buzzedName] = (updatedPoints[buzzedName] || 0) + 1;
-      await docClient.send(new UpdateCommand({
-        TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
-        Key: { roomId },
-        UpdateExpression: "SET points = :points, answerCounts = :answerCounts REMOVE buzz, excludedNames",
-        ExpressionAttributeValues: { ":points": updatedPoints, ":answerCounts": updatedAnswerCounts },
-      }));
-      await Promise.allSettled(
-        (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
-          type: "points",
-          points: updatedPoints,
-          answerCounts: updatedAnswerCounts,
-        }))
-      );
-    } else {
-      await docClient.send(new UpdateCommand({
-        TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
-        Key: { roomId },
-        UpdateExpression: "SET answerCounts = :answerCounts REMOVE buzz ADD excludedNames :names",
-        ExpressionAttributeValues: { ":answerCounts": updatedAnswerCounts, ":names": new Set([buzzedName]) },
-      }));
-      await Promise.allSettled(
-        (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
-          type: "roundReset",
-          excludedName: buzzedName,
-          answerCounts: updatedAnswerCounts,
-        }))
-      );
-    }
-
-    return { statusCode: 200, body: "" };
-  } catch (error) {
-    console.error(error);
-    return { statusCode: 500, body: "Internal Server Error" };
+    await broadcastToRoom(event, connections, {
+      type: "roundReset",
+      excludedName: buzzedName,
+      answerCounts: updatedAnswerCounts,
+    });
   }
-};
+
+  return { statusCode: 200, body: "" };
+});
 
 // WebSocketカスタムルート"resetPoints"（issue #615）。管理者のみがポイント集計を
 // 初期化できる。同じルームで2ゲーム目を始める際、前のゲームのポイントを引き継がずに
 // 再スタートしたい場合に使う。ゲームリセット（"initial"へ戻る）のたびに自動では
 // リセットしない。カテゴリを切り替えても通算得点で戦い続けたいユースケースもあり、
 // 自動リセットにするとそれを一律に壊してしまうため、管理者の明示操作のみで行う
-exports.resetQuizRoomPoints = async (event) => {
-  try {
-    const connectionId = event.requestContext.connectionId;
-    const connection = await docClient.send(new GetCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      Key: { connectionId },
-    }));
-    if (!connection.Item || connection.Item.role !== "admin") {
-      return { statusCode: 403, body: "Forbidden" };
-    }
+exports.resetQuizRoomPoints = withRoleGuard("admin", async (event, connection) => {
+  const { roomId } = connection;
+  // 回答数集計（issue #698）: 同じルームで2ゲーム目を始める際の再スタートなので、
+  // pointsと同じタイミングでanswerCountsもリセットする
+  await docClient.send(new UpdateCommand({
+    TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+    Key: { roomId },
+    UpdateExpression: "REMOVE points, answerCounts",
+  }));
 
-    const { roomId } = connection.Item;
-    // 回答数集計（issue #698）: 同じルームで2ゲーム目を始める際の再スタートなので、
-    // pointsと同じタイミングでanswerCountsもリセットする
-    await docClient.send(new UpdateCommand({
-      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
-      Key: { roomId },
-      UpdateExpression: "REMOVE points, answerCounts",
-    }));
+  const connections = await queryRoomConnections(roomId);
+  await broadcastToRoom(event, connections, { type: "points", points: {}, answerCounts: {} });
 
-    const connections = await docClient.send(new QueryCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      IndexName: "roomId-index",
-      KeyConditionExpression: "roomId = :roomId",
-      ExpressionAttributeValues: { ":roomId": roomId },
-    }));
-    const managementApi = buildManagementApiClient(event);
-    await Promise.allSettled(
-      (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
-        type: "points",
-        points: {},
-        answerCounts: {},
-      }))
-    );
-
-    return { statusCode: 200, body: "" };
-  } catch (error) {
-    console.error(error);
-    return { statusCode: 500, body: "Internal Server Error" };
-  }
-};
+  return { statusCode: 200, body: "" };
+});
 
 // WebSocketカスタムルート"closeRoom"（issue #748）。管理者のみルームを明示的に終了できる。
 // ルームレコード自体を削除するため、以後の$connect試行は404で拒否される（issue #576の
@@ -621,47 +453,26 @@ exports.resetQuizRoomPoints = async (event) => {
 // 管理者側はroomClosed受信後にフロントエンドがroomIdをクリアし（useQuizRoomAdmin.js）、
 // useQuizRoomSyncのeffectが依存値の変化で自然にWebSocketをクローズするため、ここで
 // 明示的に切断しなくても問題ない
-exports.closeQuizRoom = async (event) => {
-  try {
-    const connectionId = event.requestContext.connectionId;
-    const connection = await docClient.send(new GetCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      Key: { connectionId },
-    }));
-    if (!connection.Item || connection.Item.role !== "admin") {
-      return { statusCode: 403, body: "Forbidden" };
-    }
+exports.closeQuizRoom = withRoleGuard("admin", async (event, connection, connectionId) => {
+  const { roomId } = connection;
 
-    const { roomId } = connection.Item;
+  await docClient.send(new DeleteCommand({
+    TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+    Key: { roomId },
+  }));
 
-    await docClient.send(new DeleteCommand({
-      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
-      Key: { roomId },
-    }));
+  const connections = await queryRoomConnections(roomId);
+  await broadcastToRoom(event, connections, { type: "roomClosed" });
 
-    const connections = await docClient.send(new QueryCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      IndexName: "roomId-index",
-      KeyConditionExpression: "roomId = :roomId",
-      ExpressionAttributeValues: { ":roomId": roomId },
-    }));
-    const managementApi = buildManagementApiClient(event);
-    const items = connections.Items || [];
-    await Promise.allSettled(
-      items.map((conn) => postToConnection(managementApi, conn.connectionId, { type: "roomClosed" }))
-    );
-    await Promise.allSettled(
-      items
-        .filter((conn) => conn.connectionId !== connectionId)
-        .map((conn) => managementApi.send(new DeleteConnectionCommand({ ConnectionId: conn.connectionId })).catch(() => {}))
-    );
+  const managementApi = buildManagementApiClient(event);
+  await Promise.allSettled(
+    connections
+      .filter((conn) => conn.connectionId !== connectionId)
+      .map((conn) => managementApi.send(new DeleteConnectionCommand({ ConnectionId: conn.connectionId })).catch(() => {}))
+  );
 
-    return { statusCode: 200, body: "" };
-  } catch (error) {
-    console.error(error);
-    return { statusCode: 500, body: "Internal Server Error" };
-  }
-};
+  return { statusCode: 200, body: "" };
+});
 
 // WebSocketカスタムルート"setName"（早押し機能、issue #510）。参加者（管理者含む、
 // ただし実際に使うのは参加者のみ）が自分の表示名を接続情報へ保存する
@@ -702,18 +513,15 @@ exports.setQuizRoomName = async (event) => {
       return { statusCode: 400, body: "Invalid name" };
     }
 
-    const connection = await docClient.send(new GetCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      Key: { connectionId },
-    }));
-    if (!connection.Item) {
+    const connection = await getConnection(connectionId);
+    if (!connection) {
       // 接続情報が既に無い（切断済み等）。名前の保存自体は無意味なので何もしない
       return { statusCode: 200, body: "" };
     }
 
     // ポイント制（issue #519）はnameを集計キーにするため、同一ルーム内で名前が
     // 重複すると他人のポイントと混ざってしまう。参加時点で重複を禁止する
-    const { roomId, name: previousName } = connection.Item;
+    const { roomId, name: previousName } = connection;
     const isRenaming = previousName !== name;
 
     if (isRenaming) {
@@ -758,23 +566,9 @@ exports.setQuizRoomName = async (event) => {
 
     // 参加者一覧（issue #545）: 名前が確定したら、ルーム内の全接続（管理者含む）へ
     // 更新後の参加者一覧をブロードキャストする
-    const connections = await docClient.send(new QueryCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      IndexName: "roomId-index",
-      KeyConditionExpression: "roomId = :roomId",
-      ExpressionAttributeValues: { ":roomId": roomId },
-    }));
-    const managementApi = buildManagementApiClient(event);
-    const participantNames = (connections.Items || [])
-      .filter((conn) => conn.role === "participant")
-      .map((conn) => (conn.connectionId === connectionId ? name : conn.name))
-      .filter(Boolean);
-    await Promise.allSettled(
-      (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
-        type: "participants",
-        names: participantNames,
-      }))
-    );
+    const connections = await queryRoomConnections(roomId);
+    const participantNames = collectParticipantNames(connections, { renameConnectionId: connectionId, renameTo: name });
+    await broadcastToRoom(event, connections, { type: "participants", names: participantNames });
 
     return { statusCode: 200, body: "" };
   } catch (error) {
@@ -792,60 +586,33 @@ exports.setQuizRoomName = async (event) => {
 // 回答者名をブロードキャストする（早押し結果のリセットはupdateQuizRoomState側で行う）。
 // 正誤判定（issue #546）で不正解と判定された参加者は、そのラウンド中は
 // 再度早押しできない（excludedNamesに含まれる名前を条件付き書き込みで弾く）
-exports.buzzQuizRoom = async (event) => {
+exports.buzzQuizRoom = withRoleGuard("participant", async (event, connection, connectionId) => {
+  const { roomId, name } = connection;
+  const buzz = {
+    connectionId,
+    name: name || "名無しさん",
+    buzzedAt: Date.now(),
+  };
+
   try {
-    const connectionId = event.requestContext.connectionId;
-    const connection = await docClient.send(new GetCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      Key: { connectionId },
+    await docClient.send(new UpdateCommand({
+      TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
+      Key: { roomId },
+      UpdateExpression: "SET buzz = :buzz",
+      ConditionExpression: "attribute_not_exists(buzz) AND (attribute_not_exists(excludedNames) OR NOT contains(excludedNames, :name))",
+      ExpressionAttributeValues: { ":buzz": buzz, ":name": buzz.name },
     }));
-    if (!connection.Item || connection.Item.role !== "participant") {
-      return { statusCode: 403, body: "Forbidden" };
-    }
-
-    const { roomId, name } = connection.Item;
-    const buzz = {
-      connectionId,
-      name: name || "名無しさん",
-      buzzedAt: Date.now(),
-    };
-
-    try {
-      await docClient.send(new UpdateCommand({
-        TableName: process.env.QUIZ_ROOMS_TABLE_NAME,
-        Key: { roomId },
-        UpdateExpression: "SET buzz = :buzz",
-        ConditionExpression: "attribute_not_exists(buzz) AND (attribute_not_exists(excludedNames) OR NOT contains(excludedNames, :name))",
-        ExpressionAttributeValues: { ":buzz": buzz, ":name": buzz.name },
-      }));
-    } catch (error) {
-      if (error.name === "ConditionalCheckFailedException") {
-        // 既に他の参加者が先に押している、またはこのラウンドで不正解判定済みで
-        // 除外されている。いずれも早押しの結果は変えず、何もしない
-        return { statusCode: 200, body: "" };
-      }
-      throw error;
-    }
-
-    const connections = await docClient.send(new QueryCommand({
-      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-      IndexName: "roomId-index",
-      KeyConditionExpression: "roomId = :roomId",
-      ExpressionAttributeValues: { ":roomId": roomId },
-    }));
-
-    const managementApi = buildManagementApiClient(event);
-    await Promise.allSettled(
-      (connections.Items || []).map((conn) => postToConnection(managementApi, conn.connectionId, {
-        type: "buzz",
-        name: buzz.name,
-        connectionId: buzz.connectionId,
-      }))
-    );
-
-    return { statusCode: 200, body: "" };
   } catch (error) {
-    console.error(error);
-    return { statusCode: 500, body: "Internal Server Error" };
+    if (error.name === "ConditionalCheckFailedException") {
+      // 既に他の参加者が先に押している、またはこのラウンドで不正解判定済みで
+      // 除外されている。いずれも早押しの結果は変えず、何もしない
+      return { statusCode: 200, body: "" };
+    }
+    throw error;
   }
-};
+
+  const connections = await queryRoomConnections(roomId);
+  await broadcastToRoom(event, connections, { type: "buzz", name: buzz.name, connectionId: buzz.connectionId });
+
+  return { statusCode: 200, body: "" };
+});

--- a/backend/quizRoomStore.js
+++ b/backend/quizRoomStore.js
@@ -1,0 +1,128 @@
+// クイズ大会モード（issue #470）のWebSocketハンドラ（quizRoomHandler.js）で
+// 重複していた接続取得・ルーム内接続一覧Query・全接続へのブロードキャスト・
+// 管理者ガード＋catchブロックを共通化する（issue #804 2）。
+//
+// judgeQuizRoomBuzz（正解/不正解で2つのブロードキャストを持つ）・closeQuizRoom
+// （ブロードキャスト後に追加の切断処理がある）は、配信部分（broadcastToRoom）のみ
+// この共通化の対象とし、それぞれの個別ロジックはハンドラ側に残す。
+
+const { GetCommand, QueryCommand, DeleteCommand } = require("@aws-sdk/lib-dynamodb");
+const { ApiGatewayManagementApiClient, PostToConnectionCommand } = require("@aws-sdk/client-apigatewaymanagementapi");
+const { docClient } = require("./handler");
+
+async function getConnection(connectionId) {
+  const result = await docClient.send(new GetCommand({
+    TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+    Key: { connectionId },
+  }));
+  return result.Item;
+}
+
+async function queryRoomConnections(roomId) {
+  const result = await docClient.send(new QueryCommand({
+    TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+    IndexName: "roomId-index",
+    KeyConditionExpression: "roomId = :roomId",
+    ExpressionAttributeValues: { ":roomId": roomId },
+  }));
+  return result.Items || [];
+}
+
+function buildManagementApiClient(event) {
+  const { domainName, stage } = event.requestContext;
+  return new ApiGatewayManagementApiClient({ endpoint: `https://${domainName}/${stage}` });
+}
+
+// 切断済み接続（GoneException/410）への送信は接続レコードを掃除し、他の接続への
+// ブロードキャストは継続できるよう例外を投げずfalseを返す
+async function postToConnection(managementApi, connectionId, payload) {
+  try {
+    await managementApi.send(new PostToConnectionCommand({
+      ConnectionId: connectionId,
+      Data: Buffer.from(JSON.stringify(payload)),
+    }));
+    return true;
+  } catch (error) {
+    if (error.name === "GoneException" || error.$metadata?.httpStatusCode === 410) {
+      await docClient.send(new DeleteCommand({
+        TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+        Key: { connectionId },
+      }));
+      return false;
+    }
+    throw error;
+  }
+}
+
+// 呼び出し側が既にqueryRoomConnections()で取得済みの接続一覧（connections）へ
+// payloadを配信する。参加者名の導出等、配信前にconnectionsを使った計算が
+// 必要な呼び出し側が多いため、クエリ自体はこの関数の内側では行わない
+// （二重クエリを避ける）。除外したい接続があればexcludeConnectionIdで指定する。
+// payloadは固定値、または各接続（conn）ごとに内容を変えたい場合は関数を渡せる
+// （現状の呼び出し側はすべて固定値のため関数版は使っていないが、拡張の余地として残す）
+async function broadcastToRoom(event, connections, payload, { excludeConnectionId } = {}) {
+  const managementApi = buildManagementApiClient(event);
+  const targets = excludeConnectionId
+    ? connections.filter((conn) => conn.connectionId !== excludeConnectionId)
+    : connections;
+  await Promise.allSettled(
+    targets.map((conn) => postToConnection(
+      managementApi,
+      conn.connectionId,
+      typeof payload === "function" ? payload(conn) : payload
+    ))
+  );
+}
+
+// ルーム内接続一覧から参加者名一覧を導出する。setQuizRoomNameのように
+// 「自分自身の名前だけ確定前の新しい値に差し替える」必要がある場合のみ
+// renameConnectionId/renameToを指定する（それ以外の呼び出し側では未指定でよい）
+function collectParticipantNames(connections, { renameConnectionId, renameTo } = {}) {
+  return connections
+    .filter((conn) => conn.role === "participant")
+    .map((conn) => (conn.connectionId === renameConnectionId ? renameTo : conn.name))
+    .filter(Boolean);
+}
+
+// WebSocketカスタムルートの管理者/参加者ガード＋catchブロックの共通化。
+// ガードに使う接続の取得（getConnection）自体もここで行うため、ハンドラ側は
+// 「ガードを通った後の本処理」だけを書けばよい
+function withRoleGuard(role, handler) {
+  return async (event) => {
+    try {
+      const connectionId = event.requestContext.connectionId;
+      const connection = await getConnection(connectionId);
+      if (!connection || connection.role !== role) {
+        return { statusCode: 403, body: "Forbidden" };
+      }
+      return await handler(event, connection, connectionId);
+    } catch (error) {
+      console.error(error);
+      return { statusCode: 500, body: "Internal Server Error" };
+    }
+  };
+}
+
+// ガード（役割チェック）は不要だがcatchブロックの共通化だけ受けたいハンドラ向け
+// （connectQuizRoom・disconnectQuizRoom・syncQuizRoom）
+function withCatchAll(handler) {
+  return async (event) => {
+    try {
+      return await handler(event);
+    } catch (error) {
+      console.error(error);
+      return { statusCode: 500, body: "Internal Server Error" };
+    }
+  };
+}
+
+module.exports = {
+  getConnection,
+  queryRoomConnections,
+  buildManagementApiClient,
+  postToConnection,
+  broadcastToRoom,
+  collectParticipantNames,
+  withRoleGuard,
+  withCatchAll,
+};

--- a/frontend/src/components/Confetti.jsx
+++ b/frontend/src/components/Confetti.jsx
@@ -1,0 +1,21 @@
+// piecesの再生成タイミング（マウント時1回 vs ラウンドごと）は呼び出し側の
+// useMemo(() => buildConfettiPieces(), [...])の依存配列に委ねるため、
+// このコンポーネント自身は受け取ったpiecesを描画するだけにする（issue #804）
+function Confetti({ pieces }) {
+  if (!pieces || pieces.length === 0) return null;
+  return (
+    <div className="confetti-container" aria-hidden="true">
+      {pieces.map((c) => (
+        <span
+          key={c.id}
+          className="confetti-piece"
+          style={{ left: `${c.left}%`, animationDelay: `${c.delay}s`, animationDuration: `${c.duration}s` }}
+        >
+          {c.emoji}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default Confetti;

--- a/frontend/src/components/QuizCompletionScreen.jsx
+++ b/frontend/src/components/QuizCompletionScreen.jsx
@@ -1,45 +1,17 @@
 import { useMemo } from "react";
+import Confetti from "./Confetti";
+import { buildConfettiPieces } from "../utils/confetti";
 
 // 全札読了時の「おめでとう」演出画面（紙吹雪・セッションサマリー・スコア集計）。
 // App.jsxのisAllRead===true時に表示する
 // （issue #607: App.jsx肥大化解消のためコンポーネントとして切り出し）
-
-// Math.random()はレンダー中（useMemoのファクトリ関数を含む）に呼び出すと
-// react-hooks/purityに抵触するため、iから決定的に導出する疑似乱数を使う
-// （見た目のランダムさだけが目的で、実際の乱雑さの品質は問わない演出のため）
-const buildConfettiPieces = () => {
-  const emojis = ["🎉", "✨", "🎊", "⭐"];
-  const pseudoRandom = (seed) => {
-    const x = Math.sin(seed) * 10000;
-    return x - Math.floor(x);
-  };
-  return Array.from({ length: 24 }, (_, i) => ({
-    id: i,
-    emoji: emojis[i % emojis.length],
-    left: pseudoRandom(i) * 100,
-    delay: pseudoRandom(i + 100) * 0.6,
-    duration: 2.2 + pseudoRandom(i + 200) * 1.2,
-  }));
-};
 
 function QuizCompletionScreen({ sessionSummary, scoreSummary, restartCategory }) {
   const confettiPieces = useMemo(() => buildConfettiPieces(), []);
 
   return (
     <>
-      {confettiPieces.length > 0 && (
-        <div className="confetti-container" aria-hidden="true">
-          {confettiPieces.map(c => (
-            <span
-              key={c.id}
-              className="confetti-piece"
-              style={{ left: `${c.left}%`, animationDelay: `${c.delay}s`, animationDuration: `${c.duration}s` }}
-            >
-              {c.emoji}
-            </span>
-          ))}
-        </div>
-      )}
+      <Confetti pieces={confettiPieces} />
       <div className="alert alert-success py-5 mb-5 shadow-sm rounded-4 border-0">
         <h2 className="display-5 fw-bold mb-3">🎉 おめでとう！ 🎉</h2>
         <p className="lead mb-4">すべての札を読み上げました！</p>

--- a/frontend/src/components/TopViewChrome.jsx
+++ b/frontend/src/components/TopViewChrome.jsx
@@ -1,0 +1,27 @@
+// DivisionSelectView・CategorySelectViewで一字一句同一だったヒーローヘッダー・
+// フッターリンクの共通化（issue #804 16）
+
+export function HeroHeader() {
+  return (
+    <header className="text-center mb-5">
+      <img src="favicon.png" alt="かるたのアイコン" className="mb-4" style={{ width: "120px", height: "auto" }} />
+      <h1 className="display-4 fw-bold">かるた読み上げアプリ</h1>
+    </header>
+  );
+}
+
+export function TopViewFooterLinks({ setView, className = "text-center d-flex flex-column gap-2" }) {
+  return (
+    <div className={className}>
+      <button onClick={() => setView("all-phrases")} className="btn btn-link text-decoration-none text-muted">
+        全札一覧を見る →
+      </button>
+      <button onClick={() => setView("comments")} className="btn btn-link text-decoration-none text-muted small">
+        指摘された内容を確認する
+      </button>
+      <button onClick={() => setView("changelog")} className="btn btn-link text-decoration-none text-muted small">
+        更新履歴を見る
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/ViewHeader.jsx
+++ b/frontend/src/components/ViewHeader.jsx
@@ -1,0 +1,20 @@
+// CommentsView・ChangelogView・AllPhrasesView・DetailView・PrintEfudaViewで
+// ダミースペーサーdivまで含めて同一構造だった「← 戻る/タイトル/幅合わせ
+// スペーサー」ヘッダーの共通化（issue #804 5）。
+//
+// 見出しサイズ・余白・notranslateの有無は画面ごとに意図的に異なるため、
+// headingClassName/marginBottomをそのままpropsで渡し、暗黙のマッピングにしない。
+// E2Eが← 戻るのテキストを複数箇所で掴んでいるため、文言・DOM構造は変更しない。
+function ViewHeader({ onBack, title, headingClassName = "h2 fw-bold m-0 text-dark", marginBottom = "mb-4", noPrint = false }) {
+  return (
+    <header className={`text-center ${marginBottom} border-bottom pb-3${noPrint ? " no-print" : ""}`}>
+      <div className="d-flex justify-content-between align-items-center">
+        <button onClick={onBack} className="btn btn-sm btn-outline-secondary rounded-pill">← 戻る</button>
+        <h1 className={headingClassName}>{title}</h1>
+        <div style={{ width: "60px" }}></div>
+      </div>
+    </header>
+  );
+}
+
+export default ViewHeader;

--- a/frontend/src/utils/confetti.js
+++ b/frontend/src/utils/confetti.js
@@ -1,0 +1,18 @@
+// 全札読了時（QuizCompletionScreen）・早押し正解時（QuizRoomView）の紙吹雪演出（issue #804）の
+// 生成ロジック。Math.random()はレンダー中（呼び出し側のuseMemoファクトリ関数を含む）に
+// 呼び出すとreact-hooks/purityに抵触するため、iから決定的に導出する疑似乱数を使う
+// （見た目のランダムさだけが目的で、実際の乱雑さの品質は問わない演出のため）
+export function buildConfettiPieces() {
+  const emojis = ["🎉", "✨", "🎊", "⭐"];
+  const pseudoRandom = (seed) => {
+    const x = Math.sin(seed) * 10000;
+    return x - Math.floor(x);
+  };
+  return Array.from({ length: 24 }, (_, i) => ({
+    id: i,
+    emoji: emojis[i % emojis.length],
+    left: pseudoRandom(i) * 100,
+    delay: pseudoRandom(i + 100) * 0.6,
+    duration: 2.2 + pseudoRandom(i + 200) * 1.2,
+  }));
+}

--- a/frontend/src/views/AllPhrasesView.jsx
+++ b/frontend/src/views/AllPhrasesView.jsx
@@ -1,3 +1,5 @@
+import ViewHeader from "../components/ViewHeader";
+
 function AllPhrasesView({
   allPhrases,
   filterCategory,
@@ -41,13 +43,10 @@ function AllPhrasesView({
 
   return (
     <div className="container py-4 mx-auto">
-      <header className="text-center mb-4 border-bottom pb-3">
-        <div className="d-flex justify-content-between align-items-center">
-          <button onClick={() => { setView("game"); setSelectedCategories([]); setFilterCategory(''); setFilterDivision(''); setSearchQuery(''); }} className="btn btn-sm btn-outline-secondary rounded-pill">← 戻る</button>
-          <h1 className="h2 fw-bold m-0 text-dark">全札一覧</h1>
-          <div style={{ width: "60px" }}></div>
-        </div>
-      </header>
+      <ViewHeader
+        onBack={() => { setView("game"); setSelectedCategories([]); setFilterCategory(''); setFilterDivision(''); setSearchQuery(''); }}
+        title="全札一覧"
+      />
 
       <main className="mx-auto" style={{ maxWidth: "1200px" }}>
         {allPhrases.length === 0 ? (

--- a/frontend/src/views/CategorySelectView.jsx
+++ b/frontend/src/views/CategorySelectView.jsx
@@ -1,3 +1,5 @@
+import { HeroHeader, TopViewFooterLinks } from "../components/TopViewChrome";
+
 function CategorySelectView({
   division,
   categories,
@@ -14,10 +16,7 @@ function CategorySelectView({
 }) {
   return (
     <div className="container py-5 mx-auto">
-      <header className="text-center mb-5">
-        <img src="favicon.png" alt="かるたのアイコン" className="mb-4" style={{ width: "120px", height: "auto" }} />
-        <h1 className="display-4 fw-bold">かるた読み上げアプリ</h1>
-      </header>
+      <HeroHeader />
 
       <main className="category-selection-container p-4 mx-auto mb-5" style={{ maxWidth: "600px" }}>
         <div className="d-flex justify-content-start mb-3">
@@ -84,17 +83,7 @@ function CategorySelectView({
         )}
       </main>
 
-      <div className="text-center d-flex flex-column gap-2">
-        <button onClick={() => setView("all-phrases")} className="btn btn-link text-decoration-none text-muted">
-          全札一覧を見る →
-        </button>
-        <button onClick={() => setView("comments")} className="btn btn-link text-decoration-none text-muted small">
-          指摘された内容を確認する
-        </button>
-        <button onClick={() => setView("changelog")} className="btn btn-link text-decoration-none text-muted small">
-          更新履歴を見る
-        </button>
-      </div>
+      <TopViewFooterLinks setView={setView} />
     </div>
   );
 }

--- a/frontend/src/views/ChangelogView.jsx
+++ b/frontend/src/views/ChangelogView.jsx
@@ -1,16 +1,11 @@
 import ReactMarkdown from "react-markdown";
 import changelogData from "../changelog.json";
+import ViewHeader from "../components/ViewHeader";
 
 function ChangelogView({ setView }) {
   return (
     <div className="container py-4 mx-auto">
-      <header className="text-center mb-5 border-bottom pb-3">
-          <div className="d-flex justify-content-between align-items-center">
-          <button onClick={() => setView("game")} className="btn btn-sm btn-outline-secondary rounded-pill">← 戻る</button>
-          <h1 className="h2 fw-bold m-0 text-dark">更新履歴</h1>
-          <div style={{ width: "60px" }}></div>
-          </div>
-      </header>
+      <ViewHeader onBack={() => setView("game")} title="更新履歴" marginBottom="mb-5" />
       <main className="mx-auto" style={{ maxWidth: "800px" }}>
           {changelogData.length === 0 ? (
               <p className="text-muted text-center py-5">履歴はありません。</p>

--- a/frontend/src/views/CommentsView.jsx
+++ b/frontend/src/views/CommentsView.jsx
@@ -1,13 +1,9 @@
+import ViewHeader from "../components/ViewHeader";
+
 function CommentsView({ allComments, setView }) {
   return (
     <div className="container py-4 mx-auto">
-      <header className="text-center mb-5 border-bottom pb-3">
-        <div className="d-flex justify-content-between align-items-center">
-          <button onClick={() => setView("game")} className="btn btn-sm btn-outline-secondary rounded-pill">← 戻る</button>
-          <h1 className="h2 fw-bold m-0 text-dark">指摘された内容一覧</h1>
-          <div style={{ width: "60px" }}></div>
-        </div>
-      </header>
+      <ViewHeader onBack={() => setView("game")} title="指摘された内容一覧" marginBottom="mb-5" />
 
       <main className="mx-auto" style={{ maxWidth: "800px" }}>
         {allComments.length === 0 ? (

--- a/frontend/src/views/DetailView.jsx
+++ b/frontend/src/views/DetailView.jsx
@@ -1,3 +1,5 @@
+import ViewHeader from "../components/ViewHeader";
+
 function DetailView({
   detailPhrase,
   detailPhraseCategory,
@@ -12,13 +14,11 @@ function DetailView({
 }) {
   return (
     <div className="container py-4 mx-auto">
-      <header className="text-center mb-4 border-bottom pb-3">
-        <div className="d-flex justify-content-between align-items-center">
-          <button onClick={closeDetail} className="btn btn-sm btn-outline-secondary rounded-pill">← 戻る</button>
-          <h1 className="h4 m-0 fw-bold notranslate">{detailPhrase ? detailPhrase.category : (detailPhraseCategory || categoryLabel)} の詳細</h1>
-          <div style={{ width: "60px" }}></div>
-        </div>
-      </header>
+      <ViewHeader
+        onBack={closeDetail}
+        title={`${detailPhrase ? detailPhrase.category : (detailPhraseCategory || categoryLabel)} の詳細`}
+        headingClassName="h4 m-0 fw-bold notranslate"
+      />
 
       <main className="text-center py-4">
         {!detailPhrase ? (

--- a/frontend/src/views/DivisionSelectView.jsx
+++ b/frontend/src/views/DivisionSelectView.jsx
@@ -1,3 +1,5 @@
+import { HeroHeader, TopViewFooterLinks } from "../components/TopViewChrome";
+
 function DivisionSelectView({
   openQuizRooms,
   joinQuizRoom,
@@ -6,10 +8,7 @@ function DivisionSelectView({
 }) {
   return (
     <div className="container py-5 mx-auto">
-      <header className="text-center mb-5">
-        <img src="favicon.png" alt="かるたのアイコン" className="mb-4" style={{ width: "120px", height: "auto" }} />
-        <h1 className="display-4 fw-bold">かるた読み上げアプリ</h1>
-      </header>
+      <HeroHeader />
 
       <main className="category-selection-container p-4 mx-auto mb-5" style={{ maxWidth: "600px" }}>
         <h2 className="h4 text-center mb-4 text-dark">どなた向けに遊びますか？</h2>
@@ -63,17 +62,7 @@ function DivisionSelectView({
         </button>
       </div>
 
-      <div className="text-center d-flex flex-column gap-2 mt-4">
-        <button onClick={() => setView("all-phrases")} className="btn btn-link text-decoration-none text-muted">
-          全札一覧を見る →
-        </button>
-        <button onClick={() => setView("comments")} className="btn btn-link text-decoration-none text-muted small">
-          指摘された内容を確認する
-        </button>
-        <button onClick={() => setView("changelog")} className="btn btn-link text-decoration-none text-muted small">
-          更新履歴を見る
-        </button>
-      </div>
+      <TopViewFooterLinks setView={setView} className="text-center d-flex flex-column gap-2 mt-4" />
     </div>
   );
 }

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { API_BASE_URL } from "../config";
 import { serializeCategoriesParam } from "../hooks/useUrlQuerySync";
 import { setPrintScreenActive } from "../pdfExportStatus";
+import ViewHeader from "../components/ViewHeader";
 
 const getEfudaText = (p) => (p.answer && p.answer !== "-") ? p.answer : p.phrase;
 
@@ -134,13 +135,12 @@ function PrintEfudaView({ categoryLabel, onBack, selectedCategories, allPhrasesF
 
   return (
     <div className="container efuda-print-container py-4 mx-auto">
-      <header className="text-center mb-4 border-bottom pb-3 no-print">
-        <div className="d-flex justify-content-between align-items-center">
-          <button onClick={onBack} className="btn btn-sm btn-outline-secondary rounded-pill">← 戻る</button>
-          <h1 className="h4 m-0 fw-bold notranslate">{categoryLabel}の絵札印刷</h1>
-          <div style={{ width: "60px" }}></div>
-        </div>
-      </header>
+      <ViewHeader
+        onBack={onBack}
+        title={`${categoryLabel}の絵札印刷`}
+        headingClassName="h4 m-0 fw-bold notranslate"
+        noPrint
+      />
 
       {selectedCategories.length === 0 ? (
         <p className="text-muted text-center py-5 no-print">カテゴリを選択してください。</p>

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -8,6 +8,8 @@ import { phraseKey } from "../utils/phraseKey";
 import { clearRoomIdParam } from "../utils/quizRoomUrl";
 import AnswerAndExplanation from "../components/AnswerAndExplanation";
 import QuizRoomParticipantTable from "../components/QuizRoomParticipantTable";
+import Confetti from "../components/Confetti";
+import { buildConfettiPieces } from "../utils/confetti";
 
 // クイズ大会モード（issue #470）の参加者用入口（閲覧専用）。
 // ルームコードの直接入力、または招待URL（?roomId=...）からの参加に対応する。
@@ -265,28 +267,16 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
     buzz();
   };
 
-  // 早押し正解時の紙吹雪演出（issue #600）。App.jsxの読了時演出と同じ
-  // pseudoRandom(seed)パターンを流用し、useMemoファクトリ内でのMath.random()
-  // 呼び出し（react-hooks/purity）を避ける。showCelebrationはresult表示かつ
+  // 早押し正解時の紙吹雪演出（issue #600）。QuizCompletionScreenの読了時演出と
+  // 同じComponents/Confetti.jsxを流用する。showCelebrationはresult表示かつ
   // winner（正解と判定された回答者名）がある間だけtrueになり、次のラウンドの
   // 札が届く（roomState.typeが"phrase"に変わる）とfalseに戻るため、ラウンドが
   // 変わるたびに演出が再生成される
   const showCelebration = roomState?.type === "result" && !!roomState.content?.winner;
-  const confettiPieces = useMemo(() => {
-    if (!showCelebration) return [];
-    const emojis = ["🎉", "✨", "🎊", "⭐"];
-    const pseudoRandom = (seed) => {
-      const x = Math.sin(seed) * 10000;
-      return x - Math.floor(x);
-    };
-    return Array.from({ length: 24 }, (_, i) => ({
-      id: i,
-      emoji: emojis[i % emojis.length],
-      left: pseudoRandom(i) * 100,
-      delay: pseudoRandom(i + 100) * 0.6,
-      duration: 2.2 + pseudoRandom(i + 200) * 1.2,
-    }));
-  }, [showCelebration]);
+  const confettiPieces = useMemo(
+    () => (showCelebration ? buildConfettiPieces() : []),
+    [showCelebration]
+  );
 
   // issue #613: 正解時の演出（紙吹雪）と同じタイミングで、正解の音も鳴らす。
   // showCelebrationはラウンドが変わるたびfalse→trueと切り替わるため、trueに
@@ -484,19 +474,7 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
   if (joinRoomId) {
     return (
       <div className="container py-5 mx-auto text-center">
-        {showCelebration && (
-          <div className="confetti-container" aria-hidden="true">
-            {confettiPieces.map(c => (
-              <span
-                key={c.id}
-                className="confetti-piece"
-                style={{ left: `${c.left}%`, animationDelay: `${c.delay}s`, animationDuration: `${c.duration}s` }}
-              >
-                {c.emoji}
-              </span>
-            ))}
-          </div>
-        )}
+        <Confetti pieces={confettiPieces} />
         <header className="mb-4">
           <h1 className="h4 fw-bold">クイズ大会モード（参加者）</h1>
           <p className="text-muted small">ルーム: {joinRoomId}</p>


### PR DESCRIPTION
## Summary
issue #804の調査で洗い出した重複のうち、「最優先（低リスク・高効果・すぐ着手可）」とした5項目を実装しました（中優先・低優先の項目は対象外）。

1. **backend CORSレスポンス生成ヘルパー**（`backend/httpResponse.js`）: `jsonResponse`/`badRequest`/`notFound`/`serverError`を新設し、`handler.js`・`efudaPdfHandler.js`・`quizRoomHandler.js`（REST APIハンドラのみ）の約35箇所のベタ書きを置き換え。500応答の`error.message`有無の既存の揺れは統一せず、呼び出し側が選ぶ形で維持
2. **backend WebSocketの共通化**（`backend/quizRoomStore.js`）: `getConnection`・`queryRoomConnections`・`broadcastToRoom`・`collectParticipantNames`・管理者/参加者ガード＋catchブロック（`withRoleGuard`/`withCatchAll`）を切り出し。`judgeQuizRoomBuzz`・`closeQuizRoom`は個別ロジックを残しつつ配信部分のみ共通化
3. **Confettiコンポーネント**（`frontend/src/components/Confetti.jsx`）: `QuizCompletionScreen.jsx`と`QuizRoomView.jsx`に完全重複していた紙吹雪演出を統合。再生成タイミングの違い（マウント時1回 vs ラウンドごと）は呼び出し側のuseMemoに委ねる設計
4. **TopViewChrome**（`frontend/src/components/TopViewChrome.jsx`）: `DivisionSelectView`/`CategorySelectView`のヒーローヘッダー・フッターリンクを共通化
5. **ViewHeader**（`frontend/src/components/ViewHeader.jsx`）: `CommentsView`/`ChangelogView`/`AllPhrasesView`/`DetailView`/`PrintEfudaView`の5画面の「← 戻る/タイトル/スペーサー」ヘッダーを共通化。見出しサイズ・余白・notranslateの有無はpropsで吸収し、E2Eが依存する文言・DOM構造は変更なし

## Test plan
- [x] `cd frontend && npx eslint .`（エラー0件、警告61件。既存のsonarjs/complexity警告のみで新規エラーなし）
- [x] `cd frontend && npx vitest run`（250件成功、変更なし）
- [x] `cd backend && npx eslint .`（エラー0件、警告6件）
- [x] `cd backend && npx vitest run`（1543件成功、変更なし。`quizRoomHandler.test.js`の呼び出し順・引数検証を含め、既存テストが無変更のまま全件成功しリファクタによる外部挙動の変化が無いことを確認済み）
- [ ] このPRのCIが成功することをGitHub上で確認

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_