### PR TITLE
chore(release): v1.58.5 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.58.5](https://github.com/bamiyanapp/karuta/compare/v1.58.4...v1.58.5) (2026-07-26)
+
+
+### Bug Fixes
+
+* **quiz-room:** 早押しタイミングの読み上げ体験を改善する（issue [#861](https://github.com/bamiyanapp/karuta/issues/861), [#860](https://github.com/bamiyanapp/karuta/issues/860)） ([#864](https://github.com/bamiyanapp/karuta/issues/864)) ([1839b81](https://github.com/bamiyanapp/karuta/commit/1839b81275e03c5c6b84102c5e3807af78de4d0d))
+
 ## [1.58.4](https://github.com/bamiyanapp/karuta/compare/v1.58.3...v1.58.4) (2026-07-26)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.58.4",
+    "version": "1.58.5",
     "date": "2026/07/26",
+    "body": "### Bug Fixes\n\n* **quiz-room:** 早押しタイミングの読み上げ体験を改善する（issue [#861](https://github.com/bamiyanapp/karuta/issues/861), [#860](https://github.com/bamiyanapp/karuta/issues/860)） ([#864](https://github.com/bamiyanapp/karuta/issues/864)) ([1839b81](https://github.com/bamiyanapp/karuta/commit/1839b81275e03c5c6b84102c5e3807af78de4d0d))"
+  },
+  {
+    "version": "1.58.4",
+    "date": "2026/07/26 06:31",
     "body": "### Bug Fixes\n\n* **ci:** dev-standards参照タグをv1.12.4へ更新する（issue [#849](https://github.com/bamiyanapp/karuta/issues/849)） ([#852](https://github.com/bamiyanapp/karuta/issues/852)) ([c3711e4](https://github.com/bamiyanapp/karuta/commit/c3711e48190189452f98f92cf414f85557e6f361))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.58.4",
+  "version": "1.58.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.58.4",
+      "version": "1.58.5",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.58.4"
+  "version": "1.58.5"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。