### PR TITLE
refactor: frontend/backendに重複していたeslint-plugin-sonarjsのwarn化ロジックを共通化する

### DIFF
--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,20 +1,9 @@
 const js = require("@eslint/js");
 const globals = require("globals");
 const sonarjs = require("eslint-plugin-sonarjs");
+const { buildSonarjsWarnRules } = require("../eslint-sonarjs-warn.cjs");
 
-// eslint-plugin-sonarjsのrecommended設定は全ルールerror severityだが、
-// 既存コードに対して一度に適用すると31件のエラーが発生し（複雑度の高い
-// handler.js/quizRoomHandler.js/seed.js等の大規模なリファクタが即座に必須に
-// なってしまう）、SonarCloud導入検討（issue #806）が意図した「低コストな導入」
-// から外れる。warnへ一括ダウングレードして導入し、実際に手を入れる際の指標
-// として使う（coverage_threshold・jscpdのduplication_thresholdと同様、
-// 既定は非ゲート）
-const sonarjsWarnRules = Object.fromEntries(
-  Object.entries(sonarjs.configs.recommended.rules).map(([rule, severity]) => [
-    rule,
-    Array.isArray(severity) ? ["warn", ...severity.slice(1)] : severity === "error" ? "warn" : severity,
-  ])
-);
+const sonarjsWarnRules = buildSonarjsWarnRules(sonarjs);
 
 module.exports = [
   {

--- a/eslint-sonarjs-warn.cjs
+++ b/eslint-sonarjs-warn.cjs
@@ -1,0 +1,21 @@
+"use strict";
+
+// eslint-plugin-sonarjsのrecommended設定は全ルールerror severityだが、既存コードに
+// 一度に適用すると大量のエラーが発生し（複雑度の高い関数の即座のリファクタが必須に
+// なってしまう）、SonarCloud導入検討（issue #806）が意図した「低コストな導入」から
+// 外れる。warnへ一括ダウングレードして導入し、実際に手を入れる際の指標として使う
+// （reusable-ci.ymlのcoverage_threshold・jscpdのduplication_thresholdと同様、
+// 既定は非ゲート）。frontend/backendのeslint.config.jsに同一のロジックが重複していた
+// ため共通化した（issue #815。dev-standardsへは切り出さず、frontend/backend間
+// （karuta内部）に閉じた重複としてkaruta直下に置く。理由はeslint-sonarjs-warn.cjs
+// 冒頭ではなくissue #815本文を参照）
+function buildSonarjsWarnRules(sonarjsPlugin) {
+  return Object.fromEntries(
+    Object.entries(sonarjsPlugin.configs.recommended.rules).map(([rule, severity]) => [
+      rule,
+      Array.isArray(severity) ? ["warn", ...severity.slice(1)] : severity === "error" ? "warn" : severity,
+    ])
+  );
+}
+
+module.exports = { buildSonarjsWarnRules };

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -4,19 +4,9 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import sonarjs from 'eslint-plugin-sonarjs'
 import { defineConfig, globalIgnores } from 'eslint/config'
+import { buildSonarjsWarnRules } from '../eslint-sonarjs-warn.cjs'
 
-// eslint-plugin-sonarjsのrecommended設定は全ルールerror severityだが、
-// 既存コードに対して一度に適用すると60件のエラーが発生し（複雑度の高い
-// App.jsx/QuizRoomView.jsx等の大規模なリファクタが即座に必須になってしまう）、
-// SonarCloud導入検討（issue #806）が意図した「低コストな導入」から外れる。
-// warnへ一括ダウングレードして導入し、実際に手を入れる際の指標として使う
-// （coverage_threshold・jscpdのduplication_thresholdと同様、既定は非ゲート）
-const sonarjsWarnRules = Object.fromEntries(
-  Object.entries(sonarjs.configs.recommended.rules).map(([rule, severity]) => [
-    rule,
-    Array.isArray(severity) ? ['warn', ...severity.slice(1)] : severity === 'error' ? 'warn' : severity,
-  ])
-)
+const sonarjsWarnRules = buildSonarjsWarnRules(sonarjs)
 
 export default defineConfig([
   globalIgnores(['dist', 'src/changelog.json', 'coverage']),


### PR DESCRIPTION
## Summary
- issue #806対応（PR #813）で、`frontend/eslint.config.js`と`backend/eslint.config.js`それぞれに、`eslint-plugin-sonarjs`のrecommended設定を`warn`へ一括ダウングレードする変換ロジックがほぼ同一の内容で重複していた
- 当初はdev-standardsへの切り出しを検討したが、`reusable-ci.yml`の`frontend-test`/`backend-test`ジョブのcheckoutは`submodules: true`を指定していない（`commitlint`ジョブのみ）ため、dev-standards側に置いてもlintを実行するジョブではdev-standards submoduleの中身が空でrequireできないことが判明。実現には新規の複合action・reusable-ci.ymlの複数ジョブへの配線変更が必要になり、この程度の重複解消にはコストが見合わないため見送った
- この重複はfrontend/backend間（karuta内部）に閉じており、複数リポジトリでの共有という動機も現時点で存在しないため、karuta直下に`eslint-sonarjs-warn.cjs`を1つ置き、frontend（ESM）・backend（CommonJS）の両方から相対パスで参照する方式にした

## Test plan
- [x] `cd frontend && npx eslint .`（エラー0件、警告60件。変更前と同一警告数）
- [x] `cd frontend && npx vitest run`（250件成功）
- [x] `cd backend && npx eslint .`（エラー0件、警告29件。変更前と同一警告数）
- [x] `cd backend && npx vitest run`（1543件成功）
- [ ] このPRのCIが成功することをGitHub上で確認

Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_