### PR TITLE
feat(docs): serverless.yml/frontend静的解析によるドキュメント自動生成

### DIFF
--- a/docs/generated/README.md
+++ b/docs/generated/README.md
@@ -1,0 +1,18 @@
+# 自動生成ドキュメント
+
+このディレクトリのファイルは、`scripts/docs/`配下のスクリプトによってコード・設定ファイルの静的解析から自動生成される。**手動で編集しないこと**（再生成すると上書きされる）。
+
+再生成するには、リポジトリルートで以下を実行する。
+
+```
+npm run docs:generate
+```
+
+| ファイル | 生成元 | 対応Issue |
+| :--- | :--- | :--- |
+| [backend-api.md](./backend-api.md) | `backend/serverless.yml`のhttpApiイベント定義 | [#901](https://github.com/bamiyanapp/karuta/issues/901) |
+| [websocket-api.md](./websocket-api.md) | `backend/serverless.yml`のwebsocketイベント定義 | [#902](https://github.com/bamiyanapp/karuta/issues/902) |
+| [dynamodb-tables.md](./dynamodb-tables.md) | `backend/serverless.yml`の`AWS::DynamoDB::Table`リソース定義 | [#903](https://github.com/bamiyanapp/karuta/issues/903) |
+| [api-usage.md](./api-usage.md) | `frontend/src`配下のAPI呼び出し箇所 | [#909](https://github.com/bamiyanapp/karuta/issues/909) |
+
+生成タイミングのCI組み込み（PRごとの自動再生成・ドリフト検知等）は未対応。方針は[issue #900](https://github.com/bamiyanapp/karuta/issues/900)の検討事項を参照し、別途フォローアップで対応する。

--- a/docs/generated/api-usage.md
+++ b/docs/generated/api-usage.md
@@ -1,0 +1,36 @@
+# API利用一覧（自動生成）
+
+このファイルはfrontend側のAPI呼び出し箇所（`frontend/src`配下）を`scripts/docs/generate-api-usage.js`で正規表現ベースに静的解析して自動生成される。手動で編集しないこと。再生成するには`node scripts/docs/generate-api-usage.js`を実行する（[issue #909](https://github.com/bamiyanapp/karuta/issues/909)）。
+
+HTTPメソッドは呼び出し箇所付近に`method:`指定が見つからない場合はGETとみなす（fetchの既定メソッドと同じ扱い）。
+
+## HTTP APIの呼び出し箇所
+
+| パス | メソッド | 呼び出し元ファイル |
+| :--- | :--- | :--- |
+| `/generate-efuda-pdf-status` | GET | `frontend/src/views/PrintEfudaView.jsx` |
+| `/get-categories` | GET | `frontend/src/App.jsx` |
+| `/get-comments` | GET | `frontend/src/App.jsx` |
+| `/get-congratulation-audio` | GET | `frontend/src/hooks/useKarutaReading.js` |
+| `/get-phrase` | GET | `frontend/src/App.jsx`<br>`frontend/src/hooks/useKarutaReading.js`<br>`frontend/src/views/QuizRoomView.jsx` |
+| `/get-phrases-list` | GET | `frontend/src/App.jsx` |
+| `/quiz-room` | GET | `frontend/src/views/QuizRoomView.jsx` |
+| `/quiz-rooms` | GET | `frontend/src/hooks/useQuizRoomAdmin.js` |
+| `/generate-efuda-pdf` | POST | `frontend/src/views/PrintEfudaView.jsx` |
+| `/post-comment` | POST | `frontend/src/App.jsx` |
+| `/quiz-room` | POST | `frontend/src/hooks/useQuizRoomAdmin.js` |
+| `/record-time` | POST | `frontend/src/hooks/useKarutaReading.js` |
+
+## WebSocket APIの呼び出し箇所
+
+`action`フィールドが、対応する[WebSocket API仕様書](./websocket-api.md)のルート名に対応する。
+
+| action | 呼び出し元ファイル |
+| :--- | :--- |
+| `buzz` | `frontend/src/hooks/useQuizRoomSync.js` |
+| `closeRoom` | `frontend/src/hooks/useQuizRoomSync.js` |
+| `judgeBuzz` | `frontend/src/hooks/useQuizRoomSync.js` |
+| `resetPoints` | `frontend/src/hooks/useQuizRoomSync.js` |
+| `setName` | `frontend/src/hooks/useQuizRoomSync.js` |
+| `sync` | `frontend/src/hooks/useQuizRoomSync.js` |
+| `updateState` | `frontend/src/hooks/useQuizRoomSync.js` |

--- a/docs/generated/backend-api.md
+++ b/docs/generated/backend-api.md
@@ -1,0 +1,18 @@
+# Backend API仕様書（自動生成）
+
+このファイルは`backend/serverless.yml`のhttpApiイベント定義から`scripts/docs/generate-backend-api.js`によって自動生成される。手動で編集しないこと。再生成するには`node scripts/docs/generate-backend-api.js`を実行する（[issue #901](https://github.com/bamiyanapp/karuta/issues/901)）。
+
+| 関数名 | パス | メソッド | ハンドラー |
+| :--- | :--- | :--- | :--- |
+| generateEfudaPdf | `/generate-efuda-pdf` | POST | `efudaPdfHandler.generateEfudaPdf` |
+| getEfudaPdfStatus | `/generate-efuda-pdf-status` | GET | `efudaPdfHandler.getEfudaPdfStatus` |
+| getCategories | `/get-categories` | GET | `handler.getCategories` |
+| getComments | `/get-comments` | GET | `handler.getComments` |
+| getCongratulationAudio | `/get-congratulation-audio` | GET | `handler.getCongratulationAudio` |
+| getPhrase | `/get-phrase` | GET | `handler.getPhrase` |
+| getPhrasesList | `/get-phrases-list` | GET | `handler.getPhrasesList` |
+| postComment | `/post-comment` | POST | `handler.postComment` |
+| checkQuizRoom | `/quiz-room` | GET | `quizRoomHandler.checkQuizRoom` |
+| createQuizRoom | `/quiz-room` | POST | `quizRoomHandler.createQuizRoom` |
+| listQuizRooms | `/quiz-rooms` | GET | `quizRoomHandler.listQuizRooms` |
+| recordTime | `/record-time` | POST | `handler.recordTime` |

--- a/docs/generated/dynamodb-tables.md
+++ b/docs/generated/dynamodb-tables.md
@@ -1,0 +1,35 @@
+# DynamoDBテーブル定義書（自動生成）
+
+このファイルは`backend/serverless.yml`の`AWS::DynamoDB::Table`リソース定義から`scripts/docs/generate-dynamodb-tables.js`によって自動生成される。手動で編集しないこと。再生成するには`node scripts/docs/generate-dynamodb-tables.js`を実行する（[issue #903](https://github.com/bamiyanapp/karuta/issues/903)）。
+
+ORM（Prisma/TypeORM等）は使わずAWS SDKを直接呼び出す構成のため、外部キー制約に基づく古典的なER図は対象外とし、各テーブルのキー構造のみを一覧化する。
+
+## karuta-comments
+
+- リソース名（CloudFormation）: `CommentsTable`
+- キースキーマ: id (HASH)
+
+## karuta-phrases
+
+- リソース名（CloudFormation）: `KarutaTable`
+- キースキーマ: category (HASH), id (RANGE)
+
+## karuta-polly-cache
+
+- リソース名（CloudFormation）: `PollyCacheTable`
+- キースキーマ: id (HASH)
+- TTL: `ttl`属性（有効）
+
+## karuta-quiz-room-connections
+
+- リソース名（CloudFormation）: `QuizRoomConnectionsTable`
+- キースキーマ: connectionId (HASH)
+- GSI: `roomId-index`（roomId (HASH)）
+- TTL: `ttl`属性（有効）
+
+## karuta-quiz-rooms
+
+- リソース名（CloudFormation）: `QuizRoomsTable`
+- キースキーマ: roomId (HASH)
+- TTL: `ttl`属性（有効）
+

--- a/docs/generated/websocket-api.md
+++ b/docs/generated/websocket-api.md
@@ -1,0 +1,17 @@
+# WebSocket API仕様書（自動生成）
+
+このファイルは`backend/serverless.yml`のwebsocketイベント定義から`scripts/docs/generate-websocket-api.js`によって自動生成される。手動で編集しないこと。再生成するには`node scripts/docs/generate-websocket-api.js`を実行する（[issue #902](https://github.com/bamiyanapp/karuta/issues/902)）。
+
+クイズ大会モードのリアルタイム通信（読み札・結果画面の同期、早押し判定等）に使うAPI Gateway WebSocket API（`backend/quizRoomHandler.js`）のルート一覧。
+
+| ルート | 関数名 | ハンドラー |
+| :--- | :--- | :--- |
+| `$connect` | connectQuizRoom | `quizRoomHandler.connectQuizRoom` |
+| `$disconnect` | disconnectQuizRoom | `quizRoomHandler.disconnectQuizRoom` |
+| `buzz` | buzzQuizRoom | `quizRoomHandler.buzzQuizRoom` |
+| `closeRoom` | closeQuizRoom | `quizRoomHandler.closeQuizRoom` |
+| `judgeBuzz` | judgeQuizRoomBuzz | `quizRoomHandler.judgeQuizRoomBuzz` |
+| `resetPoints` | resetQuizRoomPoints | `quizRoomHandler.resetQuizRoomPoints` |
+| `setName` | setQuizRoomName | `quizRoomHandler.setQuizRoomName` |
+| `sync` | syncQuizRoom | `quizRoomHandler.syncQuizRoom` |
+| `updateState` | updateQuizRoomState | `quizRoomHandler.updateQuizRoomState` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@semantic-release/npm": "^13.1.3",
         "@semantic-release/release-notes-generator": "^14.0.1",
         "conventional-changelog-conventionalcommits": "^10.2.1",
+        "js-yaml": "^4.3.1",
         "semantic-release": "^25.0.2"
       }
     },
@@ -29,14 +30,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aws-sdk/client-apigatewaymanagementapi": "^3.1101.0",
-        "@aws-sdk/client-dynamodb": "^3.1101.0",
-        "@aws-sdk/client-lambda": "^3.1101.0",
-        "@aws-sdk/client-polly": "^3.1101.0",
-        "@aws-sdk/client-s3": "^3.1101.0",
-        "@aws-sdk/lib-dynamodb": "^3.1101.0",
-        "@aws-sdk/polly-request-presigner": "^3.1101.0",
-        "@aws-sdk/s3-request-presigner": "^3.1101.0",
+        "@aws-sdk/client-apigatewaymanagementapi": "^3.958.0",
+        "@aws-sdk/client-dynamodb": "^3.958.0",
+        "@aws-sdk/client-lambda": "^3.1087.0",
+        "@aws-sdk/client-polly": "^3.958.0",
+        "@aws-sdk/client-s3": "^3.958.0",
+        "@aws-sdk/lib-dynamodb": "^3.958.0",
+        "@aws-sdk/polly-request-presigner": "^3.958.0",
+        "@aws-sdk/s3-request-presigner": "^3.958.0",
         "@sparticuz/chromium": "^149.0.0",
         "csv-parse": "^7.0.0",
         "puppeteer-core": "^25.0.0"
@@ -9930,36 +9931,6 @@
           "optional": true
         }
       }
-    },
-    "backend/node_modules/osls/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "backend/node_modules/osls/node_modules/js-yaml/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
     },
     "backend/node_modules/osls/node_modules/json-cycle": {
       "version": "1.5.0",
@@ -43052,36 +43023,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/@commitlint/load/node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/@commitlint/load/node_modules/cosmiconfig/node_modules/js-yaml/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/@commitlint/cli/node_modules/@commitlint/load/node_modules/cosmiconfig/node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -49988,6 +49929,36 @@
       "resolved": "frontend",
       "link": true
     },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/js-yaml/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/semantic-release": {
       "version": "25.0.8",
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.8.tgz",
@@ -50186,36 +50157,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/semantic-release/node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/semantic-release/node_modules/cosmiconfig/node_modules/js-yaml/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
     },
     "node_modules/semantic-release/node_modules/cosmiconfig/node_modules/parse-json": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "backend"
   ],
   "scripts": {
-    "lint": "commitlint --last --verbose"
+    "lint": "commitlint --last --verbose",
+    "docs:generate": "node scripts/docs/generate-backend-api.js && node scripts/docs/generate-websocket-api.js && node scripts/docs/generate-dynamodb-tables.js && node scripts/docs/generate-api-usage.js"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.0.0",
@@ -23,6 +24,7 @@
     "@semantic-release/npm": "^13.1.3",
     "@semantic-release/release-notes-generator": "^14.0.1",
     "conventional-changelog-conventionalcommits": "^10.2.1",
+    "js-yaml": "^4.3.1",
     "semantic-release": "^25.0.2"
   },
   "version": "1.60.0"

--- a/scripts/docs/generate-api-usage.js
+++ b/scripts/docs/generate-api-usage.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const frontendSrcDir = path.join(repoRoot, "frontend", "src");
+const outputPath = path.join(repoRoot, "docs", "generated", "api-usage.md");
+
+// HTTP APIの呼び出し箇所: `${API_BASE_URL}/<path>` 形式のテンプレートリテラルを検出する
+const HTTP_CALL_RE = /\$\{API_BASE_URL\}\/([a-zA-Z0-9_-]+)/g;
+// WebSocket APIの呼び出し箇所: `ws.send(JSON.stringify({ action: "<route>" ... }))` 形式を検出する
+const WS_ACTION_RE = /\.send\(\s*JSON\.stringify\(\s*\{\s*action:\s*["'](\w+)["']/g;
+// 呼び出し箇所付近（次の300文字以内）にあるHTTPメソッド指定を探す。見つからなければGET扱いにする
+const METHOD_WINDOW_SIZE = 300;
+const METHOD_RE = /method:\s*["'](get|post|put|patch|delete)["']/i;
+
+function listSourceFiles(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...listSourceFiles(fullPath));
+      continue;
+    }
+    if (!/\.(js|jsx)$/.test(entry.name) || /\.test\.(js|jsx)$/.test(entry.name)) {
+      continue;
+    }
+    results.push(fullPath);
+  }
+  return results;
+}
+
+function extractHttpUsage(filePath, content) {
+  const usages = [];
+  let match;
+  HTTP_CALL_RE.lastIndex = 0;
+  while ((match = HTTP_CALL_RE.exec(content))) {
+    const windowText = content.slice(match.index, match.index + METHOD_WINDOW_SIZE);
+    const methodMatch = windowText.match(METHOD_RE);
+    usages.push({
+      file: path.relative(repoRoot, filePath),
+      path: match[1],
+      method: methodMatch ? methodMatch[1].toUpperCase() : "GET",
+    });
+  }
+  return usages;
+}
+
+function extractWebsocketUsage(filePath, content) {
+  const usages = [];
+  let match;
+  WS_ACTION_RE.lastIndex = 0;
+  while ((match = WS_ACTION_RE.exec(content))) {
+    usages.push({ file: path.relative(repoRoot, filePath), action: match[1] });
+  }
+  return usages;
+}
+
+function groupBy(items, keyFn) {
+  const groups = new Map();
+  for (const item of items) {
+    const key = keyFn(item);
+    if (!groups.has(key)) {
+      groups.set(key, []);
+    }
+    groups.get(key).push(item);
+  }
+  return groups;
+}
+
+function renderHttpSection(httpUsages) {
+  let body = "## HTTP APIの呼び出し箇所\n\n";
+  body += "| パス | メソッド | 呼び出し元ファイル |\n";
+  body += "| :--- | :--- | :--- |\n";
+  const groups = groupBy(httpUsages, (u) => `${u.method} /${u.path}`);
+  const sortedKeys = [...groups.keys()].sort();
+  for (const key of sortedKeys) {
+    const files = [...new Set(groups.get(key).map((u) => u.file))].sort();
+    const [method, ...pathParts] = key.split(" ");
+    body += `| \`${pathParts.join(" ")}\` | ${method} | ${files.map((f) => `\`${f}\``).join("<br>")} |\n`;
+  }
+  return body;
+}
+
+function renderWebsocketSection(wsUsages) {
+  let body = "\n## WebSocket APIの呼び出し箇所\n\n";
+  body += "`action`フィールドが、対応する[WebSocket API仕様書](./websocket-api.md)のルート名に対応する。\n\n";
+  body += "| action | 呼び出し元ファイル |\n";
+  body += "| :--- | :--- |\n";
+  const groups = groupBy(wsUsages, (u) => u.action);
+  const sortedKeys = [...groups.keys()].sort();
+  for (const key of sortedKeys) {
+    const files = [...new Set(groups.get(key).map((u) => u.file))].sort();
+    body += `| \`${key}\` | ${files.map((f) => `\`${f}\``).join("<br>")} |\n`;
+  }
+  return body;
+}
+
+function renderMarkdown(httpUsages, wsUsages) {
+  let body = "# API利用一覧（自動生成）\n\n";
+  body +=
+    "このファイルはfrontend側のAPI呼び出し箇所（`frontend/src`配下）を" +
+    "`scripts/docs/generate-api-usage.js`で正規表現ベースに静的解析して自動生成される。" +
+    "手動で編集しないこと。再生成するには`node scripts/docs/generate-api-usage.js`を実行する" +
+    "（[issue #909](https://github.com/bamiyanapp/karuta/issues/909)）。\n\n" +
+    "HTTPメソッドは呼び出し箇所付近に`method:`指定が見つからない場合はGETとみなす" +
+    "（fetchの既定メソッドと同じ扱い）。\n\n";
+  body += renderHttpSection(httpUsages);
+  body += renderWebsocketSection(wsUsages);
+  return body;
+}
+
+function main() {
+  const files = listSourceFiles(frontendSrcDir);
+  const httpUsages = [];
+  const wsUsages = [];
+  for (const filePath of files) {
+    const content = fs.readFileSync(filePath, "utf-8");
+    httpUsages.push(...extractHttpUsage(filePath, content));
+    wsUsages.push(...extractWebsocketUsage(filePath, content));
+  }
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, renderMarkdown(httpUsages, wsUsages), "utf-8");
+  console.log(
+    `Generated: ${path.relative(repoRoot, outputPath)} (${httpUsages.length} HTTP call sites, ${wsUsages.length} WebSocket action call sites)`
+  );
+}
+
+main();

--- a/scripts/docs/generate-backend-api.js
+++ b/scripts/docs/generate-backend-api.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { loadServerlessConfig, extractHttpApiRoutes } = require("./serverless-yaml");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const serverlessPath = path.join(repoRoot, "backend", "serverless.yml");
+const outputPath = path.join(repoRoot, "docs", "generated", "backend-api.md");
+
+function renderMarkdown(routes) {
+  let body = "# Backend API仕様書（自動生成）\n\n";
+  body +=
+    "このファイルは`backend/serverless.yml`のhttpApiイベント定義から" +
+    "`scripts/docs/generate-backend-api.js`によって自動生成される。手動で編集しないこと。" +
+    "再生成するには`node scripts/docs/generate-backend-api.js`を実行する" +
+    "（[issue #901](https://github.com/bamiyanapp/karuta/issues/901)）。\n\n";
+  body += "| 関数名 | パス | メソッド | ハンドラー |\n";
+  body += "| :--- | :--- | :--- | :--- |\n";
+  for (const route of routes) {
+    body += `| ${route.functionName} | \`/${route.path}\` | ${route.method} | \`${route.handler}\` |\n`;
+  }
+  return body;
+}
+
+function main() {
+  const config = loadServerlessConfig(serverlessPath);
+  const routes = extractHttpApiRoutes(config).sort(
+    (a, b) => a.path.localeCompare(b.path) || a.method.localeCompare(b.method)
+  );
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, renderMarkdown(routes), "utf-8");
+  console.log(`Generated: ${path.relative(repoRoot, outputPath)} (${routes.length} routes)`);
+}
+
+main();

