### PR TITLE
fix(ci): mermaid埋め込み画像をPNGへ切り替える

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ci:
-    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.12.0
+    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.12.2
     with:
       frontend_dir: frontend
       backend_dir: backend

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ graph TD
 
 </details>
 
-![System Architecture (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/README-1.svg)
+![System Architecture (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/README-1.png)
 
 ### Screen Transitions
 
@@ -128,7 +128,7 @@ graph TD
 
 </details>
 
-![Screen Transitions (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/README-2.svg)
+![Screen Transitions (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/README-2.png)
 
 ### Backend API (AWS Lambda)
 

--- a/docs/cicd-pipeline-specification.md
+++ b/docs/cicd-pipeline-specification.md
@@ -25,7 +25,7 @@ graph TD
 
 </details>
 
-![Architecture (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/cicd-pipeline-specification.svg)
+![Architecture (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/cicd-pipeline-specification.png)
 
 semantic-releaseの実行は`main`へのpush後（CD側の`release`ジョブ）で行われる。以前はPRの作業ブランチ上でマージ前に実行する方式だったが、GitHub Actionsの`pull_request`イベントで自動設定される`GITHUB_REF`（ワークフローYAMLの`env:`では上書き不可）により常にリリースが発行されない不具合があったため、`main`への実pushイベント上で実行する方式に修正した（[dev-standards#43](https://github.com/bamiyanapp/dev-standards/pull/43)）。
 


### PR DESCRIPTION
## Summary
- issue #837の問題2（SVG画像がGitHubモバイルアプリでタップ拡大表示できない）の最終対応
- dev-standardsの`reusable-ci.yml`参照タグを`v1.12.0`から`v1.12.2`へ更新。`v1.12.1`で`render-mermaid-diagrams`の出力がSVGからPNGへ切り替わり（[dev-standards#122](``https://github.com/bamiyanapp/dev-standards/pull/122)）、'v1.12.2'で'reusable-ci.yml'自身が使う自己参照タグ（'.dev-standards-actions'のcheckout`` ref）もその修正を含むタグへ更新済み（[dev-standards#123](https://github.com/bamiyanapp/dev-standards/pull/123)）。これによりkaruta側で実際にPNGが生成されるようになる
- `README.md`（README-1/README-2）・`docs/cicd-pipeline-specification.md`の埋め込みリンクを`.svg`から`.png`へ更新

Refs #837

## Test plan
- [x] `frontend`: `npx eslint . --max-warnings 0`（0 errors, 0 warnings）／ `npx vitest run`（250 passed）
- [x] `backend`: `npx eslint . --max-warnings 0`（0 errors, 0 warnings）／ `npx vitest run`（1543 passed）
- [x] `ci.yml`をjs-yamlでパースし、参照タグの値を確認
- [ ] マージ後、`docs-diagrams`ブランチの`latest/README-1.png`・`latest/README-2.png`・`latest/cicd-pipeline-specification.png`が実際に生成されることを確認
- [ ] GitHubモバイルアプリで実際に画像をタップし、拡大表示できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_