### PR TITLE
chore(release): v1.60.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.60.0](https://github.com/bamiyanapp/karuta/compare/v1.59.2...v1.60.0) (2026-07-29)
+
+
+### Features
+
+* **ci:** E2Eカバレッジ閾値をラチェットダウン方式で有効化する ([#887](https://github.com/bamiyanapp/karuta/issues/887)) ([315110b](https://github.com/bamiyanapp/karuta/commit/315110b16c6dc8d370989e99d8ebb8c29cd9cc26))
+
 ## [1.59.2](https://github.com/bamiyanapp/karuta/compare/v1.59.1...v1.59.2) (2026-07-28)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
+    "version": "1.60.0",
+    "date": "2026/07/29",
+    "body": "### Features\n\n* **ci:** E2Eカバレッジ閾値をラチェットダウン方式で有効化する ([#887](https://github.com/bamiyanapp/karuta/issues/887)) ([315110b](https://github.com/bamiyanapp/karuta/commit/315110b16c6dc8d370989e99d8ebb8c29cd9cc26))"
+  },
+  {
     "version": "1.59.2",
-    "date": "2026/07/28",
+    "date": "2026/07/28 22:18",
     "body": "### Bug Fixes\n\n* **pwa:** 更新通知にセーフエリア（ノッチ）対応を追加する ([#881](https://github.com/bamiyanapp/karuta/issues/881)) ([6c034d0](https://github.com/bamiyanapp/karuta/commit/6c034d0b47845db0f55af85383e93ac754a85d95))"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.59.2",
+  "version": "1.60.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.59.2",
+      "version": "1.60.0",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.59.2"
+  "version": "1.60.0"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。