### PR TITLE
fix(ci): dev-standards参照タグをv1.12.4へ更新する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ci:
-    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.12.3
+    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.12.4
     with:
       frontend_dir: frontend
       backend_dir: backend


### PR DESCRIPTION
## Summary
- issue #849（mermaid画像の日本語文字化け）の最終対応
- Renovateにより`v1.12.3`へ更新済みだったが、`v1.12.3`自体が内部で使う自己参照タグ（`.dev-standards-actions`のcheckout ref）は`v1.12.1`（フォント修正前）に固定されたままで、実際にはCJKフォントインストール（dev-standards#126）が反映されていなかった（`v1.12.3`と`v1.12.4`の`reusable-ci.yml`を実際に比較して確認済み）
- 自己参照修正を含む`v1.12.4`（dev-standards#128, #130）へ更新する

Refs #849

## Test plan
- [x] `frontend`: `npx eslint . --max-warnings 0`（0 errors, 0 warnings）／ `npx vitest run`（250 passed）
- [x] `backend`: `npx eslint . --max-warnings 0`（0 errors, 0 warnings）／ `npx vitest run`（1543 passed）
- [x] `ci.yml`をjs-yamlでパースし、参照タグの値を確認
- [ ] マージ後、`docs-diagrams`ブランチの`latest/*.png`を実際にダウンロードし、日本語ラベルが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_