### PR TITLE
test(e2e): クイズ大会モードの読み上げ履歴表示をカバーするテストを追加

### DIFF
--- a/frontend/e2e/quiz-room.spec.js
+++ b/frontend/e2e/quiz-room.spec.js
@@ -65,6 +65,65 @@ test('admin creates a quiz room and a participant sees the same card update in r
   }
 });
 
+// issue #548の読み上げ履歴表示は参加者画面にもあるが、クイズ大会モードでは
+// これまで一度もE2Eで検証されていなかった（issue #576、カバレッジ向上のため追加）。
+// 新しいラウンドの札が届いた時点で即座にローカル履歴へ積まれる実装のため
+// （QuizRoomView.jsx）、1ラウンド目が届いた時点で既に履歴表示ボタンが現れる
+test('participant can open and close the "read-aloud history" panel after a phrase is broadcast (issue #576)', async ({ browser }, testInfo) => {
+  const adminContext = await browser.newContext();
+  const adminPage = await adminContext.newPage();
+  await startCoverage(adminPage);
+
+  const participantContext = await browser.newContext();
+  let participantPage = null;
+
+  try {
+    await adminPage.goto('/');
+    await adminPage.getByText('こども向け').click();
+    await adminPage.getByRole('button', { name: /おばけかるた/ }).click();
+    const nextButton = adminPage.getByRole('button', { name: '次の札' });
+    await expect(nextButton).toBeVisible();
+
+    await adminPage.getByText('クイズ大会のルームを作成する').click();
+    const roomInfoLink = adminPage.getByText('ルーム情報を表示（クイズ大会モード）');
+    await expect(roomInfoLink).toBeVisible({ timeout: 15000 });
+    await roomInfoLink.click();
+    const roomCode = (await adminPage.locator('p.h3.fw-bold.notranslate').innerText()).trim();
+    await adminPage.getByText('← 戻る').click();
+    await expect(nextButton).toBeVisible();
+
+    participantPage = await participantContext.newPage();
+    await startCoverage(participantPage);
+    await participantPage.goto(`/?view=quiz-room&roomId=${roomCode}`);
+    await expect(participantPage.getByText('クイズ大会モード（参加者）')).toBeVisible();
+    await participantPage.getByPlaceholder('お名前').fill('たろう');
+    await participantPage.getByText('決定').click();
+    await expect(participantPage.getByText('接続状態: 接続済み')).toBeVisible({ timeout: 15000 });
+
+    await nextButton.click();
+    await expect(adminPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 30000 });
+    await expect(participantPage.locator('.yomifuda-phrase')).toBeVisible({ timeout: 15000 });
+    const phraseText = await participantPage.locator('.yomifuda-phrase').innerText();
+
+    const historyToggle = participantPage.getByRole('button', { name: /これまでに読み上げた札を表示する/ });
+    await expect(historyToggle).toBeVisible();
+    await historyToggle.click();
+    await expect(participantPage.locator('.list-group-item')).toHaveCount(1);
+    await expect(participantPage.locator('.list-group-item').first()).toContainText(phraseText);
+    await captureScreenshot(participantPage, testInfo, 'participant-history-open', '参加者：これまでに読み上げた札の履歴を開いた状態');
+
+    await participantPage.getByRole('button', { name: 'これまでに読み上げた札を閉じる' }).click();
+    await expect(participantPage.locator('.list-group-item')).toHaveCount(0);
+  } finally {
+    await stopCoverage(adminPage, testInfo);
+    if (participantPage) {
+      await stopCoverage(participantPage, testInfo);
+    }
+    await closeContext(adminContext);
+    await closeContext(participantContext);
+  }
+});
+
 // issue #640: 管理者がリロードした（このテストの再現方法）その場での挙動を固定化する
 // 回帰テスト。adminTokenはissue #697でlocalStorageへ永続化されており、当初は
 // 「参加者画面から『管理者に切り替える』ボタンで再接続する」という別導線でのみ


### PR DESCRIPTION
## Summary
- issue #576（E2Eカバレッジ80%以上）で未カバー領域として挙げられていた「クイズ大会モードの一部フロー」のうち、参加者側の読み上げ履歴パネル（issue #548）の開閉を新規E2Eテストとして追加した
- ソロモードでは既にapp-flows.spec.jsで検証済みだが、クイズ大会モードの参加者画面（QuizRoomView.jsx）ではこれまで一度もE2Eで検証されていなかった
- 検討した他の候補（複数カテゴリ選択・エンジニア向けdivision・APIエラーハンドリング系）は、実装を確認した結果いずれもE2Eカバレッジ向上に直接寄与しない、または意味のあるアサーションが組めないと判断し見送った（詳細はコミットメッセージ参照）

## Test plan
- [x] `npx eslint e2e/quiz-room.spec.js`（0件）
- [x] `frontend`: `npm run lint`（0エラー・0警告）・`npm test`（17ファイル・252件全て通過、既存ユニットテストへの回帰なし）
- [x] `backend`: `npm run lint`（0エラー・0警告）・`npm test`（8ファイル・1543件全て通過）
- [ ] このE2Eテスト自体の実行結果・カバレッジ向上効果はCI（`frontend-e2e-test`ジョブ）でのみ確認可能。本リポジトリのE2Eテストは実際にデプロイ済みのAWS環境に対して実行する設計（モックバックエンドなし）のため、ローカルサンドボックスには対象インフラへの到達手段・認証情報がなく実行できていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_