### PR TITLE
docs: mermaidソースブロックを折りたたみ表示にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@
 
 ### System Architecture
 
+<details>
+<summary>ソースを表示（mermaid記法）</summary>
+
 ```mermaid
 graph TD
     subgraph "Frontend (GitHub Pages)"
@@ -64,11 +67,16 @@ graph TD
     I -->|クイズ大会モード| P;
 ```
 
-上記の```mermaid```ブロックはPR差分ビュー・API経由でのファイル取得等ではテキストのまま表示され図として確認できない（[#824](https://github.com/bamiyanapp/karuta/issues/824)）。ソースはこのまま維持しつつ、以下は`enable_mermaid_render` job（[docs/cicd-pipeline-specification.md](./docs/cicd-pipeline-specification.md)参照）が`main`へのマージのたびに再レンダリングし、`docs-diagrams`ブランチの`latest/`へ上書き公開している画像（常に最新版）。
+上記の```mermaid```ブロックはPR差分ビュー・API経由でのファイル取得等ではテキストのまま表示され図として確認できない（[#824](https://github.com/bamiyanapp/karuta/issues/824)）。ソースはこのまま維持しつつ、下記は`enable_mermaid_render` job（[docs/cicd-pipeline-specification.md](./docs/cicd-pipeline-specification.md)参照）が`main`へのマージのたびに再レンダリングし、`docs-diagrams`ブランチの`latest/`へ上書き公開している画像（常に最新版）。
+
+</details>
 
 ![System Architecture (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/README-1.svg)
 
 ### Screen Transitions
+
+<details>
+<summary>ソースを表示（mermaid記法）</summary>
 
 ```mermaid
 graph TD
@@ -117,6 +125,8 @@ graph TD
 ```
 
 同様に、上記図もCIが再レンダリングし`docs-diagrams`ブランチの`latest/`へ公開している画像。
+
+</details>
 
 ![Screen Transitions (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/README-2.svg)
 

--- a/docs/cicd-pipeline-specification.md
+++ b/docs/cicd-pipeline-specification.md
@@ -6,6 +6,9 @@
 
 ## Architecture
 
+<details>
+<summary>ソースを表示（mermaid記法）</summary>
+
 ```mermaid
 graph TD
     A[PR] --> B[CI Workflow];
@@ -18,7 +21,9 @@ graph TD
     G --> I[Deploy Backend to AWS];
 ```
 
-上記の```mermaid```ブロックはPR差分ビュー・API経由でのファイル取得等ではテキストのまま表示され図として確認できない（[bamiyanapp/karuta#824](https://github.com/bamiyanapp/karuta/issues/824)）。ソース（mermaid記法）はこのまま維持しつつ、以下は`enable_mermaid_render` job（[dev-standards側ドキュメント](../dev-standards/docs/cicd-pipeline-specification.md#1-ci-ワークフロー-reusable-ciyml)参照）が`main`へのマージのたびに再レンダリングし、`docs-diagrams`ブランチの`latest/`へ上書き公開している画像（常に最新版）。
+上記の```mermaid```ブロックはPR差分ビュー・API経由でのファイル取得等ではテキストのまま表示され図として確認できない（[bamiyanapp/karuta#824](https://github.com/bamiyanapp/karuta/issues/824)）。ソース（mermaid記法）はこのまま維持しつつ、下記は`enable_mermaid_render` job（[dev-standards側ドキュメント](../dev-standards/docs/cicd-pipeline-specification.md#1-ci-ワークフロー-reusable-ciyml)参照）が`main`へのマージのたびに再レンダリングし、`docs-diagrams`ブランチの`latest/`へ上書き公開している画像（常に最新版）。
+
+</details>
 
 ![Architecture (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/cicd-pipeline-specification.svg)
 


### PR DESCRIPTION
## Summary
- issue #837の問題1（```mermaid```ソースブロックが冗長）に対応
- `README.md`（System Architecture／Screen Transitions）・`docs/cicd-pipeline-specification.md`（Architecture）の```` ```mermaid ```` ソースブロックを`<details><summary>ソースを表示（mermaid記法）</summary>`で囲み、既定で折りたたむようにした
- ソース（mermaid記法）自体はissue #824の制約どおりそのまま維持し、内容の変更は一切行っていない

issue #837の問題2（SVG画像がモバイルでタップ拡大表示できない）は、dev-standards側でのレンダリング出力形式変更（[bamiyanapp/dev-standards#122](``https://github.com/bamiyanapp/dev-standards/pull/122)、SVG→PNG）が必要なため別PRで対応する。あちらがリリースされ次第、karuta側の'ci.yml'の参照タグ・埋め込みリンク（'.svg'→'.png'）を追従させる。``

Refs #837

## Test plan
- [x] `frontend`: `npx eslint . --max-warnings 0`（0 errors, 0 warnings）／ `npx vitest run`（250 passed）
- [x] `backend`: `npx eslint . --max-warnings 0`（0 errors, 0 warnings）／ `npx vitest run`（1543 passed）
- [x] `<details>`/`</details>`タグの開閉数が一致することを確認
- [ ] マージ後、実際にGitHub上でREADME.md・docs/cicd-pipeline-specification.mdを開き、ソースブロックが既定で折りたたまれ、展開すると内容を確認できることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_