### PR TITLE
fix(deps): npm auditで検出された安全に修正可能な脆弱性を解消する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5242,16 +5242,16 @@
       }
     },
     "backend/node_modules/eslint/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "backend/node_modules/eslint/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
@@ -13838,16 +13838,16 @@
       }
     },
     "backend/node_modules/serverless-esbuild/node_modules/bestzip/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "backend/node_modules/serverless-esbuild/node_modules/bestzip/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
@@ -18837,16 +18837,16 @@
       }
     },
     "frontend/node_modules/eslint/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "frontend/node_modules/eslint/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
@@ -39095,9 +39095,9 @@
       "license": "MIT"
     },
     "frontend/node_modules/vite-plugin-pwa/node_modules/workbox-build/node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -39383,16 +39383,16 @@
       }
     },
     "frontend/node_modules/vite-plugin-pwa/node_modules/workbox-build/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "frontend/node_modules/vite-plugin-pwa/node_modules/workbox-build/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
@@ -41790,9 +41790,9 @@
       "license": "MIT"
     },
     "node_modules/@commitlint/cli/node_modules/@commitlint/load/node_modules/@commitlint/config-validator/node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- issue #831（Dependabot alertsが検知した3件の脆弱性、詳細未確認）の調査として`npm audit`をローカル実行。件数（29件、うちhigh 16・moderate 12・low 1）はDependabot alertsの件数（high 1・moderate 1・low 1）と一致しないが、これは`npm audit`が依存ツリー全体（推移的devDependency含む）を対象にする一方、Dependabot alertsはより限定的な集計をしているためと考えられる
- `npm audit fix`（`--force`なし、非破壊的な修正のみ）を実行し、`fast-uri`（3.1.3→3.1.4）・`brace-expansion`（5.0.7→5.0.8）の2件のtransitive dependencyを更新。既存のsemverレンジ内での解決のため`package.json`自体は変更なし
- 残る28件はいずれも`isSemVerMajor: true`（semantic-release関連プラグイン群・serverless-esbuild・vite-plugin-pwa・osls等のメジャーバージョン更新が必要）。これらはビルド・リリース時にのみ使われるdevDependencyであり、デプロイ済みのfrontend/backendの実行時攻撃面には含まれない。個別に破壊的変更のリスクがあるため、一括での`--force`適用は行わず、issue #807の方針どおりRenovateの通常更新サイクルに委ねる

Refs #831

## Test plan
- [x] `frontend`: `npx eslint . --max-warnings 0`（0 errors, 0 warnings）／ `npx vitest run`（250 passed）
- [x] `backend`: `npx eslint . --max-warnings 0`（0 errors, 0 warnings）／ `npx vitest run`（1543 passed）
- [x] `npm audit`をローカル実行し、全体の脆弱性件数が29件→28件に減少したことを確認（`package.json`自体は変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_