### PR TITLE
fix(quiz-room): 早押しタイミングの読み上げ体験を改善する（issue #861, #860）

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -213,6 +213,11 @@ function App() {
     return categoryKey ? (historyByCategory[categoryKey] || []) : [];
   }, [categoryKey, historyByCategory]);
 
+  // クイズ大会モードかどうかを、useKarutaReading（useQuizRoomAdminより前に呼ぶ
+  // 必要があり、quizRoomをまだ参照できない）へrefで伝える（issue #861）。
+  // useQuizRoomAdmin呼び出し後にこのrefへ書き込む
+  const quizRoomActiveRef = useRef(false);
+
   // 読み上げ・札めくり進行（音声再生・タイマー・フェード演出・結果確定）は
   // useKarutaReadingへ切り出した（issue #607）
   const {
@@ -241,6 +246,7 @@ function App() {
     lang,
     voiceId,
     isMultiCategorySelection,
+    quizRoomActiveRef,
   });
 
   // 「取った人を記録する」参加者登録・スコア集計（issue #518）はusePlayerScoresへ
@@ -582,6 +588,13 @@ function App() {
     revealCurrentResult,
     stopReading,
   });
+
+  // useKarutaReading（quizRoomActiveRef、issue #861）へ最新のクイズ大会モード状態を
+  // 伝える。useKarutaReadingはuseQuizRoomAdminより前に呼ぶ必要があり（useQuizRoomAdmin
+  // はuseKarutaReadingの戻り値に依存するため）quizRoomを直接propsとして渡せない
+  useEffect(() => {
+    quizRoomActiveRef.current = !!quizRoom;
+  }, [quizRoom]);
 
   useEffect(() => {
     if (view === "comments") {

--- a/frontend/src/hooks/useKarutaReading.js
+++ b/frontend/src/hooks/useKarutaReading.js
@@ -46,6 +46,7 @@ export function useKarutaReading({
   lang,
   voiceId,
   isMultiCategorySelection,
+  quizRoomActiveRef,
 }) {
   const [currentPhrase, setCurrentPhrase] = useState(null);
   // クイズ大会モード（issue #781）: 参加者への「次の札」ブロードキャストを、管理者自身の
@@ -206,6 +207,22 @@ export function useKarutaReading({
           nextContentRef.current = { type: "phrase", content: phraseData, playbackSettings };
           setIsFadingOut(true);
         }, 3000); // 待機時間
+
+        // クイズ大会モード（issue #861）: 参加者側はWebSocketブロードキャストの受信・
+        // 画面反映（ネットワーク往復＋バックエンドのpostToConnection処理）に一定の
+        // 時間がかかるため、上のsetBroadcastPhraseの直後に管理者自身の本編読み上げを
+        // 開始すると、参加者側の札めくりが管理者の読み上げより体感で遅れて見える。
+        // ブロードキャスト自体を早める恒久対応は経過時間計測（startTimeRef.current、
+        // 上のコメント参照）と絡み合い難しいため、暫定対応として管理者自身の読み上げ
+        // 開始だけを3秒遅らせ、参加者側が追いつく猶予を設ける
+        if (quizRoomActiveRef?.current) {
+          await new Promise(resolve => setTimeout(resolve, 3000));
+          if (stopRequestedRef.current) {
+            stopRequestedRef.current = false;
+            setIsReading(false);
+            return;
+          }
+        }
       }
 
       await playAudio(audioData).catch(e => console.error("Audio playback failed:", e));
@@ -237,7 +254,7 @@ export function useKarutaReading({
     return () => {
       if (flipTimeoutRef.current) clearTimeout(flipTimeoutRef.current);
     }
-  }, [audioQueue, isReading, playAudio, playIntroSound, categoryKey, setHistoryByCategory]);
+  }, [audioQueue, isReading, playAudio, playIntroSound, categoryKey, setHistoryByCategory, quizRoomActiveRef]);
 
   // 現在の札を読み上げている間に、次に読み上げる予定の札の音声を先読みしておく
   useEffect(() => {

--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -357,6 +357,23 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
   // 毎回`new Audio(...)`していると、その要素自体はユーザー操作中に一度も再生されておらず、
   // Safari等では再生がブロックされ続けてしまうため
   const lastPlayedKeyRef = useRef(null);
+  // issue #860: 早押しボタン押下時にstopSharedAudio()を呼んでも、その時点で本編音声が
+  // まだ再生開始前（フレーズ取得中・イントロ音再生中）だと何も止まらず、その後に
+  // 開始される再生を止める手段が無かった。ラウンドごとにリセットするこのフラグへ
+  // 早押し発生（自分・他の参加者いずれも）を記録し、本編再生を開始する直前に
+  // 確認することで、開始前の早押しも確実に読み上げを止められるようにする
+  const buzzStoppedRef = useRef(false);
+
+  // issue #860: buzzedByは自分の早押し（handleBuzz）・他の参加者の早押し（onBuzz）の
+  // いずれでもセットされるため、その変化を検知してbuzzStoppedRefへ反映する。
+  // handleBuzz/onBuzz内で直接refへ書き込まないのは、handleBuzzがrenderJoinedRoom()
+  // 経由でレンダー中に到達可能なコールパスとして扱われ、react-hooks/refsルール
+  // （レンダー中のref書き込み禁止）に抵触するため
+  useEffect(() => {
+    if (buzzedBy) {
+      buzzStoppedRef.current = true;
+    }
+  }, [buzzedBy]);
 
   useEffect(() => {
     if (!wsBaseUrl) {
@@ -384,6 +401,9 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
       return;
     }
     lastPlayedKeyRef.current = key;
+    // issue #860: 新しいラウンドの再生開始前に、前のラウンドの早押し停止フラグを
+    // 必ずリセットする
+    buzzStoppedRef.current = false;
 
     // 名前入力画面（confirmedName未確定）の間は再生しない（issue #530）。
     // 上のlastPlayedKeyRef更新は先に行っているため、名前確定後にこの同じ
@@ -416,7 +436,10 @@ function QuizRoomView({ setView, wsBaseUrl, adminSessionRoomId, adminSessionRest
           return;
         }
         await introPromise;
-        if (cancelled) {
+        // issue #860: このawait中（フレーズ取得・イントロ音再生の間）に早押しされて
+        // いた場合、stopSharedAudio()はまだ再生されていない音声には効かないため、
+        // buzzStoppedRefで再生開始自体を取りやめる
+        if (cancelled || buzzStoppedRef.current) {
           return;
         }
         await playSharedAudio(data.audioData);

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -810,6 +810,94 @@ describe('QuizRoomView', () => {
     expect(narrationAudio.pause).toHaveBeenCalled();
   });
 
+  it('does not start the narration audio if the participant presses the buzz button before it has started playing (issue #860: stopSharedAudio pauses nothing if playback has not begun yet, so the still-pending playSharedAudio call must be suppressed separately)', async () => {
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('/quiz-room?')) {
+        return { ok: true, json: async () => ({ exists: true }) };
+      }
+      return { ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }) };
+    });
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
+
+    // 「決定」ボタンのクリックによる解錠はデフォルトのaudioPlayImplで解決済み。
+    // ここから先、太鼓の音（イントロ）の再生完了を手動で制御できるようにする
+    // （issue #796のテストと同じ手法）
+    let resolveIntroPlayback;
+    audioPlayImpl = () => new Promise((resolve) => { resolveIntroPlayback = resolve; });
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+
+    const narrationAudio = audioInstances[0];
+
+    // 本編音声の取得（/get-phrase）はイントロ音の再生と並行して進み、ここで完了する。
+    // しかしイントロ音自体はまだ鳴り終わっていない（本編再生はまだ開始前）
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(audioFetchCalls().length).toBeGreaterThan(0);
+    expect(narrationAudio.src).toBe('data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=');
+
+    // 本編再生がまだ始まっていないこのタイミングで回答ボタンを押す
+    fireEvent.click(screen.getByText('回答する'));
+    expect(buzzMock).toHaveBeenCalled();
+
+    // その後にイントロ音の再生が完了しても、本編音声（narrationAudio）へは
+    // 差し替わらない（従来はstopSharedAudio()がまだ再生開始前の音声には効かず、
+    // このタイミングで押しても結局本編が再生されてしまっていた）
+    await act(async () => {
+      resolveIntroPlayback();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(narrationAudio.src).toBe('data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=');
+  });
+
+  it('also suppresses the not-yet-started narration audio when a different participant buzzes in before it has started playing (issue #860, mirroring issue #800)', async () => {
+    fetch.mockImplementation(async (url) => {
+      if (url.includes('/quiz-room?')) {
+        return { ok: true, json: async () => ({ exists: true }) };
+      }
+      return { ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }) };
+    });
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
+
+    let resolveIntroPlayback;
+    audioPlayImpl = () => new Promise((resolve) => { resolveIntroPlayback = resolve; });
+
+    emitState({ type: 'phrase', content: { id: 'p1', category: 'Cat1', phrase: '読み札1', level: '3' } });
+
+    const narrationAudio = audioInstances[0];
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(audioFetchCalls().length).toBeGreaterThan(0);
+
+    // 自分ではなく他の参加者が、本編再生開始前のこのタイミングで早押しした場合
+    emitBuzz({ name: 'はなこ', connectionId: 'conn-2' });
+
+    await act(async () => {
+      resolveIntroPlayback();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(narrationAudio.src).toBe('data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=');
+  });
+
   it('does not play audio for a phrase that was already in progress when joining, while still on the name entry screen, and does not play it retroactively once the name is confirmed (issue #530)', async () => {
     fetch.mockResolvedValue({ ok: true, json: async () => ({ audioData: 'data:audio/mp3;base64,DUMMY' }) });
     window.history.pushState({}, '', '?roomId=ABC123');


### PR DESCRIPTION
## Summary
- issue #861: クイズ大会モードで「読み上げ」実行から参加者側の札めくりまでが体感で大きく遅れる件を調査
  - 原因: 参加者へのブロードキャスト（`setBroadcastPhrase`）はイントロ音声（約2.2秒）のフル尺再生完了後に確定しており、さらにWebSocketブロードキャストのネットワーク往復・バックエンド処理が上乗せされる
  - 恒久対応（ブロードキャストを早める）は早押し正解の即時確定（`revealCurrentResult`の`startTimeRef.current`依存）と経過時間計測開始タイミングが密結合しており単純ではないため、指示に基づき暫定対応として、クイズ大会モードの場合に限り管理者自身の読み上げ開始を3秒遅らせ、参加者側が追いつく猶予を設けた
  - ソロモード・経過時間計測・ブロードキャストのタイミング自体は変更していない
- issue #860: 参加者側で回答ボタンを押しても読み上げが止まらないことがある件を修正
  - 原因: 参加者側の音声再生用`useEffect`（フレーズ取得→イントロ音再生完了待ち→本編再生開始）において、**本編再生開始前**（フレーズ取得中・イントロ音再生中）に回答ボタンが押されると、`stopSharedAudio()`はその時点で何も再生していないため実質空振りし、その後の非同期処理がそのまま本編音声の再生を開始してしまう競合状態があった
  - ラウンドごとにリセットする`buzzStoppedRef`を新設し、本編再生開始直前に確認することで、再生開始前の早押しも確実に読み上げを止められるようにした
  - 再発防止として、本編再生開始前に自分・他の参加者いずれが早押ししても、その後本編音声が再生されないことを確認する回帰テストを2件追加

## Test plan
- [x] `frontend`: `npm run lint`（0エラー・0警告）・`npm test`（17ファイル・252件全て通過、新規テスト2件を含む）
- [x] `backend`: `npm run lint`（0エラー・0警告）・`npm test`（8ファイル・1543件全て通過）
- [ ] issue #861（体感遅延の改善）は実機・実際のネットワーク環境での確認が必要（テストで検証可能な範囲を超えるUXの体感時間調整のため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
