### PR TITLE
chore(release): v1.58.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.58.0](https://github.com/bamiyanapp/karuta/compare/v1.57.0...v1.58.0) (2026-07-25)
+
+
+### Features
+
+* **ci:** mermaid図の対象拡張とcomplexity/sonarjs/jscpdのゲート化 ([#832](https://github.com/bamiyanapp/karuta/issues/832)) ([ecb269f](https://github.com/bamiyanapp/karuta/commit/ecb269fdb2b824ccc3c3dca79b2c6bafc2aba8e5)), closes [#833](https://github.com/bamiyanapp/karuta/issues/833)
+
 # [1.57.0](https://github.com/bamiyanapp/karuta/compare/v1.56.1...v1.57.0) (2026-07-25)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.57.0",
+    "version": "1.58.0",
     "date": "2026/07/25",
+    "body": "### Features\n\n* **ci:** mermaid図の対象拡張とcomplexity/sonarjs/jscpdのゲート化 ([#832](https://github.com/bamiyanapp/karuta/issues/832)) ([ecb269f](https://github.com/bamiyanapp/karuta/commit/ecb269fdb2b824ccc3c3dca79b2c6bafc2aba8e5)), closes [#833](https://github.com/bamiyanapp/karuta/issues/833)"
+  },
+  {
+    "version": "1.57.0",
+    "date": "2026/07/25 22:50",
     "body": "### Features\n\n* **ci:** docs内のmermaid図をSVG事前レンダリングして常時確認できるようにする（issue [#824](https://github.com/bamiyanapp/karuta/issues/824)） ([#829](https://github.com/bamiyanapp/karuta/issues/829)) ([a29da41](https://github.com/bamiyanapp/karuta/commit/a29da4187eab857e359ad8432b8141ba171965b1)), closes [bamiyanapp/dev-standards#116](https://github.com/bamiyanapp/dev-standards/issues/116) [#117](https://github.com/bamiyanapp/karuta/issues/117)"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.57.0",
+  "version": "1.58.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.57.0",
+      "version": "1.58.0",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.57.0"
+  "version": "1.58.0"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。