### PR TITLE
feat(ci): mermaid図の対象拡張とcomplexity/sonarjs/jscpdのゲート化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,11 @@ jobs:
       # ままにする）
       coverage_threshold: 80
       coverage_metrics: "statements,functions,lines"
-      # issue #824: docs/cicd-pipeline-specification.mdのArchitecture図を
-      # SVGへ事前レンダリングし、PR差分ビュー・API経由でのファイル取得等で
-      # mermaidがネイティブレンダリングされない場面でも確認できるようにする
+      # issue #824: docs/cicd-pipeline-specification.mdおよびREADME.md（System
+      # Architecture／Screen Transitionsの2図）のmermaid図をSVGへ事前レンダリング
+      # し、PR差分ビュー・API経由でのファイル取得等でmermaidがネイティブ
+      # レンダリングされない場面でも確認できるようにする
       enable_mermaid_render: true
-      mermaid_doc_paths: "docs/cicd-pipeline-specification.md"
+      mermaid_doc_paths: "docs/cicd-pipeline-specification.md\nREADME.md"
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,13 @@ jobs:
       enable_standards_check: true
       workspaces: true # npm workspaces構成（issue #608）。依存インストールをリポジトリルートで一括実行する
       # SonarCloud相当の静的解析（issue #806）のうち、コード重複検知（jscpd）を有効化する。
-      # duplication_thresholdは既定0（レポート表示のみ、ゲートなし）のまま据え置く。
-      # 試験実行時点の重複率は約22%あり、いきなりしきい値でゲートすると即座にCIが
-      # 赤くなるため、まずはJob Summaryでの可視化のみ行い、具体的なしきい値・ゲート化の
-      # 要否は実際のレポートを見ながら別途検討する
+      # 導入直後はduplication_threshold未指定（レポート表示のみ、ゲートなし）としていたが、
+      # 検出しても何も強制されない状態が放置されていたため、現状の重複率
+      # （2026-07-25時点で実測20.31%、行ベース）をベースラインとしたラチェット方式で
+      # ゲートを有効化する。既存の重複はすぐには解消せず、今後の増加のみを防ぐ
+      # （個別の削減はissue #833で追跡する）
       enable_duplication_check: true
+      duplication_threshold: 21
       # 分岐(branches)カバレッジ80%必須化（issue #459）のうち、branches指標のみ
       # 引き続き見送る。backend側で、複数のテストファイルが同一のソースファイル
       # （例: backend/handler.js）をimportする構成において、@vitest/coverage-v8の

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ graph TD
     I -->|クイズ大会モード| P;
 ```
 
+上記の```mermaid```ブロックはPR差分ビュー・API経由でのファイル取得等ではテキストのまま表示され図として確認できない（[#824](https://github.com/bamiyanapp/karuta/issues/824)）。ソースはこのまま維持しつつ、以下は`enable_mermaid_render` job（[docs/cicd-pipeline-specification.md](./docs/cicd-pipeline-specification.md)参照）が`main`へのマージのたびに再レンダリングし、`docs-diagrams`ブランチの`latest/`へ上書き公開している画像（常に最新版）。
+
+![System Architecture (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/README-1.svg)
+
 ### Screen Transitions
 
 ```mermaid
@@ -111,6 +115,10 @@ graph TD
 
     J -->|戻る| Z
 ```
+
+同様に、上記図もCIが再レンダリングし`docs-diagrams`ブランチの`latest/`へ公開している画像。
+
+![Screen Transitions (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/README-2.svg)
 
 ### Backend API (AWS Lambda)
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 29",
     "test": "vitest",
     "deploy": "npx osls deploy"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 60",
     "preview": "vite preview",
     "test": "vitest",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Summary
- **issue #824**: `docs/cicd-pipeline-specification.md`のみを`mermaid_doc_paths`の対象としていたが、README.mdにも「System Architecture」「Screen Transitions」の2つのmermaid図が存在し、PR差分ビュー・API経由でのファイル取得等でテキストのまま埋もれていたため対象に追加。`render-mermaid.js`の命名規則（1ファイル内に複数mermaidブロックがある場合`<basename>-<index>.svg`）に従い、`README-1.svg`／`README-2.svg`として`docs-diagrams`ブランチの`latest/`へ公開される想定で、各図の直後に画像埋め込みリンクを追記
- **issue #833**: issue #806で導入したESLintの`complexity`ルール・`eslint-plugin-sonarjs`（warn severity）・jscpd（`duplication_threshold`未指定）は、検出してもジョブが失敗しない状態だった。frontend/backendの`lint`スクリプトへ`--max-warnings`（現状値をベースラインとしたラチェット、frontend: 60・backend: 29）、`ci.yml`の`duplication_threshold`を21（現状の行ベース重複率20.31%に僅かな余裕を持たせた値）に設定し、今後の増加をゲートするようにした。既存の指摘・重複の削減自体はissue #833で別途追跡する

## Test plan
- [x] `frontend`: `npx eslint .`（0 errors、60 warnings、ベースライン内）／ `npx vitest run`（250 passed）
- [x] `backend`: `npx eslint .`（0 errors、29 warnings、ベースライン内）／ `npx vitest run`（1543 passed）
- [x] `ci.yml`をjs-yamlでパースし、`mermaid_doc_paths`・`duplication_threshold`の値を確認
- [x] jscpdをローカル実行し現状の重複率が20.31%（閾値21に対し超過なし）であることを確認
- [ ] CI（`render-mermaid-diagrams`ジョブ）でREADME.mdから2つのSVGが生成されることを確認
- [ ] CI（`duplication-check`ジョブ）が現状の重複率でゲートを通過することを確認
- [ ] マージ後、`docs-diagrams`ブランチの`latest/README-1.svg`・`latest/README-2.svg`が生成され、README.mdの画像リンクが実際に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
