### PR TITLE
fix(ci): jscpdのテストファイル除外に合わせduplication_thresholdを引き下げる

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,14 @@ jobs:
       # 導入直後はduplication_threshold未指定（レポート表示のみ、ゲートなし）としていたが、
       # 検出しても何も強制されない状態が放置されていたため、現状の重複率（行ベース）を
       # ベースラインとしたラチェット方式でゲートを有効化する。issue #833でQuizRoomView等
-      # の重複解消を進め、20.31%→18.64%まで削減できたためしきい値も引き下げた。
-      # 残る重複は主にテストファイル（App.test.jsx・QuizRoomView.test.jsx等）で、
-      # 引き続きissue #833で追跡する
+      # の重複解消を進め、20.31%→18.64%まで削減できた。その後dev-standards側でjscpdの
+      # 対象からテストファイル（*.test.*・*.spec.*・e2eディレクトリ配下）を除外する対応
+      # （bamiyanapp/dev-standards#132、v1.12.5で反映）が入り、除外前は主にテストファイル
+      # だった重複がスキャン対象から外れたため、プロダクトコードのみの実測値（0.46%、
+      # backend/backfill-*.jsのバックフィルスクリプト間の重複のみ）に合わせて
+      # しきい値をさらに引き下げた（issue #877）
       enable_duplication_check: true
-      duplication_threshold: 19
+      duplication_threshold: 1
       # 分岐(branches)カバレッジ80%必須化（issue #459）のうち、branches指標のみ
       # 引き続き見送る。backend側で、複数のテストファイルが同一のソースファイル
       # （例: backend/handler.js）をimportする構成において、@vitest/coverage-v8の

--- a/package-lock.json
+++ b/package-lock.json
@@ -16725,7 +16725,7 @@
         "eslint-plugin-sonarjs": "^4.2.0",
         "globals": "^17.0.0",
         "jsdom": "^30.0.0",
-        "monocart-reporter": "^2.12.4",
+        "monocart-reporter": "^2.12.2",
         "vite": "^8.0.0",
         "vite-plugin-pwa": "^1.3.0",
         "vitest": "^4.0.0",


### PR DESCRIPTION
## Summary
- issue #877: dev-standards側でjscpdの重複検知対象からテストファイルを除外する対応（bamiyanapp/dev-standards#132、v1.12.5）が入ったため、karuta側の`duplication_threshold`をプロダクトコードのみの新しい実測値に合わせて引き下げる
- karutaの`ci.yml`は既に`reusable-ci.yml@v1.12.5`を参照済み（Renovateにより自動更新済み）だったため、タグ参照の変更は不要だった
- `duplication_threshold`を19→1へ引き下げ（プロダクトコードのみの実測値0.46%、backend/backfill-*.js間の重複のみ）

## Test plan
- [x] `npx jscpd@5`をローカル実行し、実測値0.46%を確認済み
- [x] `frontend`: `npm run lint`（0エラー・0警告）・`npm test`（17ファイル・252件全て通過）
- [x] `backend`: `npm run lint`（0エラー・0警告）・`npm test`（8ファイル・1543件全て通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_