--- a/scripts/docs/generate-dynamodb-tables.js
+++ b/scripts/docs/generate-dynamodb-tables.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { loadServerlessConfig, extractDynamoDbTables } = require("./serverless-yaml");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const serverlessPath = path.join(repoRoot, "backend", "serverless.yml");
+const outputPath = path.join(repoRoot, "docs", "generated", "dynamodb-tables.md");
+
+function renderKeySchema(keySchema) {
+  return keySchema.map((k) => `${k.attribute} (${k.keyType})`).join(", ");
+}
+
+function renderTableSection(table) {
+  let section = `## ${table.tableName}\n\n`;
+  section += `- リソース名（CloudFormation）: \`${table.resourceName}\`\n`;
+  section += `- キースキーマ: ${renderKeySchema(table.keySchema)}\n`;
+  if (table.globalSecondaryIndexes.length > 0) {
+    for (const gsi of table.globalSecondaryIndexes) {
+      section += `- GSI: \`${gsi.indexName}\`（${renderKeySchema(gsi.keySchema)}）\n`;
+    }
+  }
+  if (table.timeToLive) {
+    section += `- TTL: \`${table.timeToLive.attribute}\`属性（${table.timeToLive.enabled ? "有効" : "無効"}）\n`;
+  }
+  section += "\n";
+  return section;
+}
+
+function renderMarkdown(tables) {
+  let body = "# DynamoDBテーブル定義書（自動生成）\n\n";
+  body +=
+    "このファイルは`backend/serverless.yml`の`AWS::DynamoDB::Table`リソース定義から" +
+    "`scripts/docs/generate-dynamodb-tables.js`によって自動生成される。手動で編集しないこと。" +
+    "再生成するには`node scripts/docs/generate-dynamodb-tables.js`を実行する" +
+    "（[issue #903](https://github.com/bamiyanapp/karuta/issues/903)）。\n\n" +
+    "ORM（Prisma/TypeORM等）は使わずAWS SDKを直接呼び出す構成のため、外部キー制約に基づく" +
+    "古典的なER図は対象外とし、各テーブルのキー構造のみを一覧化する。\n\n";
+  for (const table of tables) {
+    body += renderTableSection(table);
+  }
+  return body;
+}
+
+function main() {
+  const config = loadServerlessConfig(serverlessPath);
+  const tables = extractDynamoDbTables(config).sort((a, b) => a.tableName.localeCompare(b.tableName));
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, renderMarkdown(tables), "utf-8");
+  console.log(`Generated: ${path.relative(repoRoot, outputPath)} (${tables.length} tables)`);
+}
+
+main();

