### PR TITLE
fix(quality): issue #806の静的解析指摘・重複を解消しゲートを引き下げる

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,13 @@ jobs:
       workspaces: true # npm workspaces構成（issue #608）。依存インストールをリポジトリルートで一括実行する
       # SonarCloud相当の静的解析（issue #806）のうち、コード重複検知（jscpd）を有効化する。
       # 導入直後はduplication_threshold未指定（レポート表示のみ、ゲートなし）としていたが、
-      # 検出しても何も強制されない状態が放置されていたため、現状の重複率
-      # （2026-07-25時点で実測20.31%、行ベース）をベースラインとしたラチェット方式で
-      # ゲートを有効化する。既存の重複はすぐには解消せず、今後の増加のみを防ぐ
-      # （個別の削減はissue #833で追跡する）
+      # 検出しても何も強制されない状態が放置されていたため、現状の重複率（行ベース）を
+      # ベースラインとしたラチェット方式でゲートを有効化する。issue #833でQuizRoomView等
+      # の重複解消を進め、20.31%→18.64%まで削減できたためしきい値も引き下げた。
+      # 残る重複は主にテストファイル（App.test.jsx・QuizRoomView.test.jsx等）で、
+      # 引き続きissue #833で追跡する
       enable_duplication_check: true
-      duplication_threshold: 21
+      duplication_threshold: 19
       # 分岐(branches)カバレッジ80%必須化（issue #459）のうち、branches指標のみ
       # 引き続き見送る。backend側で、複数のテストファイルが同一のソースファイル
       # （例: backend/handler.js）をimportする構成において、@vitest/coverage-v8の

--- a/backend/backfill-polly-cache-ttl.test.js
+++ b/backend/backfill-polly-cache-ttl.test.js
@@ -42,7 +42,7 @@ describe('backfillPollyCacheTtl', () => {
 
     expect(updatedCount).toBe(2);
     const scanCalls = ddbMock.commandCalls(ScanCommand);
-    expect(scanCalls.length).toBe(2);
+    expect(scanCalls).toHaveLength(2);
     expect(scanCalls[1].args[0].input.ExclusiveStartKey).toEqual({ id: 'cache1' });
   });
 
