### PR TITLE
fix(e2e): Pollyコールドキャッシュ起因のE2E断続的失敗を緩和する

### DIFF
--- a/frontend/e2e/app-flows.spec.js
+++ b/frontend/e2e/app-flows.spec.js
@@ -175,8 +175,8 @@ test('engineer division: selects multiple categories, then prints combined efuda
 // 操作をまとめて検証する
 test('engineer division: toggles settings, records a taker, views history, and uses repeat/stop (issue #576)', async ({ browser }, testInfo) => {
   // 個別のtoBeVisible等のtimeout合計がグローバルの60秒を超えうる
-  // （Pollyコールドスタート待ち45秒+30秒 他）ため、テスト全体のtimeoutを底上げする
-  test.setTimeout(120000);
+  // （Pollyコールドスタート待ち60秒+30秒 他）ため、テスト全体のtimeoutを底上げする
+  test.setTimeout(150000);
 
   const context = await browser.newContext();
   const page = await context.newPage();
@@ -207,8 +207,9 @@ test('engineer division: toggles settings, records a taker, views history, and u
 
     await nextButton.click();
     // 他のカテゴリより実行頻度が低くPollyキャッシュがコールドになりやすいため
-    // （前回のCI実行で30秒では不足し実際にタイムアウトした）、余裕を持たせる
-    await expect(page.locator('.yomifuda-phrase')).toBeVisible({ timeout: 45000 });
+    // （30秒→45秒への引き上げ後もタイムアウトが再発したため、issue #820で
+    // 60秒へ再度引き上げた）、余裕を持たせる
+    await expect(page.locator('.yomifuda-phrase')).toBeVisible({ timeout: 60000 });
 
     // 取った人を記録する（表示中の札に対して）。exact: trueを指定しないと、
     // 参加者登録パネルの削除ボタン（aria-label="けんじを削除"）にも部分一致してしまい、

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -14,7 +14,10 @@ export default defineConfig({
   timeout: 60000,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 1 : 0,
+  // issue #820: Pollyコールドキャッシュ起因で稀に発生するタイムアウト（特に
+  // 実行頻度の低いカテゴリでの音声合成待ち）が、1回のリトライでも解消しない
+  // ことが複数回観測されたため、CI実行時のリトライ回数を1→2へ引き上げる
+  retries: process.env.CI ? 2 : 0,
   reporter: [
     // issue #711: CI用のhtmlレポーターは失敗の詳細（アサーション差分・エラー
     // メッセージ）をコンソール（GitHub Actionsのジョブログ）へ一切出力しない。


### PR DESCRIPTION
## Summary
- issue #576対応で追加した`engineer division「uses repeat/stop」`テストが、実行頻度の低いカテゴリ（Git大ピンチ）でPollyキャッシュがコールドになりやすく、`.yomifuda-phrase`の表示待ち（45秒）がCI実行時のリトライ（1回）後もタイムアウトすることが複数回観測された（PR #791/#797/#816/#819等）
- `playwright.config.js`: CI実行時の`retries`を1→2へ引き上げ
- `app-flows.spec.js`: 該当カテゴリの初回札表示待ちを45秒→60秒へ再度引き上げ（30秒→45秒でも再発したため）。テスト全体のtimeoutも他の待ち時間との合計に対して十分な余裕を持たせ120秒→150秒へ調整
- 恒久対応（Pollyキャッシュのウォームアップ等）は別途issue #820で継続検討する

## Test plan
- [x] `cd frontend && npx eslint .`（エラー0件、警告60件。変更なし）
- [x] `cd frontend && npx vitest run`（250件成功）
- [x] `cd backend && npx eslint . && npx vitest run`（エラー0件・警告29件、1543件成功。このPRの変更範囲外だが対象パッケージルールに基づき確認）
- [ ] このPRのCI（E2E含む）が成功することをGitHub上で確認

Refs #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_