--- a/scripts/docs/generate-websocket-api.js
+++ b/scripts/docs/generate-websocket-api.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { loadServerlessConfig, extractWebsocketRoutes } = require("./serverless-yaml");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const serverlessPath = path.join(repoRoot, "backend", "serverless.yml");
+const outputPath = path.join(repoRoot, "docs", "generated", "websocket-api.md");
+
+function renderMarkdown(routes) {
+  let body = "# WebSocket API仕様書（自動生成）\n\n";
+  body +=
+    "このファイルは`backend/serverless.yml`のwebsocketイベント定義から" +
+    "`scripts/docs/generate-websocket-api.js`によって自動生成される。手動で編集しないこと。" +
+    "再生成するには`node scripts/docs/generate-websocket-api.js`を実行する" +
+    "（[issue #902](https://github.com/bamiyanapp/karuta/issues/902)）。\n\n";
+  body += "クイズ大会モードのリアルタイム通信（読み札・結果画面の同期、早押し判定等）に使う" +
+    "API Gateway WebSocket API（`backend/quizRoomHandler.js`）のルート一覧。\n\n";
+  body += "| ルート | 関数名 | ハンドラー |\n";
+  body += "| :--- | :--- | :--- |\n";
+  for (const route of routes) {
+    body += `| \`${route.route}\` | ${route.functionName} | \`${route.handler}\` |\n`;
+  }
+  return body;
+}
+
+function main() {
+  const config = loadServerlessConfig(serverlessPath);
+  const routes = extractWebsocketRoutes(config);
+  // $connect/$disconnectを先頭に、それ以外はルート名でソートする
+  const specialRouteOrder = ["$connect", "$disconnect"];
+  routes.sort((a, b) => {
+    const aIndex = specialRouteOrder.indexOf(a.route);
+    const bIndex = specialRouteOrder.indexOf(b.route);
+    if (aIndex !== -1 || bIndex !== -1) {
+      return (aIndex === -1 ? specialRouteOrder.length : aIndex) - (bIndex === -1 ? specialRouteOrder.length : bIndex);
+    }
+    return a.route.localeCompare(b.route);
+  });
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, renderMarkdown(routes), "utf-8");
+  console.log(`Generated: ${path.relative(repoRoot, outputPath)} (${routes.length} routes)`);
+}
+
+main();

