### PR TITLE
feat(ci): docs内のmermaid図をSVG事前レンダリングして常時確認できるようにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,10 @@ jobs:
       # ままにする）
       coverage_threshold: 80
       coverage_metrics: "statements,functions,lines"
+      # issue #824: docs/cicd-pipeline-specification.mdのArchitecture図を
+      # SVGへ事前レンダリングし、PR差分ビュー・API経由でのファイル取得等で
+      # mermaidがネイティブレンダリングされない場面でも確認できるようにする
+      enable_mermaid_render: true
+      mermaid_doc_paths: "docs/cicd-pipeline-specification.md"
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/docs/cicd-pipeline-specification.md
+++ b/docs/cicd-pipeline-specification.md
@@ -18,6 +18,10 @@ graph TD
     G --> I[Deploy Backend to AWS];
 ```
 
+上記の```mermaid```ブロックはPR差分ビュー・API経由でのファイル取得等ではテキストのまま表示され図として確認できない（[bamiyanapp/karuta#824](https://github.com/bamiyanapp/karuta/issues/824)）。ソース（mermaid記法）はこのまま維持しつつ、以下は`enable_mermaid_render` job（[dev-standards側ドキュメント](../dev-standards/docs/cicd-pipeline-specification.md#1-ci-ワークフロー-reusable-ciyml)参照）が`main`へのマージのたびに再レンダリングし、`docs-diagrams`ブランチの`latest/`へ上書き公開している画像（常に最新版）。
+
+![Architecture (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/cicd-pipeline-specification.svg)
+
 semantic-releaseの実行は`main`へのpush後（CD側の`release`ジョブ）で行われる。以前はPRの作業ブランチ上でマージ前に実行する方式だったが、GitHub Actionsの`pull_request`イベントで自動設定される`GITHUB_REF`（ワークフローYAMLの`env:`では上書き不可）により常にリリースが発行されない不具合があったため、`main`への実pushイベント上で実行する方式に修正した（[dev-standards#43](https://github.com/bamiyanapp/dev-standards/pull/43)）。
 
 karutaの`main`は「変更は必ずPR経由」のリポジトリルールで保護されているため、`release`ジョブによる`main`への直接pushはそのままではGH013エラーで拒否される。この問題に対応するため、直接pushが失敗した場合はローカルに作成済みのリリースコミットを新しいブランチへpushし、`main`へのPRを作成してAPI経由でsquash mergeするフォールバックが追加されている（[dev-standards#44](https://github.com/bamiyanapp/dev-standards/pull/44)、タグ名の導出方法の修正が[dev-standards#45](https://github.com/bamiyanapp/dev-standards/pull/45)、GitHub Release作成の冪等化が[dev-standards#46](https://github.com/bamiyanapp/dev-standards/pull/46)）。karuta運用者が意識する必要がある手順の違いはなく、`release`ジョブの結果として`new_release_published`が正しく出力されればデプロイジョブは通常どおり実行される。詳細は[dev-standards側ドキュメント](../dev-standards/docs/cicd-pipeline-specification.md#4-リリース運用)を参照。


### PR DESCRIPTION
## Summary
- dev-standards側で追加した`render-mermaid-diagrams` job（bamiyanapp/dev-standards#116, #117, #119、`v1.12.0`で最終形リリース済み。`ci.yml`の参照タグは既にRenovateにより`v1.12.0`へ更新済み）をkaruta側でも有効化する
- `docs/cicd-pipeline-specification.md`のArchitecture図（mermaidブロック）を対象に`enable_mermaid_render: true`・`mermaid_doc_paths`を指定した
- `push`（`main`へのマージ）のたびに`docs-diagrams`ブランチの`latest/`へ上書き公開される安定URLを、Architecture図のmermaidブロック直後へ`[...](``...)'として恒久的に埋め込んだ。mermaidソース自体は維持したまま、PR差分ビュー・API経由でのファイル取得等mermaidがネイティブレンダリングされない場面でもドキュメント本体から常に最新のレンダリング結果を確認できるようにする（dev-standards側の同じ仕組み・埋め込みパターンを踏襲）``

## Test plan
- [x] dev-standardsのactionlintで`ci.yml`を含むワークフローファイルを検証し問題なし
- [x] `cd frontend && npx eslint .`（エラー0件、警告60件。変更なし）
- [x] `cd frontend && npx vitest run`（250件成功）
- [x] `cd backend && npx eslint . && npx vitest run`（エラー0件・警告29件、1543件成功。このPRの変更範囲外だが対象パッケージルールに基づき確認）
- [ ] このPRのCI（`render-mermaid-diagrams` jobを含む）が成功することをGitHub上で確認
- [ ] マージ後、`docs/cicd-pipeline-specification.md`をGitHub上で開き、埋め込んだ画像リンクが実際にレンダリングされた図を表示することを確認

Refs #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_