### PR TITLE
fix(pwa): 更新通知にセーフエリア（ノッチ）対応を追加する

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="google" content="notranslate" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- viewport-fit=cover: PWAのstandaloneモード（vite.config.jsのdisplay: 'standalone'）
+         では、iOSはこの指定がないとenv(safe-area-inset-*)を常に0として扱い、
+         ノッチ・ステータスバー領域を考慮したレイアウト調整ができない（issue #840） -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700&display=swap" rel="stylesheet">

--- a/frontend/src/PwaUpdatePrompt.css
+++ b/frontend/src/PwaUpdatePrompt.css
@@ -3,8 +3,12 @@
   /* 画面下部固定だと、入力欄フォーカスでソフトウェアキーボードが表示された際に
      隠れて操作できなくなる（issue #759）。画面中央よりやや上への変更（issue #759）
      は中途半端な位置だったため、キーボードに隠れず座りも良い最上部へ固定する
-     （issue #776） */
-  top: 1rem;
+     （issue #776）。PWAをホーム画面から起動した場合（standaloneモード）、
+     iOSはノッチ・ステータスバー分の領域をenv(safe-area-inset-top)として
+     提供するため、固定値の1remだけだとその領域と重なって最上部に見えない
+     ことがある（issue #840）。index.htmlのviewport-fit=coverと合わせ、
+     safe-area-inset-topが1remより大きい場合はそちらを優先する */
+  top: max(1rem, env(safe-area-inset-top));
   left: 50%;
   transform: translateX(-50%);
   z-index: 1000;


### PR DESCRIPTION
## Summary
- issue #840: 「オフラインで利用可能になりました」通知が最上部に表示されない件の対応
- CSS自体は既にissue #776で最上部固定（`top: 1rem`）になっていたが、本アプリは`display: 'standalone'`のPWAであり、ホーム画面から起動した場合iOSはノッチ・ステータスバー領域を`env(safe-area-inset-top)`として提供する
- `index.html`の`viewport-fit=cover`指定がないとiOSはこの値を常に0として扱うため、固定値の1remだけではセーフエリアと重なって見える可能性がある、というissueで推測されていた原因への具体的な対応
- `top: max(1rem, env(safe-area-inset-top))`へ変更し、セーフエリアがある場合はそちらを優先する

## Test plan
- [x] `frontend`: `npm run lint`（0エラー・0警告）・`npm test`（17ファイル・252件全て通過）
- [x] `backend`: `npm run lint`（0エラー・0警告）・`npm test`（8ファイル・1543件全て通過）
- [ ] 実機（ノッチ付き端末でのホーム画面起動）での見た目確認が必要。`env(safe-area-inset-top)`の実際の値はヘッドレスブラウザ（ノッチなし）では常に0のため、CIでの自動検証は従来の1rem固定と区別がつかない

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_