--- a/scripts/docs/serverless-yaml.js
+++ b/scripts/docs/serverless-yaml.js
@@ -1,0 +1,136 @@
+"use strict";
+
+const fs = require("fs");
+const yaml = require("js-yaml");
+
+// serverless.ymlはCloudFormationテンプレートのresourcesを含み、!GetAtt・!Subのような
+// CloudFormation組み込み関数の短縮タグを使う。js-yamlの既定スキーマはこれらのタグを
+// 知らずパースエラーになるため、値をそのまま`{ "Fn::<Tag>": <値> }`として保持するだけの
+// 最小限のカスタムスキーマを用意する（本パーサーは静的なルート・テーブル定義の抽出が
+// 目的で、組み込み関数の値解決自体は行わない。参照: issue #901/#902/#903）。
+const INTRINSIC_TAGS = [
+  "GetAtt",
+  "Sub",
+  "Ref",
+  "Join",
+  "Select",
+  "Split",
+  "FindInMap",
+  "ImportValue",
+  "If",
+  "Equals",
+  "Not",
+  "And",
+  "Or",
+  "Condition",
+];
+
+const CLOUDFORMATION_SCHEMA = yaml.DEFAULT_SCHEMA.extend(
+  INTRINSIC_TAGS.flatMap((tag) =>
+    ["scalar", "sequence", "mapping"].map(
+      (kind) =>
+        new yaml.Type(`!${tag}`, {
+          kind,
+          construct: (data) => ({ [`Fn::${tag}`]: data }),
+        })
+    )
+  )
+);
+
+function loadServerlessConfig(filePath) {
+  const raw = fs.readFileSync(filePath, "utf-8");
+  return yaml.load(raw, { schema: CLOUDFORMATION_SCHEMA });
+}
+
+const SELF_CUSTOM_VAR_RE = /\$\{self:custom\.([\w.]+)\}/g;
+
+// serverless.ymlの`${self:custom.xxx}`変数参照（Serverless Framework独自の変数構文で
+// CloudFormationの組み込み関数ではないため上記スキーマでは解決されない）を、
+// customセクションの実際の値に置き換える。customの値自体が文字列でない場合や
+// キーが見つからない場合は元の文字列のまま返す（値解決の失敗を静かに握りつぶさない）。
+function resolveSelfCustomVariables(value, config) {
+  if (typeof value !== "string") {
+    return value;
+  }
+  return value.replace(SELF_CUSTOM_VAR_RE, (whole, keyPath) => {
+    const resolved = keyPath
+      .split(".")
+      .reduce((acc, key) => (acc && typeof acc === "object" ? acc[key] : undefined), config.custom || {});
+    return typeof resolved === "string" ? resolved : whole;
+  });
+}
+
+// functions.<name>.eventsのうちhttp/websocketイベントを持つものを抽出する共通ロジック
+function extractFunctionEvents(config, eventKey) {
+  const functions = config.functions || {};
+  const results = [];
+  for (const [functionName, def] of Object.entries(functions)) {
+    for (const event of def.events || []) {
+      if (event[eventKey]) {
+        results.push({ functionName, handler: def.handler, ...event[eventKey] });
+      }
+    }
+  }
+  return results;
+}
+
+function extractHttpApiRoutes(config) {
+  return extractFunctionEvents(config, "http").map((entry) => ({
+    functionName: entry.functionName,
+    handler: entry.handler,
+    path: entry.path,
+    method: String(entry.method || "").toUpperCase(),
+  }));
+}
+
+function extractWebsocketRoutes(config) {
+  return extractFunctionEvents(config, "websocket").map((entry) => ({
+    functionName: entry.functionName,
+    handler: entry.handler,
+    route: entry.route,
+  }));
+}
+
+function extractDynamoDbTables(config) {
+  const resources = (config.resources && config.resources.Resources) || {};
+  const tables = [];
+  for (const [resourceName, def] of Object.entries(resources)) {
+    if (!def || def.Type !== "AWS::DynamoDB::Table") {
+      continue;
+    }
+    const props = def.Properties || {};
+    tables.push({
+      resourceName,
+      tableName: resolveSelfCustomVariables(props.TableName, config),
+      attributeDefinitions: (props.AttributeDefinitions || []).map((a) => ({
+        attribute: a.AttributeName,
+        type: a.AttributeType,
+      })),
+      keySchema: (props.KeySchema || []).map((k) => ({
+        attribute: k.AttributeName,
+        keyType: k.KeyType,
+      })),
+      globalSecondaryIndexes: (props.GlobalSecondaryIndexes || []).map((gsi) => ({
+        indexName: gsi.IndexName,
+        keySchema: (gsi.KeySchema || []).map((k) => ({
+          attribute: k.AttributeName,
+          keyType: k.KeyType,
+        })),
+      })),
+      timeToLive: props.TimeToLiveSpecification
+        ? {
+            attribute: props.TimeToLiveSpecification.AttributeName,
+            enabled: !!props.TimeToLiveSpecification.Enabled,
+          }
+        : null,
+    });
+  }
+  return tables;
+}
+
+module.exports = {
+  loadServerlessConfig,
+  extractHttpApiRoutes,
+  extractWebsocketRoutes,
+  extractDynamoDbTables,
+};