@@ -63,7 +63,7 @@ describe('backfillPollyCacheTtl', () => {
     const updatedCount = await backfillPollyCacheTtl();
 
     expect(updatedCount).toBe(0);
-    expect(ddbMock.commandCalls(UpdateCommand).length).toBe(0);
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
   });
 
   it('treats a Scan response with no Items field as an empty page instead of throwing', async () => {

--- a/backend/backfill-total-stats.test.js
+++ b/backend/backfill-total-stats.test.js
@@ -44,7 +44,7 @@ describe('backfillTotalStats', () => {
 
     expect(updatedCount).toBe(2);
     const scanCalls = ddbMock.commandCalls(ScanCommand);
-    expect(scanCalls.length).toBe(2);
+    expect(scanCalls).toHaveLength(2);
     expect(scanCalls[1].args[0].input.ExclusiveStartKey).toEqual({ category: 'c1', id: 'p1' });
     const updatedIds = ddbMock.commandCalls(UpdateCommand).map(call => call.args[0].input.Key.id);
     expect(updatedIds).toEqual(['p1', 'p2']);
@@ -84,6 +84,6 @@ describe('backfillTotalStats', () => {
     const updatedCount = await backfillTotalStats();
 
     expect(updatedCount).toBe(0);
-    expect(ddbMock.commandCalls(UpdateCommand).length).toBe(0);
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
   });
 });

--- a/backend/efudaPdfHandler.test.js
+++ b/backend/efudaPdfHandler.test.js
@@ -32,7 +32,7 @@ vi.mock('puppeteer-core', () => ({
 vi.mock('@sparticuz/chromium', () => ({
   default: {
     args: ['--chromium-arg'],
-    executablePath: vi.fn().mockResolvedValue('/tmp/chromium'),
+    executablePath: vi.fn().mockResolvedValue('/opt/mock-chromium/chromium'),
   },
 }));
 

--- a/backend/handler.js
+++ b/backend/handler.js
@@ -253,6 +253,105 @@ exports.getCongratulationAudio = async (event) => {
 // レコードが際限なく増加しないよう、DynamoDB TTLで一定期間後に自動削除する
 const POLLY_CACHE_TTL_SECONDS = 30 * 24 * 60 * 60; // 30日
 
+// getPhrase用: id/categoryの指定状況に応じて対象の1件を取得する。
+// getPhrase本体の複雑度を抑えるため分離している
+async function findPhraseItem(targetId, category) {
+  if (targetId && category) {
+    // IDとカテゴリ両方ある場合はGetItem
+    const getResult = await docClient.send(new GetCommand({
+      TableName: process.env.TABLE_NAME,
+      Key: { category, id: targetId },
+    }));
+    return getResult.Item;
+  }
+
+  // それ以外は従来通りScan（またはQueryに最適化可能だが一旦Scan）
+  const scanParams = {
+    TableName: process.env.TABLE_NAME,
+    ProjectionExpression: "id, category, phrase, #lvl, kana, phrase_en, answer, explanation, readCount, averageTime, averageDifficulty, totalTime, totalDifficulty",
+    ExpressionAttributeNames: {
+      "#lvl": "level",
+    },
+  };
+  const scanResult = await docClient.send(new ScanCommand(scanParams));
+  let items = scanResult.Items || [];
+
+  if (targetId) {
+    return items.find(item => item.id === targetId);
+  }
+  if (category) {
+    items = items.filter(item => (item.category || "").trim() === category.trim());
+  }
+  if (items.length === 0) {
+    return null;
+  }
+  // eslint-disable-next-line sonarjs/pseudo-random -- かるたの札をランダムに選ぶだけの用途で暗号学的な強度は不要
+  const randomIndex = Math.floor(Math.random() * items.length);
+  return items[randomIndex];
+}
+
+// getPhrase用: 読み上げ内容（SSML）を組み立てる純粋関数。getPhrase本体の
+// 複雑度を抑えるため分離している
+function buildPhraseSsml({ lang, level, speechPhrase, repeatCount, announceCategory, category, speechRate }) {
+  const levelPrefix = lang === "en" ? "Level" : "レベル";
+  const hasLevel = level !== "-" && level !== null && level !== undefined && String(level).trim() !== "";
+  const escapedPhrase = escapeSsml(speechPhrase);
+  const phraseWithLevel = hasLevel ? `${levelPrefix}, ${escapeSsml(level)}. ${escapedPhrase}` : escapedPhrase;
+
+  let innerContent = phraseWithLevel;
+  if (repeatCount >= 2) {
+    innerContent = `${phraseWithLevel}<break time="1500ms"/>${phraseWithLevel}`;
+  }
+  // 複数種別を選択している場合、読み札がどの種別のものかを最後に1回だけ読み上げる（言語設定によらず日本語で読み上げる）
+  if (announceCategory && category) {
+    innerContent = `${innerContent}<break time="800ms"/>${escapeSsml(category)}`;
+  }
+  return `<speak><prosody rate="${speechRate}">${innerContent}</prosody></speak>`;
+}
+
+// getPhrase用: Pollyキャッシュ（DynamoDB）にヒットすればその音声を返す
+async function getCachedPhraseAudio(pollyCacheTableName, cacheId, targetId) {
+  if (!pollyCacheTableName) {
+    return null;
+  }
+  const cachedAudio = await docClient.send(new GetCommand({
+    TableName: pollyCacheTableName,
+    Key: { id: cacheId },
+  }));
+  if (!cachedAudio.Item) {
+    return null;
+  }
+  console.log("Serving audio from cache for id:", targetId);
+  return cachedAudio.Item.audioData;
+}
+
+// getPhrase用: Pollyで音声を合成し、キャッシュ有効時はDynamoDBへ保存する
+async function synthesizePhraseAudio({ ssmlText, voiceId, engine, pollyCacheTableName, cacheId }) {
+  const command = new SynthesizeSpeechCommand({
+    Text: ssmlText,
+    TextType: "ssml",
+    OutputFormat: "mp3",
+    VoiceId: voiceId,
+    Engine: engine
+  });
+  const pollyResponse = await pollyClient.send(command);
+  const audioBuffer = await streamToBuffer(pollyResponse.AudioStream);
+  const audioData = `data:audio/mp3;base64,${audioBuffer.toString("base64")}`;
+
+  if (pollyCacheTableName) {
+    await docClient.send(new PutCommand({
+      TableName: pollyCacheTableName,
+      Item: {
+        id: cacheId,
+        audioData: audioData,
+        createdAt: new Date().toISOString(),
+        ttl: Math.floor(Date.now() / 1000) + POLLY_CACHE_TTL_SECONDS,
+      },
+    }));
+  }
+  return audioData;
+}
+
 exports.getPhrase = async (event) => {
   const allowedOrigin = resolveAllowedOrigin(event);
   try {
@@ -266,49 +365,12 @@ exports.getPhrase = async (event) => {
     let targetId = params.id || null;
     const pollyCacheTableName = process.env.POLLY_CACHE_TABLE_NAME;
 
-    let selectedItem = null;
-
-    if (targetId && category) {
-      // IDとカテゴリ両方ある場合はGetItem
-      const getResult = await docClient.send(new GetCommand({
-        TableName: process.env.TABLE_NAME,
-        Key: { category, id: targetId },
-      }));
-      selectedItem = getResult.Item;
-    } else {
-      // それ以外は従来通りScan（またはQueryに最適化可能だが一旦Scan）
-      const scanParams = {
-        TableName: process.env.TABLE_NAME,
-        ProjectionExpression: "id, category, phrase, #lvl, kana, phrase_en, answer, explanation, readCount, averageTime, averageDifficulty, totalTime, totalDifficulty",
-        ExpressionAttributeNames: {
-          "#lvl": "level",
-        },
-      };
-
-      const scanResult = await docClient.send(new ScanCommand(scanParams));
-      let items = scanResult.Items || [];
-
-      if (targetId) {
-        selectedItem = items.find(item => item.id === targetId);
-      } else {
-        if (category) {
-          items = items.filter(item => (item.category || "").trim() === category.trim());
-        }
-        
-        if (items.length > 0) {
-          const randomIndex = Math.floor(Math.random() * items.length);
-          selectedItem = items[randomIndex];
-        }
-      }
-    }
-
+    const selectedItem = await findPhraseItem(targetId, category);
     if (!selectedItem) {
       return notFound(allowedOrigin, "Phrase not found");
     }
 
     targetId = selectedItem.id;
-
-    let audioData = null;
 
     const level = selectedItem.level;
     const speechPhrase = lang === "en"
@@ -320,60 +382,18 @@ exports.getPhrase = async (event) => {
       `${targetId}-${repeatCount}-${speechRate}-${lang}-${announceCategory}-${voiceId}-${JSON.stringify([level, speechPhrase, selectedItem.category])}`
     ).digest("hex");
 
-    if (pollyCacheTableName) {
-      const cachedAudio = await docClient.send(new GetCommand({
-        TableName: pollyCacheTableName,
-        Key: { id: cacheId },
-      }));
-      if (cachedAudio.Item) {
-        console.log("Serving audio from cache for id:", targetId);
-        audioData = cachedAudio.Item.audioData;
-      }
-    }
-
+    let audioData = await getCachedPhraseAudio(pollyCacheTableName, cacheId, targetId);
     if (!audioData) {
-      const levelPrefix = lang === "en" ? "Level" : "レベル";
-
-      const hasLevel = level !== "-" && level !== null && level !== undefined && String(level).trim() !== "";
-      const escapedPhrase = escapeSsml(speechPhrase);
-      const phraseWithLevel = hasLevel ? `${levelPrefix}, ${escapeSsml(level)}. ${escapedPhrase}` : escapedPhrase;
-
-      let innerContent = phraseWithLevel;
-      if (repeatCount >= 2) {
-        innerContent = `${phraseWithLevel}<break time="1500ms"/>${phraseWithLevel}`;
-      }
-
-      // 複数種別を選択している場合、読み札がどの種別のものかを最後に1回だけ読み上げる（言語設定によらず日本語で読み上げる）
-      if (announceCategory && selectedItem.category) {
-        innerContent = `${innerContent}<break time="800ms"/>${escapeSsml(selectedItem.category)}`;
-      }
-
-      const ssmlText = `<speak><prosody rate="${speechRate}">${innerContent}</prosody></speak>`;
-
-      const command = new SynthesizeSpeechCommand({
-        Text: ssmlText,
-        TextType: "ssml",
-        OutputFormat: "mp3",
-        VoiceId: voiceId,
-        Engine: engine
+      const ssmlText = buildPhraseSsml({
+        lang,
+        level,
+        speechPhrase,
+        repeatCount,
+        announceCategory,
+        category: selectedItem.category,
+        speechRate,
       });
-      const pollyResponse = await pollyClient.send(command);
-
-      const audioBuffer = await streamToBuffer(pollyResponse.AudioStream);
-      const base64Audio = audioBuffer.toString("base64");
-      audioData = `data:audio/mp3;base64,${base64Audio}`;
-
-      if (pollyCacheTableName) {
-        await docClient.send(new PutCommand({
-          TableName: pollyCacheTableName,
-          Item: {
-            id: cacheId,
-            audioData: audioData,
-            createdAt: new Date().toISOString(),
-            ttl: Math.floor(Date.now() / 1000) + POLLY_CACHE_TTL_SECONDS,
-          },
-        }));
-      }
+      audioData = await synthesizePhraseAudio({ ssmlText, voiceId, engine, pollyCacheTableName, cacheId });
     }
 
     const stats = computePhraseStats(selectedItem);

--- a/backend/handler.test.js
+++ b/backend/handler.test.js
@@ -13,6 +13,13 @@ const pollyMock = mockClient(PollyClient);
 vi.spyOn(crypto, 'randomUUID').mockReturnValue('mock-uuid');
 vi.spyOn(console, 'error').mockImplementation(() => {});
 
+function createAudioStream() {
+    const s = new Readable();
+    s.push('audio data');
+    s.push(null);
+    return s;
+}
+
 
 describe('resolveAllowedOrigin', () => {
   it('reflects the request origin when it is on the allow-list', () => {
@@ -331,7 +338,7 @@ describe('postComment', () => {
         };
         const response = await postComment(event);
         expect(response.statusCode).toBe(400);
-        expect(ddbMock.commandCalls(PutCommand).length).toBe(0);
+        expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
     });
 
     it('should accept a comment exactly at the maximum length', async () => {
@@ -478,7 +485,7 @@ describe('getCongratulationAudio', () => {
         await getCongratulationAudio(event);
         
         const pollyCalls = pollyMock.calls();
-        expect(pollyCalls.length).toBe(1);
+        expect(pollyCalls).toHaveLength(1);
         const pollyParams = pollyCalls[0].args[0].input;
         expect(pollyParams.Text).toContain('<prosody rate="120%">');
     });
@@ -746,7 +753,7 @@ describe('getPhrase', () => {
         const body = JSON.parse(response.body);
         expect(body.id).toBe('p1');
         expect(body.readCount).toBe(5);
-        expect(body.averageTime).toBe(12.3);
+        expect(body.averageTime).toBeCloseTo(12.3);
     });
 
     it('looks up a phrase directly via GetItem (skipping the Scan) when both id and category are provided', async () => {
@@ -767,7 +774,7 @@ describe('getPhrase', () => {
 
         expect(response.statusCode).toBe(200);
         expect(body.id).toBe('p1');
-        expect(ddbMock.commandCalls(ScanCommand).length).toBe(0);
+        expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(0);
     });
 
     it('filters out items whose category does not match (tolerating a missing category field on other items), returning 404 when nothing matches', async () => {
@@ -819,8 +826,8 @@ describe('getPhrase', () => {
         const response = await getPhrase(event);
 
         expect(response.statusCode).toBe(200);
-        expect(ddbMock.commandCalls(GetCommand).length).toBe(0);
-        expect(ddbMock.commandCalls(PutCommand).length).toBe(0);
+        expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
+        expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
     });
 
     it('uses averageTime/averageDifficulty as a legacy fallback (0 when also absent) when only one of totalTime/totalDifficulty is present (partial migration)', async () => {
@@ -922,7 +929,7 @@ describe('getPhrase', () => {
         await getPhrase(event);
 
         const pollyCalls = pollyMock.calls();
-        expect(pollyCalls.length).toBe(1);
+        expect(pollyCalls).toHaveLength(1);
         const pollyParams = pollyCalls[0].args[0].input;
         expect(pollyParams.Text).toContain('<prosody rate="110%">');
     });
@@ -1113,13 +1120,7 @@ describe('getPhrase', () => {
         ddbMock.on(GetCommand).resolves({ Item: undefined }); // Cache miss
         ddbMock.on(PutCommand).resolves({});
 
-        const audioStream = () => {
-            const s = new Readable();
-            s.push('audio data');
-            s.push(null);
-            return s;
-        };
-        pollyMock.on(SynthesizeSpeechCommand).callsFake(() => ({ AudioStream: audioStream() }));
+        pollyMock.on(SynthesizeSpeechCommand).callsFake(() => ({ AudioStream: createAudioStream() }));
 
         ddbMock.on(ScanCommand).resolves({
             Items: [{ id: 'p1', category: '犬棒かるた', phrase: 'phrase 1', level: '-' }],
@@ -1139,13 +1140,7 @@ describe('getPhrase', () => {
         ddbMock.on(GetCommand).resolves({ Item: undefined }); // Cache miss
         ddbMock.on(PutCommand).resolves({});
 
-        const audioStream = () => {
-            const s = new Readable();
-            s.push('audio data');
-            s.push(null);
-            return s;
-        };
-        pollyMock.on(SynthesizeSpeechCommand).callsFake(() => ({ AudioStream: audioStream() }));
+        pollyMock.on(SynthesizeSpeechCommand).callsFake(() => ({ AudioStream: createAudioStream() }));
 
         ddbMock.on(ScanCommand).resolves({
             Items: [{ id: 'p1', category: 'c1', phrase: '元の読み札', level: '1' }],
@@ -1167,13 +1162,7 @@ describe('getPhrase', () => {
         ddbMock.on(GetCommand).resolves({ Item: undefined }); // Cache miss
         ddbMock.on(PutCommand).resolves({});
 
-        const audioStream = () => {
-            const s = new Readable();
-            s.push('audio data');
-            s.push(null);
-            return s;
-        };
-        pollyMock.on(SynthesizeSpeechCommand).callsFake(() => ({ AudioStream: audioStream() }));
+        pollyMock.on(SynthesizeSpeechCommand).callsFake(() => ({ AudioStream: createAudioStream() }));
 
         ddbMock.on(ScanCommand).resolves({
             Items: [{ id: 'p1', category: 'c1', phrase: '元の読み札', phrase_en: 'Original phrase', level: '1' }],
@@ -1209,9 +1198,9 @@ describe('recordTime', () => {
         expect(response.statusCode).toBe(200);
 
         // 読み取り→書き込みの競合を避けるため、GetItemを使わずUpdateItemのADDのみで完結させる
-        expect(ddbMock.commandCalls(GetCommand).length).toBe(0);
+        expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
         const updateCalls = ddbMock.commandCalls(UpdateCommand);
-        expect(updateCalls.length).toBe(1);
+        expect(updateCalls).toHaveLength(1);
         const updateParams = updateCalls[0].args[0].input;
         expect(updateParams.Key).toEqual({ category: 'c1', id: 'p1' });
         expect(updateParams.ConditionExpression).toBe('attribute_exists(id)');
@@ -1277,7 +1266,7 @@ describe('recordTime', () => {
         expect(response.statusCode).toBe(400);
         // readCountとtotalTimeが常に対応するサンプル数を保つよう、
         // 異常値のときはDB書き込み自体を行わない（部分更新はしない）
-        expect(ddbMock.commandCalls(UpdateCommand).length).toBe(0);
+        expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
     });
 
     it('should return 400 when id is missing', async () => {

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint . --max-warnings 29",
+    "lint": "eslint . --max-warnings 0",
     "test": "vitest",
     "deploy": "npx osls deploy"
   },

--- a/backend/phrases.test.js
+++ b/backend/phrases.test.js
@@ -116,7 +116,7 @@ function expectedKana(target) {
   if (!target) return null;
   const first = target[0];
   if (/^[A-Za-z]$/.test(first)) return first.toUpperCase(); // 英字 → 大文字
-  if (/^[0-9]$/.test(first)) return first;                  // 数字 → 完全一致
+  if (/^\d$/.test(first)) return first;                      // 数字 → 完全一致
   if (/^[ぁ-ゖ]$/.test(first)) return first;        // ひらがな → 完全一致
   if (/^[ァ-ヶ]$/.test(first)) return katakanaToHiragana(first); // カタカナ → ひらがな
   return null; // 漢字・その他 → テスト省略
@@ -200,7 +200,8 @@ describe('大ピンチレベルの整合性', () => {
     for (const r of records) {
       if (r.level === '-') continue;
       if (!POSITIVE_INT_RE.test(r.level) || parseInt(r.level, 10) <= 0) continue; // 初級・上級など非整数はスキップ
-      (byCategory[r.category] ??= []).push(r.level);
+      byCategory[r.category] ??= [];
+      byCategory[r.category].push(r.level);
     }
     expect(
       Object.keys(byCategory).length,

--- a/backend/quizRoomHandler.js
+++ b/backend/quizRoomHandler.js
@@ -113,7 +113,10 @@ exports.listQuizRooms = async (event) => {
         // 結果表示（result）の間はcontentに含まれず一時的にnullへ戻ることがあるため、
         // ステータスの判定にはtype自体を使い、categoryの有無には依存させない
         const isAllRead = content?.isAllRead === true;
-        const status = isAllRead ? "終了" : (type === "phrase" || type === "result") ? "進行中" : "開始前";
+        const isInProgress = type === "phrase" || type === "result";
+        let status = "開始前";
+        if (isAllRead) status = "終了";
+        else if (isInProgress) status = "進行中";
         return {
           roomId: item.roomId,
           createdAt: item.createdAt,
@@ -296,13 +299,42 @@ exports.syncQuizRoom = withCatchAll(async (event) => {
   return { statusCode: 200, body: "" };
 });
 
+// updateQuizRoomState用: 状態データが妥当か（未指定・非オブジェクト・配列・肥大化のいずれでもないか）
+function isValidRoomState(newState, stateJson) {
+  if (!newState || typeof newState !== "object" || Array.isArray(newState)) {
+    return false;
+  }
+  return stateJson.length <= MAX_STATE_JSON_LENGTH;
+}
+
+// updateQuizRoomState用: 読み上げ設定の変更等で、ラウンドが進んだわけではなく
+// 同じ札のphraseが再ブロードキャストされることがある（App.jsxのbroadcast
+// effect参照）。このケースを新しいラウンドの開始と誤認すると、まだ判定が
+// 済んでいない早押し記録を消してしまうため、直前の状態と札のidを比較して区別する
+function isSamePhraseRebroadcast(existingState, newState) {
+  return newState.type === "phrase"
+    && existingState?.type === "phrase"
+    && existingState?.content?.id === newState.content?.id;
+}
+
+// updateQuizRoomState用: 早押し正誤判定（issue #546）: ポイント付与は管理者の
+// 正誤判定（judgeQuizRoomBuzz）でのみ行う。「次の札」へ進んだ時点でまだ判定
+// されていない早押しがあっても加点しない（未判定は無効試行として扱う）。
+// 新しい札（次の問題）や、ゲームのリセット等で"initial"に戻った場合は、
+// 前のラウンドの早押し・除外状態をリセットする。result表示中や、同じ札の
+// 再ブロードキャスト中は、まだそのラウンドの判定を確定させたくないため
+// リセットしない
+function shouldResetRoundOnStateUpdate(existingState, newState) {
+  return newState.type !== "result" && !isSamePhraseRebroadcast(existingState, newState);
+}
+
 // WebSocketカスタムルート"updateState"。管理者のみが状態を更新でき、
 // 更新後はルーム内の全接続（管理者自身を含む）へブロードキャストする
 exports.updateQuizRoomState = withRoleGuard("admin", async (event, connection) => {
   const body = JSON.parse(event.body || "{}");
   const newState = body.state;
   const stateJson = JSON.stringify(newState ?? null);
-  if (!newState || typeof newState !== "object" || Array.isArray(newState) || stateJson.length > MAX_STATE_JSON_LENGTH) {
+  if (!isValidRoomState(newState, stateJson)) {
     return { statusCode: 400, body: "Invalid state" };
   }
 
@@ -313,22 +345,7 @@ exports.updateQuizRoomState = withRoleGuard("admin", async (event, connection) =
     Key: { roomId },
   }));
 
-  // 読み上げ設定の変更等で、ラウンドが進んだわけではなく同じ札のphraseが
-  // 再ブロードキャストされることがある（App.jsxのbroadcast effect参照）。
-  // このケースを新しいラウンドの開始と誤認すると、まだ判定が済んでいない
-  // 早押し記録を消してしまうため、直前の状態と札のidを比較して区別する
-  const isSamePhraseRebroadcast = newState.type === "phrase"
-    && room.Item?.state?.type === "phrase"
-    && room.Item?.state?.content?.id === newState.content?.id;
-
-  // 早押し正誤判定（issue #546）: ポイント付与は管理者の正誤判定
-  // （judgeQuizRoomBuzz）でのみ行う。「次の札」へ進んだ時点でまだ判定されて
-  // いない早押しがあっても加点しない（未判定は無効試行として扱う）。
-  // 新しい札（次の問題）や、ゲームのリセット等で"initial"に戻った場合は、
-  // 前のラウンドの早押し・除外状態をリセットする。result表示中や、同じ札の
-  // 再ブロードキャスト中は、まだそのラウンドの判定を確定させたくないため
-  // リセットしない
-  const resetRound = newState.type !== "result" && !isSamePhraseRebroadcast;
+  const resetRound = shouldResetRoundOnStateUpdate(room.Item?.state, newState);
   const updateExpression = resetRound
     ? "SET #state = :state, #ttl = :ttl REMOVE buzz, excludedNames"
     : "SET #state = :state, #ttl = :ttl";
@@ -504,6 +521,50 @@ async function releaseQuizRoomName(roomId, name) {
   }));
 }
 
+// setQuizRoomName用: 名前を予約する。他人と重複していた場合はnameErrorを
+// 本人へ通知し、呼び出し側へ「衝突した（続行不可）」ことを伝える
+async function tryReserveNameOrNotify(event, roomId, name, connectionId) {
+  try {
+    await reserveQuizRoomName(roomId, name);
+    return { conflict: false };
+  } catch (reserveError) {
+    if (reserveError.name !== "ConditionalCheckFailedException") {
+      throw reserveError;
+    }
+    const managementApi = buildManagementApiClient(event);
+    await postToConnection(managementApi, connectionId, {
+      type: "nameError",
+      message: "その名前は既に使われています。別の名前を入力してください。",
+    });
+    return { conflict: true };
+  }
+}
+
+// setQuizRoomName用: 接続レコードへ名前を保存する。接続が既に消えていた場合は
+// （予約済みの名前があれば）解放してからその旨を呼び出し側へ伝える
+async function updateConnectionNameOrRollback(connectionId, name, roomId, isRenaming) {
+  try {
+    await docClient.send(new UpdateCommand({
+      TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
+      Key: { connectionId },
+      UpdateExpression: "SET #name = :name",
+      ExpressionAttributeNames: { "#name": "name" },
+      ExpressionAttributeValues: { ":name": name },
+      ConditionExpression: "attribute_exists(connectionId)",
+    }));
+    return { connectionGone: false };
+  } catch (updateError) {
+    // 接続が消えていた場合、予約した名前を解放してから終了する
+    if (isRenaming) {
+      await releaseQuizRoomName(roomId, name);
+    }
+    if (updateError.name === "ConditionalCheckFailedException") {
+      return { connectionGone: true };
+    }
+    throw updateError;
+  }
+}
+
 exports.setQuizRoomName = async (event) => {
   try {
     const connectionId = event.requestContext.connectionId;
@@ -525,39 +586,15 @@ exports.setQuizRoomName = async (event) => {
     const isRenaming = previousName !== name;
 
     if (isRenaming) {
-      try {
-        await reserveQuizRoomName(roomId, name);
-      } catch (reserveError) {
-        if (reserveError.name === "ConditionalCheckFailedException") {
-          const managementApi = buildManagementApiClient(event);
-          await postToConnection(managementApi, connectionId, {
-            type: "nameError",
-            message: "その名前は既に使われています。別の名前を入力してください。",
-          });
-          return { statusCode: 200, body: "" };
-        }
-        throw reserveError;
+      const { conflict } = await tryReserveNameOrNotify(event, roomId, name, connectionId);
+      if (conflict) {
+        return { statusCode: 200, body: "" };
       }
     }
 
-    try {
-      await docClient.send(new UpdateCommand({
-        TableName: process.env.QUIZ_ROOM_CONNECTIONS_TABLE_NAME,
-        Key: { connectionId },
-        UpdateExpression: "SET #name = :name",
-        ExpressionAttributeNames: { "#name": "name" },
-        ExpressionAttributeValues: { ":name": name },
-        ConditionExpression: "attribute_exists(connectionId)",
-      }));
-    } catch (updateError) {
-      // 接続が消えていた場合、予約した名前を解放してから終了する
-      if (isRenaming) {
-        await releaseQuizRoomName(roomId, name);
-      }
-      if (updateError.name === "ConditionalCheckFailedException") {
-        return { statusCode: 200, body: "" };
-      }
-      throw updateError;
+    const { connectionGone } = await updateConnectionNameOrRollback(connectionId, name, roomId, isRenaming);
+    if (connectionGone) {
+      return { statusCode: 200, body: "" };
     }
 
     if (isRenaming && previousName) {

--- a/backend/reset-stats.test.js
+++ b/backend/reset-stats.test.js
@@ -19,7 +19,7 @@ describe('resetStats', () => {
     await resetStats('c1', 'p1');
 
     const calls = ddbMock.commandCalls(UpdateCommand);
-    expect(calls.length).toBe(1);
+    expect(calls).toHaveLength(1);
     const input = calls[0].args[0].input;
     expect(input.Key).toEqual({ category: 'c1', id: 'p1' });
     expect(input.ExpressionAttributeValues[':zero']).toBe(0);
@@ -32,7 +32,7 @@ describe('resetStats', () => {
   it('does not call DynamoDB and sets a non-zero exit code when category or id is missing', async () => {
     await resetStats(undefined, 'p1');
 
-    expect(ddbMock.commandCalls(UpdateCommand).length).toBe(0);
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
     expect(process.exitCode).toBe(1);
   });
 

--- a/backend/seed.js
+++ b/backend/seed.js
@@ -18,6 +18,105 @@ const CATEGORY_RENAMES = {
   "大ピンチ法則かるた": ["法則と効果かるた"],
 };
 
+function trimOrDefault(value, defaultValue) {
+  return value ? value.trim() : defaultValue;
+}
+
+// 既存アイテムが無い（=新規レコード）場合は各統計を0で初期化する
+function extractStats(existingItem) {
+  if (!existingItem) {
+    return { readCount: 0, averageTime: 0, averageDifficulty: 0, totalTime: 0, totalDifficulty: 0 };
+  }
+  return {
+    readCount: existingItem.readCount,
+    averageTime: existingItem.averageTime,
+    averageDifficulty: existingItem.averageDifficulty || 0,
+    totalTime: existingItem.totalTime || 0,
+    totalDifficulty: existingItem.totalDifficulty || 0,
+  };
+}
+
+// CSVのlevel列を、数字文字列なら数値に、それ以外（初級/上級/"-"等）はそのまま文字列で扱う
+function parseLevel(levelRaw) {
+  if (levelRaw !== "-" && !isNaN(parseInt(levelRaw, 10)) && /^\d+$/.test(levelRaw)) {
+    return parseInt(levelRaw, 10);
+  }
+  return levelRaw;
+}
+
+// カテゴリ名が変更されていても、CATEGORY_RENAMESを辿って過去の統計（readCount等）を引き継ぐ
+function findExistingItem(existingItemsMap, category, id) {
+  const direct = existingItemsMap.get(`${category}-${id}`);
+  if (direct) return direct;
+  return (CATEGORY_RENAMES[category] || [])
+    .map((oldCategory) => existingItemsMap.get(`${oldCategory}-${id}`))
+    .find((item) => item !== undefined);
+}
+
+// CSVの1レコードと既存データ（統計の引き継ぎ元）から、新しいアイテムを組み立てる。
+// seed本体の複雑度を抑えるため分離している
+function buildMergedItem(record, existingItemsMap) {
+  const category = trimOrDefault(record.category, "大ピンチずかん");
+  const id = record.id;
+  const level = parseLevel(trimOrDefault(record.level, "-"));
+  const existingItem = findExistingItem(existingItemsMap, category, id);
+  const group = trimOrDefault(record.group, "") === "engineer" ? "engineer" : "kids";
+
+  return {
+    key: `${category}-${id}`,
+    item: {
+      id,
+      category,
+      group,
+      level,
+      kana: trimOrDefault(record.kana, "-"),
+      phrase: trimOrDefault(record.phrase, ""),
+      phrase_en: trimOrDefault(record.phrase_en, ""),
+      answer: trimOrDefault(record.answer, "-"),
+      explanation: trimOrDefault(record.explanation, "-"),
+      ...extractStats(existingItem),
+    },
+  };
+}
+
+// CSVデータと既存のDynamoDBデータをマージして新しいアイテムマップを作成する
+function buildNewItemsMap(records, existingItemsMap) {
+  const newItemsMap = new Map(); // key: `${category}-${id}`
+  for (const record of records) {
+    const { key, item } = buildMergedItem(record, existingItemsMap);
+    newItemsMap.set(key, item);
+  }
+  return newItemsMap;
+}
+
+// 新しいCSVに存在しなくなったレコードを削除する
+async function deleteObsoleteItems(existingItemsMap, newItemsMap) {
+  let deleteCount = 0;
+  for (const existingItem of existingItemsMap.values()) {
+    if (!newItemsMap.has(`${existingItem.category}-${existingItem.id}`)) {
+      await docClient.send(new DeleteCommand({
+        TableName: TABLE_NAME,
+        Key: { category: existingItem.category, id: existingItem.id },
+      }));
+      deleteCount++;
+    }
+  }
+  if (deleteCount > 0) console.log(`Deleted ${deleteCount} obsolete records.`);
+}
+
+// 新しいデータを投入・更新する（Upsert方式）
+async function upsertItems(newItemsMap) {
+  let upsertCount = 0;
+  for (const item of newItemsMap.values()) {
+    await docClient.send(new PutCommand({
+      TableName: TABLE_NAME,
+      Item: item,
+    }));
+    upsertCount++;
+  }
+  console.log(`Upserted ${upsertCount} records.`);
+}
+
 async function seed() {
   try {
     // 1. CSVファイルを読み込んでパース
@@ -28,9 +127,6 @@ async function seed() {
     });
     console.log(`Read ${records.length} records from CSV.`);
 
-    // 2. CSVデータと既存のDynamoDBデータをマージして新しいアイテムマップを作成
-    const newItemsMap = new Map(); // key: `${category}-${id}`
-
     // 既存の全アイテムを一度取得 (readCountとaverageTimeを保持するため)
     console.log("Fetching existing data from DynamoDB...");
     const existingItemsScan = await docClient.send(new ScanCommand({ TableName: TABLE_NAME }));
@@ -40,66 +136,14 @@ async function seed() {
     });
     console.log(`Found ${existingItemsMap.size} existing items in DB.`);
 
-    for (const record of records) {
-      const category = record.category ? record.category.trim() : "大ピンチずかん";
-      const id = record.id;
-      
-      const levelRaw = record.level ? record.level.trim() : "-";
-      let level;
-      if (levelRaw !== "-" && !isNaN(parseInt(levelRaw, 10)) && /^\d+$/.test(levelRaw)) {
-        level = parseInt(levelRaw, 10);
-      } else {
-        level = levelRaw;
-      }
-
-      const existingItem = existingItemsMap.get(`${category}-${id}`)
-        ?? (CATEGORY_RENAMES[category] || [])
-          .map((oldCategory) => existingItemsMap.get(`${oldCategory}-${id}`))
-          .find((item) => item !== undefined);
-      const groupRaw = record.group ? record.group.trim() : "";
-      const group = groupRaw === "engineer" ? "engineer" : "kids";
-
-      newItemsMap.set(`${category}-${id}`, {
-        id,
-        category,
-        group,
-        level,
-        kana: record.kana ? record.kana.trim() : "-",
-        phrase: record.phrase ? record.phrase.trim() : "",
-        phrase_en: record.phrase_en ? record.phrase_en.trim() : "",
-        answer: record.answer ? record.answer.trim() : "-",
-        explanation: record.explanation ? record.explanation.trim() : "-",
-        readCount: existingItem ? existingItem.readCount : 0,
-        averageTime: existingItem ? existingItem.averageTime : 0,
-        averageDifficulty: existingItem ? (existingItem.averageDifficulty || 0) : 0,
-        totalTime: existingItem ? (existingItem.totalTime || 0) : 0,
-        totalDifficulty: existingItem ? (existingItem.totalDifficulty || 0) : 0
-      });
-    }
+    // 2. CSVデータと既存のDynamoDBデータをマージして新しいアイテムマップを作成
+    const newItemsMap = buildNewItemsMap(records, existingItemsMap);
 
     // 3. 不要なデータを削除
-    let deleteCount = 0;
-    for (const existingItem of existingItemsMap.values()) {
-      if (!newItemsMap.has(`${existingItem.category}-${existingItem.id}`)) {
-        await docClient.send(new DeleteCommand({
-          TableName: TABLE_NAME,
-          Key: { category: existingItem.category, id: existingItem.id },
-        }));
-        deleteCount++;
-      }
-    }
-    if (deleteCount > 0) console.log(`Deleted ${deleteCount} obsolete records.`);
+    await deleteObsoleteItems(existingItemsMap, newItemsMap);
 
     // 4. 新しいデータを投入・更新（Upsert方式）
-    let upsertCount = 0;
-    for (const item of newItemsMap.values()) {
-      await docClient.send(new PutCommand({
-        TableName: TABLE_NAME,
-        Item: item,
-      }));
-      upsertCount++;
-    }
-    console.log(`Upserted ${upsertCount} records.`);
+    await upsertItems(newItemsMap);
 
     console.log("Seeding completed successfully (Incremental Sync with statistics).");
   } catch (error) {

--- a/frontend/e2e/quiz-room.spec.js
+++ b/frontend/e2e/quiz-room.spec.js
@@ -344,13 +344,9 @@ test('admin resets participant points (issue #615)', async ({ browser }, testInf
 // closeQuizRoom（backend/quizRoomHandler.js）は、ルームレコード削除に使うDeleteCommandに
 // 必要なdynamodb:DeleteItem権限がserverless.ymlのIAMステートメントから漏れていたため、
 // AccessDeniedExceptionで処理全体が失敗し、参加者・管理者のどちらもroomClosedを受け取れない
-// 状態だった（issue #576のE2E追加で判明）。IAM側は修正済みだが、CD経由で実際にデプロイ
-// されるまでは本番Lambdaに反映されず、このテストは失敗し続けてしまうため、デプロイ確認が
-// 取れるまで一時的にskipする（TODO: デプロイ確認後、上のresetQuizRoomPointsテストと同様の
-// フローに続けて「ルームを閉じる」操作・参加者への通知を検証するテストとして有効化する）
+// 状態だった（issue #576のE2E追加で判明）。IAM側の修正（issue #748）はデプロイ済みのため
+// 有効化する
 test('admin closes the room, and the participant sees a closed-by-host message (issue #748)', async ({ browser }, testInfo) => {
-  test.skip(true, 'issue #748: closeQuizRoomのIAM権限修正（本PR）がCD経由でデプロイされるまで無効化する');
-
   const adminContext = await browser.newContext();
   const adminPage = await adminContext.newPage();
   await startCoverage(adminPage);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint . --max-warnings 60",
+    "lint": "eslint . --max-warnings 0",
     "preview": "vite preview",
     "test": "vitest",
     "test:e2e": "playwright test",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,80 @@ const HISTORY_STORAGE_KEY = "historyByCategory";
 // バックエンド側はURL直叩き等を弾く二次防御
 const MAX_EFUDA_PRINT_CARDS = 500;
 
+// カテゴリ一覧の再取得後、選択中のカテゴリのうち引き続き存在するものだけへ絞り込む
+function filterStillValidCategories(prev, availableNames) {
+  if (prev.length === 0) return prev;
+  const stillValid = prev.filter(cat => availableNames.includes(cat));
+  return stillValid.length !== prev.length ? stillValid : prev;
+}
+
+// 指定したカテゴリ名一覧について、対応するcount（枚数）の合計を求める
+// （絵札印刷の上限バリデーション用）
+function sumCategoryCounts(categoryNames, categories) {
+  return categoryNames.reduce((total, name) => {
+    const info = categories.find(c => c.name === name);
+    return total + (info?.count || 0);
+  }, 0);
+}
+
+// 初級=1000000、上級=1000001 として数値化し一貫したソートを保証
+function toLevelNum(v) {
+  if (v === '初級') return 1_000_000;
+  if (v === '上級') return 1_000_001;
+  const n = parseInt(v, 10);
+  return isNaN(n) ? 1_000_002 : n;
+}
+
+// レベル列は未設定('-')を常に末尾へ固定するため、direction に関わらない順序を
+// 早期に返す。該当しない場合はnullを返し、呼び出し側の通常比較へフォールバックする
+function compareByLevelPresence(aValue, bValue) {
+  if (aValue === '-' && bValue !== '-') return 1;
+  if (aValue !== '-' && bValue === '-') return -1;
+  if (aValue === '-' && bValue === '-') return 0;
+  return null;
+}
+
+// answer列は未設定（市販品で答えデータが無い）を常に末尾へ固定する
+function compareByAnswerPresence(aValue, bValue) {
+  const aMissing = !aValue || aValue === '-';
+  const bMissing = !bValue || bValue === '-';
+  if (aMissing && !bMissing) return 1;
+  if (!aMissing && bMissing) return -1;
+  if (aMissing && bMissing) return 0;
+  return null;
+}
+
+const NUMERIC_FALLBACK_ZERO_KEYS = new Set(['readCount', 'averageDifficulty', 'averageTime']);
+
+function normalizeSortValues(sortKey, aValue, bValue) {
+  if (sortKey === 'level') return [toLevelNum(aValue), toLevelNum(bValue)];
+  if (NUMERIC_FALLBACK_ZERO_KEYS.has(sortKey)) return [aValue || 0, bValue || 0];
+  if (sortKey === 'answer' || typeof aValue === 'string') {
+    return [(aValue || '').toLowerCase(), (bValue || '').toLowerCase()];
+  }
+  return [aValue, bValue];
+}
+
+function comparePhraseValues(a, b, sortConfig) {
+  const sortKey = sortConfig.key;
+  let aValue = a[sortKey];
+  let bValue = b[sortKey];
+
+  if (sortKey === 'level') {
+    const presenceResult = compareByLevelPresence(aValue, bValue);
+    if (presenceResult !== null) return presenceResult;
+  } else if (sortKey === 'answer') {
+    const presenceResult = compareByAnswerPresence(aValue, bValue);
+    if (presenceResult !== null) return presenceResult;
+  }
+
+  [aValue, bValue] = normalizeSortValues(sortKey, aValue, bValue);
+
+  if (aValue < bValue) return sortConfig.direction === 'asc' ? -1 : 1;
+  if (aValue > bValue) return sortConfig.direction === 'asc' ? 1 : -1;
+  return 0;
+}
+
 function App() {
   const [categories, setCategories] = useState([]);
   const [division, setDivision] = useState(() => {
@@ -95,7 +169,8 @@ function App() {
   const [postingComment, setPostingComment] = useState(false);
 
   const resolvedTheme = useMemo(() => {
-    return themeSetting === "system" ? (systemPrefersDark ? "dark" : "light") : themeSetting;
+    if (themeSetting !== "system") return themeSetting;
+    return systemPrefersDark ? "dark" : "light";
   }, [themeSetting, systemPrefersDark]);
 
   const categoryKey = useMemo(() => {
@@ -219,47 +294,7 @@ function App() {
   const sortedPhrases = useMemo(() => {
     let sortableItems = [...allPhrases];
     if (sortConfig.key !== null) {
-      sortableItems.sort((a, b) => {
-        let aValue = a[sortConfig.key];
-        let bValue = b[sortConfig.key];
-        
-        if (sortConfig.key === 'level') {
-            if (aValue === '-' && bValue !== '-') return 1;
-            if (aValue !== '-' && bValue === '-') return -1;
-            if (aValue === '-' && bValue === '-') return 0;
-            // 初級=1000000、上級=1000001 として数値化し一貫したソートを保証
-            const toLevelNum = (v) => {
-              if (v === '初級') return 1_000_000;
-              if (v === '上級') return 1_000_001;
-              const n = parseInt(v, 10);
-              return isNaN(n) ? 1_000_002 : n;
-            };
-            aValue = toLevelNum(aValue);
-            bValue = toLevelNum(bValue);
-        } else if (sortConfig.key === 'readCount' || sortConfig.key === 'averageDifficulty' || sortConfig.key === 'averageTime') {
-            aValue = aValue || 0;
-            bValue = bValue || 0;
-        } else if (sortConfig.key === 'answer') {
-            const aMissing = !aValue || aValue === '-';
-            const bMissing = !bValue || bValue === '-';
-            if (aMissing && !bMissing) return 1;
-            if (!aMissing && bMissing) return -1;
-            if (aMissing && bMissing) return 0;
-            aValue = aValue.toLowerCase();
-            bValue = bValue.toLowerCase();
-        } else if (typeof aValue === 'string') {
-            aValue = aValue.toLowerCase();
-            bValue = bValue.toLowerCase();
-        }
-
-        if (aValue < bValue) {
-          return sortConfig.direction === 'asc' ? -1 : 1;
-        }
-        if (aValue > bValue) {
-          return sortConfig.direction === 'asc' ? 1 : -1;
-        }
-        return 0;
-      });
+      sortableItems.sort((a, b) => comparePhraseValues(a, b, sortConfig));
     }
     return sortableItems;
   }, [allPhrases, sortConfig]);
@@ -327,11 +362,7 @@ function App() {
 
           if (availableCategories.length > 0 && viewRef.current === "game") {
             const availableNames = availableCategories.map(cat => cat.name);
-            setSelectedCategories(prev => {
-              if (prev.length === 0) return prev;
-              const stillValid = prev.filter(cat => availableNames.includes(cat));
-              return stillValid.length !== prev.length ? stillValid : prev;
-            });
+            setSelectedCategories(prev => filterStillValidCategories(prev, availableNames));
           }
         }
     } catch (error) {
@@ -623,10 +654,7 @@ function App() {
       // 追加後の合計枚数が上限を超える場合は選択自体をブロックする
       // （PDF出力が破綻しない範囲に選択可能な種別を制限するバリデーション）
       const catInfo = categories.find(c => c.name === cat);
-      const currentCount = prev.reduce((total, name) => {
-        const info = categories.find(c => c.name === name);
-        return total + (info?.count || 0);
-      }, 0);
+      const currentCount = sumCategoryCounts(prev, categories);
       if (currentCount + (catInfo?.count || 0) > MAX_EFUDA_PRINT_CARDS) {
         return prev;
       }
@@ -670,6 +698,10 @@ function App() {
     setDetailPhraseCategory(null);
   };
 
+  // ゲーム画面以外の各画面（詳細・絵札印刷・全札一覧・指摘一覧・更新履歴・クイズ大会・
+  // division/カテゴリ選択）へのルーティング。Appコンポーネント本体の複雑度を抑えるため、
+  // 該当する画面が無ければnullを返すだけの即時実行関数へ分岐をまとめている
+  const routedView = (() => {
   if (detailPhraseId) {
     return (
       <DetailView
@@ -804,6 +836,10 @@ function App() {
     );
   }
 
+  return null;
+  })();
+  if (routedView) return routedView;
+
   const renderPhrase = (phrase) => {
     if (!phrase) return null;
     return (
@@ -825,6 +861,55 @@ function App() {
       </div>
     )
   }
+
+  // ゲーム画面本体（読了後のお祝い画面 or 読み札カード＋操作ボタン）。
+  // Appコンポーネント本体の複雑度を抑えるため、別関数として切り出している
+  const renderGameMain = () => {
+    if (isAllRead) {
+      return (
+        <QuizCompletionScreen
+          sessionSummary={sessionSummary}
+          scoreSummary={scoreSummary}
+          restartCategory={restartCategory}
+        />
+      );
+    }
+    return (
+      <>
+        <div className={`yomifuda-container mb-4 ${isFadingOut ? 'fade-out' : 'fade-in'}`}>
+          {displayContent.type === 'phrase' && renderPhrase(displayContent.content)}
+          {displayContent.type === 'result' && <ResultCard result={displayContent.content} division={division} />}
+          {displayContent.type === 'initial' && renderInitial()}
+        </div>
+
+        {displayContent.type === 'phrase' && division !== "kids" && players.length > 0 && (
+          <div className="mb-4">
+            <div className="text-muted small mb-2">取った人:</div>
+            <div className="d-flex flex-wrap gap-2 justify-content-center">
+              {players.map(name => (
+                <button
+                  key={name}
+                  onClick={() => recordTaken(name)}
+                  className={`btn btn-sm rounded-pill px-3 ${currentRoundTakenBy === name ? 'btn-dark' : 'btn-outline-dark'}`}
+                >
+                  {name}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="d-flex flex-wrap gap-3 justify-content-center mb-5">
+          <button onClick={playKaruta} disabled={loading || isReadingLastPhrase} className="btn btn-lg px-4 py-3 fw-bold rounded-pill shadow btn-karuta">
+            {loading && <span className="spinner-border spinner-border-sm me-2"></span>}
+            {loading ? "読み込み中..." : "次の札"}
+          </button>
+          <button onClick={repeatPhrase} disabled={isReading || !currentPhrase} className="btn btn-lg px-4 py-3 fw-bold rounded-pill border-3 border-dark bg-white text-dark shadow-sm">もう一度</button>
+          <button onClick={stopReading} disabled={!isReading} className="btn btn-lg px-4 py-3 fw-bold rounded-pill border-3 border-danger bg-white text-danger shadow-sm">停止</button>
+        </div>
+      </>
+    );
+  };
 
   return (
     <div className="container py-4 mx-auto">
@@ -857,47 +942,7 @@ function App() {
       </header>
 
       <main className="text-center">
-        {isAllRead ? (
-          <QuizCompletionScreen
-            sessionSummary={sessionSummary}
-            scoreSummary={scoreSummary}
-            restartCategory={restartCategory}
-          />
-        ) : (
-          <>
-            <div className={`yomifuda-container mb-4 ${isFadingOut ? 'fade-out' : 'fade-in'}`}>
-              {displayContent.type === 'phrase' && renderPhrase(displayContent.content)}
-              {displayContent.type === 'result' && <ResultCard result={displayContent.content} division={division} />}
-              {displayContent.type === 'initial' && renderInitial()}
-            </div>
-
-            {displayContent.type === 'phrase' && division !== "kids" && players.length > 0 && (
-              <div className="mb-4">
-                <div className="text-muted small mb-2">取った人:</div>
-                <div className="d-flex flex-wrap gap-2 justify-content-center">
-                  {players.map(name => (
-                    <button
-                      key={name}
-                      onClick={() => recordTaken(name)}
-                      className={`btn btn-sm rounded-pill px-3 ${currentRoundTakenBy === name ? 'btn-dark' : 'btn-outline-dark'}`}
-                    >
-                      {name}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            <div className="d-flex flex-wrap gap-3 justify-content-center mb-5">
-              <button onClick={playKaruta} disabled={loading || isReadingLastPhrase} className="btn btn-lg px-4 py-3 fw-bold rounded-pill shadow btn-karuta">
-                {loading && <span className="spinner-border spinner-border-sm me-2"></span>}
-                {loading ? "読み込み中..." : "次の札"}
-              </button>
-              <button onClick={repeatPhrase} disabled={isReading || !currentPhrase} className="btn btn-lg px-4 py-3 fw-bold rounded-pill border-3 border-dark bg-white text-dark shadow-sm">もう一度</button>
-              <button onClick={stopReading} disabled={!isReading} className="btn btn-lg px-4 py-3 fw-bold rounded-pill border-3 border-danger bg-white text-danger shadow-sm">停止</button>
-            </div>
-          </>
-        )}
+        {renderGameMain()}
       </main>
 
       {currentHistory.length > 0 && (

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -324,7 +324,7 @@ describe('App', () => {
     });
 
     const categoriesCalls = fetch.mock.calls.filter(([url]) => url.includes('get-categories'));
-    expect(categoriesCalls.length).toBe(1);
+    expect(categoriesCalls).toHaveLength(1);
   });
 
   it('starts game when category is selected', async () => {
@@ -588,7 +588,7 @@ describe('App', () => {
     }, { timeout: 20000 });
 
     // プリフェッチ済みのp2をそのまま使うため、/get-phraseの追加呼び出しは発生しない
-    expect(getPhraseCallIds.length).toBe(callCountBeforeSecondClick);
+    expect(getPhraseCallIds).toHaveLength(callCountBeforeSecondClick);
     expect(getPhraseCallIds).toEqual(['p1', 'p2']);
 
     randomSpy.mockRestore();
@@ -596,7 +596,6 @@ describe('App', () => {
 
   it('ignores a second "次の札" click while the first is still advancing (e.g. during the fade-out animation), instead of flipping multiple cards at once (issue #590)', async () => {
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
-    const getPhraseCallIds = [];
     const phraseById = {
       p1: { id: 'p1', category: 'Cat1', phrase: '読み札1' },
       p2: { id: 'p2', category: 'Cat1', phrase: '読み札2' },
@@ -612,7 +611,6 @@ describe('App', () => {
       }
       if (url.includes('/get-phrase?')) {
         const id = new URL(url).searchParams.get('id');
-        getPhraseCallIds.push(id);
         return { ok: true, json: async () => ({ ...phraseById[id], audioData: 'dummy' }) };
       }
       return { ok: false };
@@ -746,7 +744,7 @@ describe('App', () => {
     expect(paperLinks[1]).toHaveAttribute('target', '_blank');
 
     // 11枚 → 10面/ページなので2ページ生成される
-    expect(document.querySelectorAll('.efuda-page').length).toBe(2);
+    expect(document.querySelectorAll('.efuda-page')).toHaveLength(2);
 
     fireEvent.click(screen.getByText('印刷する'));
     expect(window.print).toHaveBeenCalled();
@@ -1217,7 +1215,7 @@ describe('App', () => {
 
     await waitFor(() => {
       // カテゴリ境界で改ページせず、1枚ずつでも詰めて1ページにまとまる
-      expect(document.querySelectorAll('.efuda-page').length).toBe(1);
+      expect(document.querySelectorAll('.efuda-page')).toHaveLength(1);
       expect(screen.getByText('Cat1テキスト')).toBeInTheDocument();
       expect(screen.getByText('Cat2テキスト')).toBeInTheDocument();
     });
@@ -1310,11 +1308,11 @@ describe('App', () => {
     await waitFor(() => {
       // Cat1(7枚)+Cat2(5枚)=12枚 → 10面/ページなので2ページ生成される
       const pages = document.querySelectorAll('.efuda-page');
-      expect(pages.length).toBe(2);
+      expect(pages).toHaveLength(2);
       // 1ページ目はカテゴリ境界で途切れず10面すべて埋まる(空白カードなし)
-      expect(pages[0].querySelectorAll('.efuda-card-text').length).toBe(10);
+      expect(pages[0].querySelectorAll('.efuda-card-text')).toHaveLength(10);
       // 2ページ目はCat2の残り2枚のみ
-      expect(pages[1].querySelectorAll('.efuda-card-text').length).toBe(2);
+      expect(pages[1].querySelectorAll('.efuda-card-text')).toHaveLength(2);
     });
   });
 
@@ -1952,14 +1950,14 @@ describe('App', () => {
     // 回数列でソート（readCount未設定/0 のフォールバック分岐を通す）
     fireEvent.click(readCountHeader);
     await waitFor(() => {
-      expect(getPhraseOrder().length).toBe(6);
+      expect(getPhraseOrder()).toHaveLength(6);
     });
     fireEvent.click(readCountHeader);
 
     // 答え列でソート（未設定/"-"/実値の組み合わせを網羅）
     fireEvent.click(answerHeader);
     await waitFor(() => {
-      expect(getPhraseOrder().length).toBe(6);
+      expect(getPhraseOrder()).toHaveLength(6);
     });
     fireEvent.click(answerHeader);
 

--- a/frontend/src/PwaUpdatePrompt.jsx
+++ b/frontend/src/PwaUpdatePrompt.jsx
@@ -13,13 +13,21 @@ const OFFLINE_READY_AUTO_DISMISS_MS = 5000;
 // 毎レンダー新しい関数を作らず安定した参照にすることで、useEffectの依存配列を汚さない
 const noop = () => {};
 
+// virtual:pwa-register/reactが未提供の場合のフォールバック込みで、必要な値・
+// 関数一式を取り出す。PwaUpdatePrompt本体の複雑度を抑えるため分離している
+function resolveSwState(sw) {
+  return {
+    needRefresh: sw?.needRefresh?.[0] || false,
+    setNeedRefresh: sw?.needRefresh?.[1] || noop,
+    offlineReady: sw?.offlineReady?.[0] || false,
+    setOfflineReady: sw?.offlineReady?.[1] || noop,
+    updateServiceWorker: sw?.updateServiceWorker || noop,
+  };
+}
+
 function PwaUpdatePrompt() {
   const sw = useRegisterSW();
-  const needRefresh = sw?.needRefresh?.[0] || false;
-  const setNeedRefresh = sw?.needRefresh?.[1] || noop;
-  const offlineReady = sw?.offlineReady?.[0] || false;
-  const setOfflineReady = sw?.offlineReady?.[1] || noop;
-  const updateServiceWorker = sw?.updateServiceWorker || noop;
+  const { needRefresh, setNeedRefresh, offlineReady, setOfflineReady, updateServiceWorker } = resolveSwState(sw);
   // 絵札PDF印刷画面（PrintEfudaView）はバックエンドAPIへの通信が必須でオフラインでは
   // 動作しないため、この画面を開いている間に「オフラインで利用可能になりました」を
   // 出すと誤解を招く（issue #473）

--- a/frontend/src/components/PlayerRegistrationPanel.jsx
+++ b/frontend/src/components/PlayerRegistrationPanel.jsx
@@ -8,6 +8,10 @@ function PlayerRegistrationPanel({
   addPlayer,
   maxPlayers,
 }) {
+  let toggleButtonLabel = "取った人を記録する";
+  if (showPlayerRegistration) toggleButtonLabel = "参加者登録を閉じる";
+  else if (players.length > 0) toggleButtonLabel = "参加者を編集する";
+
   return (
     <div>
       <button
@@ -15,7 +19,7 @@ function PlayerRegistrationPanel({
         onClick={() => setShowPlayerRegistration(prev => !prev)}
         className="btn btn-sm btn-outline-secondary rounded-pill px-3"
       >
-        {showPlayerRegistration ? "参加者登録を閉じる" : players.length > 0 ? "参加者を編集する" : "取った人を記録する"}
+        {toggleButtonLabel}
       </button>
       {showPlayerRegistration && (
         <div className="mt-3 mx-auto text-start" style={{ maxWidth: "360px" }}>

--- a/frontend/src/components/QuizCompletionScreen.jsx
+++ b/frontend/src/components/QuizCompletionScreen.jsx
@@ -9,6 +9,10 @@ import { buildConfettiPieces } from "../utils/confetti";
 function QuizCompletionScreen({ sessionSummary, scoreSummary, restartCategory }) {
   const confettiPieces = useMemo(() => buildConfettiPieces(), []);
 
+  let winnerHeading = "取った札の記録はありません";
+  if (scoreSummary?.winners.length === 1) winnerHeading = `🏆 優勝: ${scoreSummary.winners[0]}`;
+  else if (scoreSummary?.winners.length > 1) winnerHeading = `🏆 優勝: ${scoreSummary.winners.join('・')}（同点）`;
+
   return (
     <>
       <Confetti pieces={confettiPieces} />
@@ -41,13 +45,7 @@ function QuizCompletionScreen({ sessionSummary, scoreSummary, restartCategory })
         )}
         {scoreSummary && (
           <div className="mb-4 text-dark">
-            <h3 className="h5 fw-bold mb-3">
-              {scoreSummary.winners.length === 1
-                ? `🏆 優勝: ${scoreSummary.winners[0]}`
-                : scoreSummary.winners.length > 1
-                ? `🏆 優勝: ${scoreSummary.winners.join('・')}（同点）`
-                : "取った札の記録はありません"}
-            </h3>
+            <h3 className="h5 fw-bold mb-3">{winnerHeading}</h3>
             <div className="d-flex flex-wrap gap-2 justify-content-center">
               {scoreSummary.entries.map(e => (
                 <div key={e.name} className="bg-white rounded-3 shadow-sm px-3 py-2">

--- a/frontend/src/components/SettingsFooter.jsx
+++ b/frontend/src/components/SettingsFooter.jsx
@@ -1,3 +1,55 @@
+// ラベル・選択肢一覧・現在値・変更ハンドラを渡すだけで、アクティブ表示
+// （btn-dark/btn-outline-dark切り替え）付きのボタン群を描画する。SettingsFooterの
+// 各設定項目（テーマ・言語・声・順番・スピード）で同じ構造が繰り返されていたため共通化した
+function SettingsButtonGroup({ label, options, value, onChange, wrapClassName }) {
+  return (
+    <div className={wrapClassName ?? "mb-3 d-flex align-items-center justify-content-center gap-3 border-bottom pb-2"}>
+      <span className="fw-bold text-dark small">{label}:</span>
+      <div className="btn-group btn-group-sm" role="group">
+        {options.map((opt) => (
+          <button
+            key={opt.value}
+            onClick={() => onChange(opt.value)}
+            className={`btn ${value === opt.value ? 'btn-dark' : 'btn-outline-dark'}`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const THEME_OPTIONS = [
+  { value: "system", label: "自動" },
+  { value: "light", label: "ライト" },
+  { value: "dark", label: "ダーク" },
+];
+const LANG_OPTIONS = [
+  { value: "ja", label: "日本語" },
+  { value: "en", label: "English" },
+];
+const VOICE_OPTIONS = [
+  { value: "Mizuki", label: "Mizuki" },
+  { value: "Takumi", label: "Takumi" },
+  { value: "Kazuha", label: "Kazuha" },
+  { value: "Tomoko", label: "Tomoko" },
+];
+const SORT_ORDER_OPTIONS = [
+  { value: "random", label: "ランダム" },
+  { value: "easy", label: "簡単" },
+  { value: "hard", label: "難しい" },
+];
+const SPEECH_RATE_OPTIONS = [
+  { value: "70%", label: "ゆっくり" },
+  { value: "80%", label: "ふつう" },
+  { value: "100%", label: "はやい" },
+];
+const REPEAT_COUNT_OPTIONS = [
+  { value: 1, label: "1回" },
+  { value: 2, label: "2回" },
+];
+
 function SettingsFooter({
   themeSetting,
   setThemeSetting,
@@ -14,55 +66,26 @@ function SettingsFooter({
 }) {
   return (
     <section className="settings-container mb-4 p-3 mx-auto shadow-sm rounded-4 bg-light border" style={{ maxWidth: "500px" }}>
-      <div className="mb-3 d-flex align-items-center justify-content-center gap-3 border-bottom pb-2">
-        <span className="fw-bold text-dark small">テーマ:</span>
-        <div className="btn-group btn-group-sm" role="group">
-          <button onClick={() => setThemeSetting("system")} className={`btn ${themeSetting === "system" ? 'btn-dark' : 'btn-outline-dark'}`}>自動</button>
-          <button onClick={() => setThemeSetting("light")} className={`btn ${themeSetting === "light" ? 'btn-dark' : 'btn-outline-dark'}`}>ライト</button>
-          <button onClick={() => setThemeSetting("dark")} className={`btn ${themeSetting === "dark" ? 'btn-dark' : 'btn-outline-dark'}`}>ダーク</button>
-        </div>
-      </div>
-      <div className="mb-3 d-flex align-items-center justify-content-center gap-3 border-bottom pb-2">
-        <span className="fw-bold text-dark small">言語:</span>
-        <div className="btn-group btn-group-sm" role="group">
-          <button onClick={() => setLang("ja")} className={`btn ${lang === "ja" ? 'btn-dark' : 'btn-outline-dark'}`}>日本語</button>
-          <button onClick={() => setLang("en")} className={`btn ${lang === "en" ? 'btn-dark' : 'btn-outline-dark'}`}>English</button>
-        </div>
-      </div>
+      <SettingsButtonGroup label="テーマ" options={THEME_OPTIONS} value={themeSetting} onChange={setThemeSetting} />
+      <SettingsButtonGroup label="言語" options={LANG_OPTIONS} value={lang} onChange={setLang} />
       {lang === "ja" && (
-        <div className="mb-3 d-flex align-items-center justify-content-center gap-3 border-bottom pb-2 flex-wrap">
-          <span className="fw-bold text-dark small">声:</span>
-          <div className="btn-group btn-group-sm" role="group">
-            <button onClick={() => setVoiceId("Mizuki")} className={`btn ${voiceId === "Mizuki" ? 'btn-dark' : 'btn-outline-dark'}`}>Mizuki</button>
-            <button onClick={() => setVoiceId("Takumi")} className={`btn ${voiceId === "Takumi" ? 'btn-dark' : 'btn-outline-dark'}`}>Takumi</button>
-            <button onClick={() => setVoiceId("Kazuha")} className={`btn ${voiceId === "Kazuha" ? 'btn-dark' : 'btn-outline-dark'}`}>Kazuha</button>
-            <button onClick={() => setVoiceId("Tomoko")} className={`btn ${voiceId === "Tomoko" ? 'btn-dark' : 'btn-outline-dark'}`}>Tomoko</button>
-          </div>
-        </div>
+        <SettingsButtonGroup
+          label="声"
+          options={VOICE_OPTIONS}
+          value={voiceId}
+          onChange={setVoiceId}
+          wrapClassName="mb-3 d-flex align-items-center justify-content-center gap-3 border-bottom pb-2 flex-wrap"
+        />
       )}
-      <div className="mb-3 d-flex align-items-center justify-content-center gap-3 border-bottom pb-2">
-        <span className="fw-bold text-dark small">順番:</span>
-        <div className="btn-group btn-group-sm" role="group">
-          <button onClick={() => setSortOrder("random")} className={`btn ${sortOrder === "random" ? 'btn-dark' : 'btn-outline-dark'}`}>ランダム</button>
-          <button onClick={() => setSortOrder("easy")} className={`btn ${sortOrder === "easy" ? 'btn-dark' : 'btn-outline-dark'}`}>簡単</button>
-          <button onClick={() => setSortOrder("hard")} className={`btn ${sortOrder === "hard" ? 'btn-dark' : 'btn-outline-dark'}`}>難しい</button>
-        </div>
-      </div>
-      <div className="mb-3 d-flex align-items-center justify-content-center gap-3 border-bottom pb-2">
-        <span className="fw-bold text-dark small">スピード:</span>
-        <div className="btn-group btn-group-sm" role="group">
-          <button onClick={() => setSpeechRate("70%")} className={`btn ${speechRate === "70%" ? 'btn-dark' : 'btn-outline-dark'}`}>ゆっくり</button>
-          <button onClick={() => setSpeechRate("80%")} className={`btn ${speechRate === "80%" ? 'btn-dark' : 'btn-outline-dark'}`}>ふつう</button>
-          <button onClick={() => setSpeechRate("100%")} className={`btn ${speechRate === "100%" ? 'btn-dark' : 'btn-outline-dark'}`}>はやい</button>
-        </div>
-      </div>
-      <div className="d-flex align-items-center justify-content-center gap-3">
-        <span className="fw-bold text-dark small">回数:</span>
-        <div className="btn-group btn-group-sm" role="group">
-          <button onClick={() => setRepeatCount(1)} className={`btn ${repeatCount === 1 ? 'btn-dark' : 'btn-outline-dark'}`}>1回</button>
-          <button onClick={() => setRepeatCount(2)} className={`btn ${repeatCount === 2 ? 'btn-dark' : 'btn-outline-dark'}`}>2回</button>
-        </div>
-      </div>
+      <SettingsButtonGroup label="順番" options={SORT_ORDER_OPTIONS} value={sortOrder} onChange={setSortOrder} />
+      <SettingsButtonGroup label="スピード" options={SPEECH_RATE_OPTIONS} value={speechRate} onChange={setSpeechRate} />
+      <SettingsButtonGroup
+        label="回数"
+        options={REPEAT_COUNT_OPTIONS}
+        value={repeatCount}
+        onChange={setRepeatCount}
+        wrapClassName="d-flex align-items-center justify-content-center gap-3"
+      />
     </section>
   );
 }

--- a/frontend/src/hooks/useKarutaReading.js
+++ b/frontend/src/hooks/useKarutaReading.js
@@ -10,8 +10,22 @@ const pickTargetPhrase = (unreadPhrases, sortOrder) => {
   if (sortOrder === "hard") {
     return [...unreadPhrases].sort((a, b) => (b.averageDifficulty || 0) - (a.averageDifficulty || 0))[0];
   }
+  // eslint-disable-next-line sonarjs/pseudo-random -- かるたの札をランダムに選ぶだけの用途で暗号学的な強度は不要
   const randomIndex = Math.floor(Math.random() * unreadPhrases.length);
   return unreadPhrases[randomIndex];
+};
+
+// 履歴（カテゴリ別）へ既読の札を追加する。同じ札が既に記録済みなら何もしない
+const appendToHistory = (historyByCategory, categoryKey, phraseData) => {
+  const currentList = historyByCategory[categoryKey] || [];
+  const alreadyRecorded = currentList.some(p => p.id === phraseData.id && p.category === phraseData.category);
+  if (alreadyRecorded) {
+    return historyByCategory;
+  }
+  return {
+    ...historyByCategory,
+    [categoryKey]: [phraseData, ...currentList]
+  };
 };
 
 // 読み上げ・札めくり進行（音声再生・タイマー・フェード演出・結果確定）をまとめた
@@ -152,16 +166,7 @@ export function useKarutaReading({
       if (phraseData) {
         setCurrentPhrase(phraseData);
 
-        setHistoryByCategory(prev => {
-          const currentList = prev[categoryKey] || [];
-          if (currentList.find(p => p.id === phraseData.id && p.category === phraseData.category)) {
-            return prev;
-          }
-          return {
-            ...prev,
-            [categoryKey]: [phraseData, ...currentList]
-          };
-        });
+        setHistoryByCategory(prev => appendToHistory(prev, categoryKey, phraseData));
       }
 
       await playIntroSound();
@@ -380,7 +385,6 @@ export function useKarutaReading({
       const announceCategory = isMultiCategorySelection;
       const settingsSignature = JSON.stringify({ repeatCount, speechRate, lang, voiceId, announceCategory, sortOrder });
       const prefetched = prefetchedNextRef.current;
-      let targetPhrase;
       let data;
 
       if (
@@ -389,11 +393,10 @@ export function useKarutaReading({
         unreadPhrases.some(p => p.id === prefetched.phrase.id && p.category === prefetched.phrase.category)
       ) {
         // プリフェッチ済みの音声データをそのまま使い、取得待ちをスキップする
-        targetPhrase = prefetched.phrase;
         data = prefetched.data;
         prefetchedNextRef.current = null;
       } else {
-        targetPhrase = pickTargetPhrase(unreadPhrases, sortOrder);
+        const targetPhrase = pickTargetPhrase(unreadPhrases, sortOrder);
 
         const apiUrl = `${API_BASE_URL}/get-phrase?id=${targetPhrase.id}&category=${encodeURIComponent(targetPhrase.category)}&repeatCount=${repeatCount}&speechRate=${encodeURIComponent(speechRate)}&lang=${lang}&voiceId=${encodeURIComponent(voiceId)}&announceCategory=${announceCategory}`;
         const response = await fetch(apiUrl);

--- a/frontend/src/hooks/useQuizRoomAdmin.test.jsx
+++ b/frontend/src/hooks/useQuizRoomAdmin.test.jsx
@@ -38,6 +38,45 @@ window.Audio = vi.fn().mockImplementation(function (url) {
 
 window.scrollTo = vi.fn();
 
+// 各テストで使うMockWebSocket（sent配列に送信内容を記録する標準版）を新規に組み立て、
+// window.WebSocketへ差し込む。テストごとにinstancesを空にした新しいクラスが必要なため
+// （前のテストの接続が残っていると数え上げがずれる）、呼び出しのたびに新規定義する
+function installMockWebSocket() {
+  class MockWebSocket {
+    constructor(url) {
+      this.url = url;
+      this.readyState = 0;
+      this.sent = [];
+      MockWebSocket.instances.push(this);
+    }
+    send(data) {
+      this.sent.push(data);
+    }
+    close() {}
+  }
+  MockWebSocket.OPEN = 1;
+  MockWebSocket.instances = [];
+  window.WebSocket = MockWebSocket;
+  return MockWebSocket;
+}
+
+// send()した内容を記録しない最小版（送信内容の検証が不要なテスト用）
+function installMinimalMockWebSocket() {
+  class MockWebSocket {
+    constructor(url) {
+      this.url = url;
+      this.readyState = 0;
+      MockWebSocket.instances.push(this);
+    }
+    send() {}
+    close() {}
+  }
+  MockWebSocket.OPEN = 1;
+  MockWebSocket.instances = [];
+  window.WebSocket = MockWebSocket;
+  return MockWebSocket;
+}
+
 // 注意（issue #712）: 各テスト内のMockWebSocketはsend()した内容を記録するのみで、
 // サーバー応答（judgeQuizRoomBuzzによる`points`/`roundReset`ブロードキャスト等）は
 // 自動生成されない。判定操作（正解/不正解ボタン押下）後の状態反映を検証する場合は、
@@ -76,21 +115,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   });
 
   it('places the player-registration button next to the quiz-room button, and hides it once a quiz room has been created (issue #549)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -157,21 +182,7 @@ describe('useQuizRoomAdmin (via App)', () => {
     localStorage.setItem('lang', 'ja');
     localStorage.setItem('voiceId', 'Mizuki');
 
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -320,21 +331,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 20000);
 
   it('shows the responder\'s name to the admin when a participant buzzes in, and resets it once the next card is shown (issue #510)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -379,21 +376,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('shows a judgment modal with 正解/不正解 buttons when a participant buzzes in, and sends the judgment over the WebSocket while closing the modal (issue #546)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -441,21 +424,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('shows the buzz judgment modal even while the admin is on the room info screen (issue #613)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -510,21 +479,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('shows the current phrase\'s answer in the judgment modal, so the admin can tell whether the response was correct (issue #586)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -572,21 +527,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('reveals the result screen (and stops the elapsed-time measurement) as soon as a buzz is judged correct, instead of waiting for the admin to click 次の札, and broadcasts the winner\'s name (issue #600)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -647,21 +588,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('stops the admin\'s own reading progression when a participant buzzes in, without discarding the elapsed-time measurement needed for the next 次の札 press (issue #788)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -724,21 +651,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('broadcasts isAllRead:true once the selected category\'s last phrase has been read, so the top-page room list can show a "終了" status (issue #501)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -796,21 +709,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('shows the winner\'s name in the "これまでに読み上げた札" history once a buzz is judged correct (issue #695)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -862,21 +761,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('reflects both attempts (回答数) and correct (正答数) counts in the room-info participant table after an incorrect judgment followed by a different participant\'s correct judgment (issue #698)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -951,21 +836,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('does not clear the responder shown to the admin when the same card is re-broadcast (e.g. a settings change re-sends the same phrase), only when the round actually changes (issue #510)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -1014,21 +885,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('shows each participant\'s points to the admin as a "points" message arrives, sorted from highest to lowest (issue #519)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -1074,21 +931,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('shows participants who have not scored yet as 0pt in the same list once a "participants" message arrives (issue #545)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -1139,21 +982,7 @@ describe('useQuizRoomAdmin (via App)', () => {
     localStorage.setItem('lang', 'ja');
     localStorage.setItem('voiceId', 'Mizuki');
 
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -1200,18 +1029,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('shows the list of open quiz rooms on the top page and lets a participant join directly from it (issue #489)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        MockWebSocket.instances.push(this);
-      }
-      send() {}
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMinimalMockWebSocket();
 
     fetch.mockImplementation(async (url) => {
       if (url.includes('/quiz-rooms')) {
@@ -1353,18 +1171,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   });
 
   it('re-fetches the open quiz room list every time the top page is shown again, not just on first mount (issue #531)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        MockWebSocket.instances.push(this);
-      }
-      send() {}
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    installMinimalMockWebSocket();
 
     let quizRoomsCallCount = 0;
     fetch.mockImplementation(async (url) => {
@@ -1482,21 +1289,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   });
 
   it('persists the admin token on room creation, then lets a fresh session (e.g. after closing the tab) restore admin mode from the participant screen using the saved token (issue #697)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -1557,21 +1350,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('offers to resume the saved admin session from the reading screen itself, instead of only via the participant URL (issue #744)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -1630,21 +1409,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('discards the saved admin token and falls back to the participant screen with an error when the saved token fails to connect (issue #697)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     // 事前に（失効済み・無効化された）管理者トークンが保存されている状況を模す
     localStorage.setItem('quizRoomAdminSession', JSON.stringify({ roomId: 'XYZ999', adminToken: 'stale-token' }));
@@ -1687,21 +1452,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('closes the room from the room-info screen, clears the saved admin session, and returns to the reading screen (issue #748)', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {
@@ -1753,21 +1504,7 @@ describe('useQuizRoomAdmin (via App)', () => {
   }, 40000);
 
   it('does not close the room when the confirmation dialog is dismissed', async () => {
-    class MockWebSocket {
-      constructor(url) {
-        this.url = url;
-        this.readyState = 0;
-        this.sent = [];
-        MockWebSocket.instances.push(this);
-      }
-      send(data) {
-        this.sent.push(data);
-      }
-      close() {}
-    }
-    MockWebSocket.OPEN = 1;
-    MockWebSocket.instances = [];
-    window.WebSocket = MockWebSocket;
+    const MockWebSocket = installMockWebSocket();
 
     fetch.mockImplementation(async (url, options) => {
       if (url.includes('/quiz-room') && options?.method === 'POST') {

--- a/frontend/src/hooks/useQuizRoomSync.js
+++ b/frontend/src/hooks/useQuizRoomSync.js
@@ -18,6 +18,44 @@ const ERROR_RETRY_INTERVAL_MS = 15000;
 const SYNC_POLL_BASE_INTERVAL_MS = 45000;
 const SYNC_POLL_JITTER_MS = 15000;
 
+// issue #619: 固定間隔のsetIntervalではなく、送信のたびにジッターを加えて
+// 次回をスケジュールし直すsetTimeoutチェーンにする。あわせて、タブが
+// 非表示（document.hidden）の間は送信自体をスキップしてコストを抑える
+// （フォアグラウンド復帰時はvisibilitychangeハンドラが即座に1回同期する）
+function scheduleNextSyncPoll(ws, pollTimerRef) {
+  // eslint-disable-next-line sonarjs/pseudo-random -- ポーリング間隔のジッター用途で暗号学的な強度は不要
+  const delay = SYNC_POLL_BASE_INTERVAL_MS + Math.random() * SYNC_POLL_JITTER_MS;
+  pollTimerRef.current = setTimeout(() => {
+    if (ws.readyState === WebSocket.OPEN) {
+      if (typeof document === "undefined" || document.visibilityState === "visible") {
+        ws.send(JSON.stringify({ action: "sync" }));
+      }
+      scheduleNextSyncPoll(ws, pollTimerRef);
+    }
+  }, delay);
+}
+
+// WebSocketで届いたメッセージのtypeごとに対応するコールバックへ振り分ける。
+// useQuizRoomSync本体（ws.onmessage）の複雑度を抑えるため、if/elseの連鎖ではなく
+// typeをキーとしたディスパッチテーブルにしている
+const QUIZ_ROOM_MESSAGE_HANDLERS = {
+  state: (data, refs) => refs.onStateRef.current?.(data.state, data.role),
+  buzz: (data, refs) => refs.onBuzzRef.current?.({ name: data.name, connectionId: data.connectionId }),
+  // 回答数集計（issue #698）: answerCountsは名前→{attempts, correct}のマップ
+  points: (data, refs) => refs.onPointsRef.current?.(data.points, data.answerCounts),
+  nameError: (data, refs) => refs.onNameErrorRef.current?.(data.message),
+  // 回答数集計（issue #698）: 不正解判定でもattemptsが増えるため、roundResetブロード
+  // キャストにも更新後のanswerCountsを含めて配信する
+  roundReset: (data, refs) => refs.onRoundResetRef.current?.({ excludedName: data.excludedName, answerCounts: data.answerCounts }),
+  participants: (data, refs) => refs.onParticipantsRef.current?.(data.names),
+  roomClosed: (_data, refs) => refs.onRoomClosedRef.current?.(),
+};
+
+function dispatchQuizRoomMessage(data, refs) {
+  const handler = QUIZ_ROOM_MESSAGE_HANDLERS[data?.type];
+  handler?.(data, refs);
+}
+
 // connectionStatusの値ごとの表示ラベル。参加者画面（QuizRoomView.jsx）・
 // 管理者画面（App.jsx、issue #614で追加）の両方で同じ表記を使うため共有する
 export const CONNECTION_STATUS_LABEL = {
@@ -129,45 +167,21 @@ export function useQuizRoomSync({ wsBaseUrl, roomId, adminToken, onState, onBuzz
         if (pendingNameRef.current !== null) {
           ws.send(JSON.stringify({ action: "setName", name: pendingNameRef.current }));
         }
-        // issue #619: 固定間隔のsetIntervalではなく、送信のたびにジッターを加えて
-        // 次回をスケジュールし直すsetTimeoutチェーンにする。あわせて、タブが
-        // 非表示（document.hidden）の間は送信自体をスキップしてコストを抑える
-        // （フォアグラウンド復帰時は下記のvisibilitychangeハンドラが即座に1回同期する）
-        const scheduleNextSyncPoll = () => {
-          const delay = SYNC_POLL_BASE_INTERVAL_MS + Math.random() * SYNC_POLL_JITTER_MS;
-          pollTimerRef.current = setTimeout(() => {
-            if (ws.readyState === WebSocket.OPEN) {
-              if (typeof document === "undefined" || document.visibilityState === "visible") {
-                ws.send(JSON.stringify({ action: "sync" }));
-              }
-              scheduleNextSyncPoll();
-            }
-          }, delay);
-        };
-        scheduleNextSyncPoll();
+        scheduleNextSyncPoll(ws, pollTimerRef);
       };
 
       ws.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
-          if (data?.type === "state") {
-            onStateRef.current?.(data.state, data.role);
-          } else if (data?.type === "buzz") {
-            onBuzzRef.current?.({ name: data.name, connectionId: data.connectionId });
-          } else if (data?.type === "points") {
-            // 回答数集計（issue #698）: answerCountsは名前→{attempts, correct}のマップ
-            onPointsRef.current?.(data.points, data.answerCounts);
-          } else if (data?.type === "nameError") {
-            onNameErrorRef.current?.(data.message);
-          } else if (data?.type === "roundReset") {
-            // 回答数集計（issue #698）: 不正解判定でもattemptsが増えるため、
-            // roundResetブロードキャストにも更新後のanswerCountsを含めて配信する
-            onRoundResetRef.current?.({ excludedName: data.excludedName, answerCounts: data.answerCounts });
-          } else if (data?.type === "participants") {
-            onParticipantsRef.current?.(data.names);
-          } else if (data?.type === "roomClosed") {
-            onRoomClosedRef.current?.();
-          }
+          dispatchQuizRoomMessage(data, {
+            onStateRef,
+            onBuzzRef,
+            onPointsRef,
+            onNameErrorRef,
+            onRoundResetRef,
+            onParticipantsRef,
+            onRoomClosedRef,
+          });
         } catch (error) {
           console.error("Failed to parse quiz room message:", error);
         }

--- a/frontend/src/views/CategorySelectView.jsx
+++ b/frontend/src/views/CategorySelectView.jsx
@@ -14,6 +14,13 @@ function CategorySelectView({
   handlePrintEfudaClick,
   setView,
 }) {
+  let categoryListContent = null;
+  if (categories.length === 0) {
+    categoryListContent = <div className="text-success fw-bold p-3">読み込み中...</div>;
+  } else if (categoriesForDivision.length === 0) {
+    categoryListContent = <div className="text-muted p-3">このかるたはまだありません。</div>;
+  }
+
   return (
     <div className="container py-5 mx-auto">
       <HeroHeader />
@@ -26,29 +33,23 @@ function CategorySelectView({
           かるたの種類を選んでね{division === "engineer" ? "（複数選択可）" : ""}
         </h2>
         <div className="d-flex flex-wrap gap-3 justify-content-center">
-          {categories.length === 0 ? (
-            <div className="text-success fw-bold p-3">読み込み中...</div>
-          ) : categoriesForDivision.length === 0 ? (
-            <div className="text-muted p-3">このかるたはまだありません。</div>
-          ) : (
-            categoriesForDivision.map(cat => {
-              const isSelected = draftCategories.includes(cat.name);
-              // 選択済みの解除は常に可能。未選択のものだけ、追加すると上限を超える場合に無効化する
-              const wouldExceedCap = !isSelected && draftCardCount + (cat.count || 0) > maxEfudaPrintCards;
-              return (
-                <button
-                  key={cat.name}
-                  onClick={() => toggleDraftCategory(cat.name)}
-                  disabled={wouldExceedCap}
-                  title={wouldExceedCap ? `印刷できる上限（${maxEfudaPrintCards}枚）を超えるため選択できません` : undefined}
-                  className={`btn btn-lg px-4 py-3 fw-bold rounded-pill shadow-sm notranslate btn-karuta ${isSelected ? 'selected' : ''}`}
-                  aria-pressed={isSelected}
-                >
-                  {isSelected ? '✓ ' : ''}{cat.name}
-                </button>
-              );
-            })
-          )}
+          {categoryListContent ?? categoriesForDivision.map(cat => {
+            const isSelected = draftCategories.includes(cat.name);
+            // 選択済みの解除は常に可能。未選択のものだけ、追加すると上限を超える場合に無効化する
+            const wouldExceedCap = !isSelected && draftCardCount + (cat.count || 0) > maxEfudaPrintCards;
+            return (
+              <button
+                key={cat.name}
+                onClick={() => toggleDraftCategory(cat.name)}
+                disabled={wouldExceedCap}
+                title={wouldExceedCap ? `印刷できる上限（${maxEfudaPrintCards}枚）を超えるため選択できません` : undefined}
+                className={`btn btn-lg px-4 py-3 fw-bold rounded-pill shadow-sm notranslate btn-karuta ${isSelected ? 'selected' : ''}`}
+                aria-pressed={isSelected}
+              >
+                {isSelected ? '✓ ' : ''}{cat.name}
+              </button>
+            );
+          })}
         </div>
         {division === "engineer" && categoriesForDivision.length > 0 && (
           <div className="text-center mt-4">

--- a/frontend/src/views/DetailView.jsx
+++ b/frontend/src/views/DetailView.jsx
@@ -1,5 +1,90 @@
 import ViewHeader from "../components/ViewHeader";
 
+// 詳細画面本体（読み込み中はDetailView側で「読み込み中...」を出すため、
+// ここはdetailPhraseが確定してから呼ばれる前提）。DetailView本体の複雑度を
+// 抑えるため、別関数として切り出している
+function renderDetailContent({
+  detailPhrase,
+  repeatPhrase,
+  commentText,
+  setCommentText,
+  postComment,
+  postingComment,
+  detailPhraseComments,
+}) {
+  return (
+    <div className="mx-auto" style={{ maxWidth: "600px" }}>
+      <div className="d-flex justify-content-center mb-4">
+        <div className="yomifuda-container mb-4" onClick={repeatPhrase} role="button">
+          <div className="yomifuda shadow-lg">
+            <div className="yomifuda-kana"><span>{detailPhrase.kana || (detailPhrase.phrase && detailPhrase.phrase[0])}</span></div>
+            <div className="yomifuda-phrase">{detailPhrase.phrase}</div>
+            {detailPhrase.phrase_en && <div className="yomifuda-phrase-en">{detailPhrase.phrase_en}</div>}
+            {detailPhrase.level !== "-" && <div className="yomifuda-level fw-bold">レベル: {detailPhrase.level}</div>}
+          </div>
+        </div>
+      </div>
+      <div className="mb-4 text-muted">
+        <p>読み上げ回数: {detailPhrase.readCount || 0}回</p>
+        <p>平均時間: {(detailPhrase.averageTime || 0).toFixed(2)}秒</p>
+        <p>難易度レベル: {(detailPhrase.averageDifficulty || 0).toFixed(2)}</p>
+      </div>
+
+      {detailPhrase.answer && detailPhrase.answer !== "-" && (
+        <div className="mb-4">
+          <div className="text-muted mb-2">答え</div>
+          <div className="h4 fw-bold text-dark">{detailPhrase.answer}</div>
+        </div>
+      )}
+      {detailPhrase.explanation && detailPhrase.explanation !== "-" && (
+        <div className="mb-4 fs-6 text-dark">{detailPhrase.explanation}</div>
+      )}
+      <div className="mb-5">
+        <button
+          onClick={repeatPhrase}
+          className="btn btn-lg px-5 py-3 fw-bold rounded-pill shadow btn-karuta"
+        >
+          読み上げる
+        </button>
+      </div>
+
+    {detailPhraseComments && detailPhraseComments.length > 0 && (
+      <section className="text-start mb-4">
+        <h2 className="h6 fw-bold mb-3 text-muted">これまでの指摘（{detailPhraseComments.length}件）</h2>
+        <div className="d-flex flex-column gap-2">
+          {detailPhraseComments.map(c => (
+            <div key={c.id} className="p-3 bg-light rounded-3 border-start border-4 border-danger">
+              <small className="text-muted d-block mb-1">{new Date(c.createdAt).toLocaleString()}</small>
+              <p className="mb-0 text-dark">{c.comment}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    )}
+
+    <section className="comment-form-container text-start p-4 bg-light rounded-4 shadow-sm border">
+      <h2 className="h5 fw-bold mb-3 text-dark">かるたの誤りを指摘する</h2>
+      <form onSubmit={postComment}>
+          <div className="mb-3">
+            <textarea
+              className="form-control rounded-3"
+              rows="3"
+              placeholder="例：かなが間違っている、フレーズが違うなど"
+              value={commentText}
+              onChange={(e) => setCommentText(e.target.value)}
+              maxLength={1000}
+              required
+            ></textarea>
+          </div>
+          <button type="submit" disabled={postingComment} className="btn btn-danger w-100 rounded-pill py-2 fw-bold shadow-sm">
+            {postingComment ? "送信中..." : "指摘内容を送信する"}
+          </button>
+        </form>
+      </section>
+    </div>
+  );
+}
+
 function DetailView({
   detailPhrase,
   detailPhraseCategory,
@@ -24,75 +109,15 @@ function DetailView({
         {!detailPhrase ? (
           <div className="p-5 text-muted">読み込み中...</div>
         ) : (
-          <div className="mx-auto" style={{ maxWidth: "600px" }}>
-            <div className="d-flex justify-content-center mb-4">
-              <div className="yomifuda-container mb-4" onClick={repeatPhrase} role="button">
-                <div className="yomifuda shadow-lg">
-                  <div className="yomifuda-kana"><span>{detailPhrase.kana || (detailPhrase.phrase && detailPhrase.phrase[0])}</span></div>
-                  <div className="yomifuda-phrase">{detailPhrase.phrase}</div>
-                  {detailPhrase.phrase_en && <div className="yomifuda-phrase-en">{detailPhrase.phrase_en}</div>}
-                  {detailPhrase.level !== "-" && <div className="yomifuda-level fw-bold">レベル: {detailPhrase.level}</div>}
-                </div>
-              </div>
-            </div>
-            <div className="mb-4 text-muted">
-              <p>読み上げ回数: {detailPhrase.readCount || 0}回</p>
-              <p>平均時間: {(detailPhrase.averageTime || 0).toFixed(2)}秒</p>
-              <p>難易度レベル: {(detailPhrase.averageDifficulty || 0).toFixed(2)}</p>
-            </div>
-
-            {detailPhrase.answer && detailPhrase.answer !== "-" && (
-              <div className="mb-4">
-                <div className="text-muted mb-2">答え</div>
-                <div className="h4 fw-bold text-dark">{detailPhrase.answer}</div>
-              </div>
-            )}
-            {detailPhrase.explanation && detailPhrase.explanation !== "-" && (
-              <div className="mb-4 fs-6 text-dark">{detailPhrase.explanation}</div>
-            )}
-            <div className="mb-5">
-              <button
-                onClick={repeatPhrase}
-                className="btn btn-lg px-5 py-3 fw-bold rounded-pill shadow btn-karuta"
-              >
-                読み上げる
-              </button>
-            </div>
-
-          {detailPhraseComments && detailPhraseComments.length > 0 && (
-            <section className="text-start mb-4">
-              <h2 className="h6 fw-bold mb-3 text-muted">これまでの指摘（{detailPhraseComments.length}件）</h2>
-              <div className="d-flex flex-column gap-2">
-                {detailPhraseComments.map(c => (
-                  <div key={c.id} className="p-3 bg-light rounded-3 border-start border-4 border-danger">
-                    <small className="text-muted d-block mb-1">{new Date(c.createdAt).toLocaleString()}</small>
-                    <p className="mb-0 text-dark">{c.comment}</p>
-                  </div>
-                ))}
-              </div>
-            </section>
-          )}
-
-          <section className="comment-form-container text-start p-4 bg-light rounded-4 shadow-sm border">
-            <h2 className="h5 fw-bold mb-3 text-dark">かるたの誤りを指摘する</h2>
-            <form onSubmit={postComment}>
-                <div className="mb-3">
-                  <textarea
-                    className="form-control rounded-3"
-                    rows="3"
-                    placeholder="例：かなが間違っている、フレーズが違うなど"
-                    value={commentText}
-                    onChange={(e) => setCommentText(e.target.value)}
-                    maxLength={1000}
-                    required
-                  ></textarea>
-                </div>
-                <button type="submit" disabled={postingComment} className="btn btn-danger w-100 rounded-pill py-2 fw-bold shadow-sm">
-                  {postingComment ? "送信中..." : "指摘内容を送信する"}
-                </button>
-              </form>
-            </section>
-          </div>
+          renderDetailContent({
+            detailPhrase,
+            repeatPhrase,
+            commentText,
+            setCommentText,
+            postComment,
+            postingComment,
+            detailPhraseComments,
+          })
         )}
       </main>
     </div>

--- a/frontend/src/views/DivisionSelectView.jsx
+++ b/frontend/src/views/DivisionSelectView.jsx
@@ -1,5 +1,11 @@
 import { HeroHeader, TopViewFooterLinks } from "../components/TopViewChrome";
 
+function roomStatusBadgeClass(status) {
+  if (status === "進行中") return "text-bg-success";
+  if (status === "終了") return "text-bg-dark";
+  return "text-bg-secondary";
+}
+
 function DivisionSelectView({
   openQuizRooms,
   joinQuizRoom,
@@ -40,12 +46,7 @@ function DivisionSelectView({
               >
                 <span className="fw-bold notranslate">{room.roomId}</span>
                 <span className="d-flex align-items-center gap-2">
-                  <span className={`badge rounded-pill ${
-                    room.status === "進行中" ? "text-bg-success"
-                      : room.status === "終了" ? "text-bg-dark"
-                        : "text-bg-secondary"
-                  }`}
-                  >
+                  <span className={`badge rounded-pill ${roomStatusBadgeClass(room.status)}`}>
                     {room.status}
                   </span>
                   {room.category && <span className="text-muted small notranslate">{room.category}</span>}

--- a/frontend/src/views/PrintEfudaView.jsx
+++ b/frontend/src/views/PrintEfudaView.jsx
@@ -85,6 +85,23 @@ function PrintEfudaView({ categoryLabel, onBack, selectedCategories, allPhrasesF
     [allPhrasesForCategory]
   );
 
+  let emptyStateContent = null;
+  if (selectedCategories.length === 0) {
+    emptyStateContent = <p className="text-muted text-center py-5 no-print">カテゴリを選択してください。</p>;
+  } else if (allPhrasesForCategory.length === 0 && phrasesFetchError) {
+    // issue #474: 「読み込み中」と「取得失敗」を区別する。以前はどちらも
+    // allPhrasesForCategory.length === 0だけで判定していたため、取得に失敗した
+    // 場合も「読み込み中...」の表示のまま進まなくなっていた
+    emptyStateContent = (
+      <div className="text-center py-5 no-print">
+        <p className="text-danger mb-3">かるたデータの取得に失敗しました。</p>
+        <button onClick={onRetryFetchPhrases} className="btn btn-outline-dark rounded-pill px-4">再試行する</button>
+      </div>
+    );
+  } else if (allPhrasesForCategory.length === 0) {
+    emptyStateContent = <p className="text-muted text-center py-5 no-print">読み込み中...</p>;
+  }
+
   const downloadPdf = async () => {
     setIsGeneratingPdf(true);
     try {
@@ -142,19 +159,7 @@ function PrintEfudaView({ categoryLabel, onBack, selectedCategories, allPhrasesF
         noPrint
       />
 
-      {selectedCategories.length === 0 ? (
-        <p className="text-muted text-center py-5 no-print">カテゴリを選択してください。</p>
-      ) : allPhrasesForCategory.length === 0 && phrasesFetchError ? (
-        // issue #474: 「読み込み中」と「取得失敗」を区別する。以前はどちらも
-        // allPhrasesForCategory.length === 0だけで判定していたため、取得に失敗した
-        // 場合も「読み込み中...」の表示のまま進まなくなっていた
-        <div className="text-center py-5 no-print">
-          <p className="text-danger mb-3">かるたデータの取得に失敗しました。</p>
-          <button onClick={onRetryFetchPhrases} className="btn btn-outline-dark rounded-pill px-4">再試行する</button>
-        </div>
-      ) : allPhrasesForCategory.length === 0 ? (
-        <p className="text-muted text-center py-5 no-print">読み込み中...</p>
-      ) : (
+      {emptyStateContent ?? (
         <>
           {phrasesFetchError && (
             <div className="alert alert-warning no-print text-center d-flex align-items-center justify-content-center gap-3 flex-wrap">
@@ -203,8 +208,9 @@ function PrintEfudaView({ categoryLabel, onBack, selectedCategories, allPhrasesF
                     {Array.from({ length: efudaPerPage }).map((_, slotIndex) => {
                       const p = page.items[resolvePhraseIndex(slotIndex, printSide)];
                       const patternName = p && backPatternMap.get(p.category);
+                      const cardClassName = patternName ? `efuda-card efuda-color-${patternName}` : "efuda-card";
                       return (
-                        <div className={`efuda-card ${patternName ? `efuda-color-${patternName}` : ""}`} key={slotIndex}>
+                        <div className={cardClassName} key={slotIndex}>
                           {p && (printSide === "back" ? (
                             <div className={`efuda-card-back efuda-pattern-${patternName}`}>
                               <div className="efuda-card-back-category">{p.category}</div>

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -61,6 +61,45 @@ function renderParticipantContent(roomState) {
   return null;
 }
 
+// 早押し状態に応じた表示（不正解案内／回答中表示／回答ボタン）を1つに決定する。
+// - excludedThisRound: 直前に不正解と判定され、次の札を待っている状態を優先表示する
+// - winnerAlreadyShown: result画面側で既に正解者名を表示している間は「回答中」の
+//   重複表示を出さない（issue #696）
+// レンダー中に評価する早押しラウンドキーの導出（QuizRoomView本体の複雑度を
+// 抑えるための純粋関数）。"result"表示中は直前のラウンドキーを維持し、
+// それ以外の未知の状態（"initial"等）ではラウンドなし（null）とする
+function deriveBuzzRoundKey(roomState, lastBuzzRoundKey) {
+  if (roomState?.type === "phrase" && roomState.content?.id) {
+    return phraseKey(roomState.content);
+  }
+  if (roomState?.type !== "result") {
+    return null;
+  }
+  return lastBuzzRoundKey;
+}
+
+function renderBuzzStatus({ excludedThisRound, buzzedBy, roomState, onBuzz }) {
+  if (excludedThisRound) {
+    // issue #680: 不正解と判定された本人には「回答中」ではなく、不正解だった
+    // ことと次の札を待つよう案内する専用の表示を出す
+    return <p className="fw-bold text-muted mt-4">不正解でした。次の問題まで待っててね</p>;
+  }
+  const winnerAlreadyShown = roomState?.type === "result" && roomState.content?.winner;
+  if (buzzedBy && !winnerAlreadyShown) {
+    return <p className="fw-bold text-dark mt-4">🔔 {buzzedBy.name} さんが回答中</p>;
+  }
+  if (roomState?.type === "phrase") {
+    return (
+      <div className="mt-4">
+        <button onClick={onBuzz} className="btn btn-danger btn-lg rounded-pill px-5">
+          回答する
+        </button>
+      </div>
+    );
+  }
+  return null;
+}
+
 function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRestoreError, switchToAdminMode }) {
   const urlRoomId = useMemo(() => new URLSearchParams(window.location.search).get("roomId"), []);
   const [joinRoomId, setJoinRoomId] = useState(urlRoomId);
@@ -232,12 +271,7 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
   // 「直前のラウンドキー（lastBuzzRoundKey）を参照して"result"中は維持する」という
   // 前回値への依存を持つため、値の変化だけを検知するuseValueChangeにはそのまま乗らず、
   // ここでは個別に扱う
-  let currentBuzzRoundKey = lastBuzzRoundKey;
-  if (roomState?.type === "phrase" && roomState.content?.id) {
-    currentBuzzRoundKey = phraseKey(roomState.content);
-  } else if (roomState?.type !== "result") {
-    currentBuzzRoundKey = null;
-  }
+  const currentBuzzRoundKey = deriveBuzzRoundKey(roomState, lastBuzzRoundKey);
   if (currentBuzzRoundKey !== lastBuzzRoundKey) {
     setLastBuzzRoundKey(currentBuzzRoundKey);
     setBuzzedBy(null);
@@ -396,6 +430,103 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
     };
   }, [roomState, confirmedName]);
 
+  // ルームコード確認済み・参加中の画面。routedViewの複雑度を抑えるため、
+  // 別関数として切り出している
+  const renderJoinedRoom = () => {
+    return (
+      <div className="container py-5 mx-auto text-center">
+        <Confetti pieces={confettiPieces} />
+        <header className="mb-4">
+          <h1 className="h4 fw-bold">クイズ大会モード（参加者）</h1>
+          <p className="text-muted small">ルーム: {joinRoomId}</p>
+        </header>
+        {/* 管理者セッション復帰（issue #697）: 保存済みの管理者トークンで管理者への
+            切り替えを試みて失敗した場合のエラー表示。この時点で保存済みトークンは
+            既に破棄されているため、「管理者に切り替える」ボタン自体も表示されなくなる */}
+        {adminSessionRestoreError && <p className="text-danger small mb-3">{adminSessionRestoreError}</p>}
+        <p className="text-muted small mb-3">
+          <span>接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}</span>
+          {/* issue #614: 再接続の上限に達した場合、フォアグラウンド復帰・オンライン復帰では
+              自動的に再接続を試みるが、それでも復帰しない場合に手動でやり直せる導線が
+              無かったため追加する */}
+          {connectionStatus === "error" && (
+            <button
+              type="button"
+              onClick={reconnect}
+              className="btn btn-sm btn-outline-danger rounded-pill ms-2"
+            >
+              再接続
+            </button>
+          )}
+        </p>
+        <p className="fw-bold text-dark">獲得ポイント: {points[confirmedName] || 0}</p>
+        {renderParticipantContent(roomState)}
+        {renderBuzzStatus({ excludedThisRound, buzzedBy, roomState, onBuzz: handleBuzz })}
+        {/* 参加者一覧（issue #545）: まだ得点していない参加者も0ptとして含めた1つのリストに
+            統合して表示する（管理者画面と同じ並び順）。表形式・接続ステータス表示、回答ボタン
+            より下への配置はissue #599で対応。回答数（issue #698）: 早押しして正誤判定された
+            累計回数（attempts）も併せて表示する */}
+        <QuizRoomParticipantTable
+          participantNames={participants}
+          points={points}
+          answerCounts={answerCounts}
+          highlightName={confirmedName}
+        />
+        {phraseHistory.length > 0 && (
+          <div className="mx-auto mt-4 text-center" style={{ maxWidth: "480px" }}>
+            <button
+              type="button"
+              onClick={() => setShowHistory(prev => !prev)}
+              className="btn btn-sm btn-outline-secondary rounded-pill px-3"
+            >
+              {showHistory ? "これまでに読み上げた札を閉じる" : `これまでに読み上げた札を表示する（${phraseHistory.length}枚）`}
+            </button>
+            {showHistory && (
+              // 管理者側の「詳細・報告 →」リンク（openDetail、DetailViewへの画面遷移を伴う指摘
+              // コメント投稿につながる）はここでは出さず、閲覧専用の簡易表示にとどめる（issue #548）。
+              // クイズ大会モードの参加者は端末を共有していない不特定多数のため、管理者専用機能への
+              // 導線をそのまま公開する必要はないと判断した
+              <div className="text-start mt-3">
+                <div className="list-group shadow-sm rounded">
+                  {phraseHistory.map((p, index) => (
+                    <div key={`${p.category}-${p.id}-${phraseHistory.length - index}`} className="list-group-item d-flex align-items-center">
+                      {p.level !== "-" && <span className="badge bg-danger me-2">Lv.{p.level}</span>}
+                      <span className="text-dark">{p.phrase}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+        {/* 管理者セッション復帰（issue #697）: このルームの管理者トークンが保存されている
+            場合のみ表示する。押すと保存済みトークンで管理者として再接続し、
+            管理者画面（QuizRoomInfoView）へ切り替わる */}
+        {adminSessionRoomId === joinRoomId && (
+          <div className="mt-4">
+            <button
+              type="button"
+              onClick={() => {
+                if (switchToAdminMode(joinRoomId)) {
+                  setView("quiz-room-info");
+                }
+              }}
+              className="btn btn-sm btn-outline-dark rounded-pill px-3"
+            >
+              管理者に切り替える
+            </button>
+          </div>
+        )}
+        <div className="mt-5">
+          <button onClick={goBack} className="btn btn-link text-muted text-decoration-none">← 戻る</button>
+        </div>
+      </div>
+    );
+  };
+
+  // ルームコード入力前の各種早期リターン・参加中画面。QuizRoomViewコンポーネント
+  // 本体の複雑度を抑えるため、該当が無ければnullを返すだけの即時実行関数へまとめている
+  const routedView = (() => {
   if (!wsBaseUrl) {
     return (
       <div className="container py-5 mx-auto text-center">
@@ -471,114 +602,11 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
     );
   }
 
-  if (joinRoomId) {
-    return (
-      <div className="container py-5 mx-auto text-center">
-        <Confetti pieces={confettiPieces} />
-        <header className="mb-4">
-          <h1 className="h4 fw-bold">クイズ大会モード（参加者）</h1>
-          <p className="text-muted small">ルーム: {joinRoomId}</p>
-        </header>
-        {/* 管理者セッション復帰（issue #697）: 保存済みの管理者トークンで管理者への
-            切り替えを試みて失敗した場合のエラー表示。この時点で保存済みトークンは
-            既に破棄されているため、「管理者に切り替える」ボタン自体も表示されなくなる */}
-        {adminSessionRestoreError && <p className="text-danger small mb-3">{adminSessionRestoreError}</p>}
-        <p className="text-muted small mb-3">
-          <span>接続状態: {CONNECTION_STATUS_LABEL[connectionStatus] || connectionStatus}</span>
-          {/* issue #614: 再接続の上限に達した場合、フォアグラウンド復帰・オンライン復帰では
-              自動的に再接続を試みるが、それでも復帰しない場合に手動でやり直せる導線が
-              無かったため追加する */}
-          {connectionStatus === "error" && (
-            <button
-              type="button"
-              onClick={reconnect}
-              className="btn btn-sm btn-outline-danger rounded-pill ms-2"
-            >
-              再接続
-            </button>
-          )}
-        </p>
-        <p className="fw-bold text-dark">獲得ポイント: {points[confirmedName] || 0}</p>
-        {renderParticipantContent(roomState)}
-        {excludedThisRound ? (
-          // issue #680: 不正解と判定された本人には「回答中」ではなく、不正解だった
-          // ことと次の札を待つよう案内する専用の表示を出す。excludedThisRoundは
-          // 次の札が届いたタイミングでfalseに戻る（上記のラウンド切り替え判定）
-          <p className="fw-bold text-muted mt-4">不正解でした。次の問題まで待っててね</p>
-        ) : /* issue #696: 正解と判定されresult画面に勝者（winner）が表示されている間は、
-               「回答中」の重複表示を出さない（結果画面側で既に正解者名を表示しているため）。
-               winnerが無いresult（早押しを介さない通常の「次の札」による結果表示等）では、
-               従来どおり回答者表示を維持する */
-        buzzedBy && !(roomState?.type === "result" && roomState.content?.winner) ? (
-          <p className="fw-bold text-dark mt-4">🔔 {buzzedBy.name} さんが回答中</p>
-        ) : roomState?.type === "phrase" && (
-          <div className="mt-4">
-            <button onClick={handleBuzz} className="btn btn-danger btn-lg rounded-pill px-5">
-              回答する
-            </button>
-          </div>
-        )}
-        {/* 参加者一覧（issue #545）: まだ得点していない参加者も0ptとして含めた1つのリストに
-            統合して表示する（管理者画面と同じ並び順）。表形式・接続ステータス表示、回答ボタン
-            より下への配置はissue #599で対応。回答数（issue #698）: 早押しして正誤判定された
-            累計回数（attempts）も併せて表示する */}
-        <QuizRoomParticipantTable
-          participantNames={participants}
-          points={points}
-          answerCounts={answerCounts}
-          highlightName={confirmedName}
-        />
-        {phraseHistory.length > 0 && (
-          <div className="mx-auto mt-4 text-center" style={{ maxWidth: "480px" }}>
-            <button
-              type="button"
-              onClick={() => setShowHistory(prev => !prev)}
-              className="btn btn-sm btn-outline-secondary rounded-pill px-3"
-            >
-              {showHistory ? "これまでに読み上げた札を閉じる" : `これまでに読み上げた札を表示する（${phraseHistory.length}枚）`}
-            </button>
-            {showHistory && (
-              // 管理者側の「詳細・報告 →」リンク（openDetail、DetailViewへの画面遷移を伴う指摘
-              // コメント投稿につながる）はここでは出さず、閲覧専用の簡易表示にとどめる（issue #548）。
-              // クイズ大会モードの参加者は端末を共有していない不特定多数のため、管理者専用機能への
-              // 導線をそのまま公開する必要はないと判断した
-              <div className="text-start mt-3">
-                <div className="list-group shadow-sm rounded">
-                  {phraseHistory.map((p, index) => (
-                    <div key={`${p.category}-${p.id}-${phraseHistory.length - index}`} className="list-group-item d-flex align-items-center">
-                      {p.level !== "-" && <span className="badge bg-danger me-2">Lv.{p.level}</span>}
-                      <span className="text-dark">{p.phrase}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-        {/* 管理者セッション復帰（issue #697）: このルームの管理者トークンが保存されている
-            場合のみ表示する。押すと保存済みトークンで管理者として再接続し、
-            管理者画面（QuizRoomInfoView）へ切り替わる */}
-        {adminSessionRoomId === joinRoomId && (
-          <div className="mt-4">
-            <button
-              type="button"
-              onClick={() => {
-                if (switchToAdminMode(joinRoomId)) {
-                  setView("quiz-room-info");
-                }
-              }}
-              className="btn btn-sm btn-outline-dark rounded-pill px-3"
-            >
-              管理者に切り替える
-            </button>
-          </div>
-        )}
-        <div className="mt-5">
-          <button onClick={goBack} className="btn btn-link text-muted text-decoration-none">← 戻る</button>
-        </div>
-      </div>
-    );
-  }
+  if (joinRoomId) return renderJoinedRoom();
+
+  return null;
+  })();
+  if (routedView) return routedView;
 
   return (
     <div className="container py-5 mx-auto">


### PR DESCRIPTION
## Summary
- issue #833で洗い出した現状の指摘（ESLintの`complexity`ルール・`eslint-plugin-sonarjs`計89件、jscpd重複20.31%）を実際に解消
- **prefer-specific-assertions**（24件）: `expect(x.length).toBe(n)`等を`toHaveLength`等の専用アサーションへ機械的に置換
- **no-identical-functions**: `useQuizRoomAdmin.test.jsx`の重複していた`MockWebSocket`クラス定義（22件）を`installMockWebSocket`/`installMinimalMockWebSocket`へ、`handler.test.js`の`audioStream`生成を`createAudioStream()`へ共通化
- **complexity/cognitive-complexity**: `App.jsx`（33→解消）・`QuizRoomView.jsx`（41→解消）・`SettingsFooter.jsx`・`DetailView.jsx`・`PwaUpdatePrompt.jsx`・`useQuizRoomSync.js`・backend `handler.js`（32→解消）・`seed.js`（30→解消）・`quizRoomHandler.js`（17/19→解消）を、画面ルーティングの関数分割・SSML組み立て等の純粋関数抽出・メッセージtypeのディスパッチテーブル化等でそれぞれ解消
- 残りの単発警告（no-nested-conditional/no-nested-functions/pseudo-random等）もあわせて解消し、**frontend/backend双方とも0警告を達成**
- 実測値に合わせてゲートをratchet down: `--max-warnings`（frontend/backendとも60/29→**0**）、jscpdの`duplication_threshold`（21→**19**、実測20.31%→**18.64%**）
- issue #748（closeQuizRoomのIAM権限修正）はデプロイ確認済みのため、該当するskip中だったE2Eテスト（`admin closes the room, and the participant sees a closed-by-host message`）を有効化

Refs #833

## Test plan
- [x] `frontend`: `npx eslint . --max-warnings 0`（0 errors, 0 warnings）／ `npx vitest run`（250 passed）
- [x] `backend`: `npx eslint . --max-warnings 0`（0 errors, 0 warnings）／ `npx vitest run`（1543 passed）
- [x] jscpdをローカル実行し重複率が18.64%（閾値19に対し超過なし）であることを確認
- [x] `ci.yml`をjs-yamlでパースし、`duplication_threshold`の値を確認
- [ ] CIで新設定（`--max-warnings 0`・`duplication_threshold: 19`）を用いた`frontend-test`/`backend-test`/`duplication-check`ジョブが実際に通過することを確認
- [ ] CIで有効化した`admin closes the room...`のE2Eテストが実際のAWS環境に対して成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_