### PR DESCRIPTION
## Summary
- issue #901（Backend API仕様書）・#902（WebSocket API仕様書）・#903（DynamoDBテーブル定義書）・#909（API利用一覧）をまとめて実装
- `backend/serverless.yml`をパースする共通モジュール（`scripts/docs/serverless-yaml.js`）を実装し、4つの生成スクリプトを追加
- 生成結果を`docs/generated/`配下にMarkdownとして出力し、ルート`package.json`に`docs:generate`スクリプトを追加

## 実装内容

- `scripts/docs/serverless-yaml.js`: `backend/serverless.yml`をjs-yamlでパースする共通モジュール。CloudFormationの組み込み関数タグ（`!GetAtt`・`!Sub`）を許容する最小限のカスタムスキーマと、`${self:custom.xxx}`変数参照を実値に解決するユーティリティを含む
- `scripts/docs/generate-backend-api.js` → `docs/generated/backend-api.md`（#901）
- `scripts/docs/generate-websocket-api.js` → `docs/generated/websocket-api.md`（#902）
- `scripts/docs/generate-dynamodb-tables.js` → `docs/generated/dynamodb-tables.md`（#903）
- `scripts/docs/generate-api-usage.js` → `docs/generated/api-usage.md`（#909、frontend/src配下を正規表現で走査しHTTP/WebSocket双方の呼び出し箇所を抽出）

生成結果は、README.mdに既存の手動記載（Backend API 12件・WebSocket API 9件・DynamoDBテーブル5件）と一致することを確認済み。

## スコープ外（フォローアップ）

CIへの組み込み（PRごとの自動再生成・既存README手動記載とのドリフト検知等）は本PRの対象外とし、issue #900の検討事項として別途フォローアップで対応する。

## Test plan
- [x] `npm run docs:generate`を実行し、4ファイルが正しく生成されることを確認
- [x] frontend `npm run lint` エラー0件
- [x] backend `npm run lint` エラー0件
- [x] frontend/backend既存テストが全て通過（frontend 252件、backend 1543件。アプリケーションコードの変更はなし）


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_