### PR TITLE
feat(docs): 静的解析ドキュメントにMermaid図式化を追加

### DIFF
--- a/docs/generated/README.md
+++ b/docs/generated/README.md
@@ -11,8 +11,10 @@ npm run docs:generate
 | ファイル | 生成元 | 対応Issue |
 | :--- | :--- | :--- |
 | [backend-api.md](./backend-api.md) | `backend/serverless.yml`のhttpApiイベント定義 | [#901](https://github.com/bamiyanapp/karuta/issues/901) |
-| [websocket-api.md](./websocket-api.md) | `backend/serverless.yml`のwebsocketイベント定義 | [#902](https://github.com/bamiyanapp/karuta/issues/902) |
-| [dynamodb-tables.md](./dynamodb-tables.md) | `backend/serverless.yml`の`AWS::DynamoDB::Table`リソース定義 | [#903](https://github.com/bamiyanapp/karuta/issues/903) |
+| [websocket-api.md](./websocket-api.md) | `backend/serverless.yml`のwebsocketイベント定義（Mermaidシーケンス図を含む） | [#902](https://github.com/bamiyanapp/karuta/issues/902) |
+| [dynamodb-tables.md](./dynamodb-tables.md) | `backend/serverless.yml`の`AWS::DynamoDB::Table`リソース定義（Mermaid ER図を含む） | [#903](https://github.com/bamiyanapp/karuta/issues/903) |
+| [serverless-architecture.md](./serverless-architecture.md) | `backend/serverless.yml`のリソース定義・各Lambda関数コードの環境変数参照（Mermaidフロー図） | [#904](https://github.com/bamiyanapp/karuta/issues/904) |
+| [cicd-architecture.md](./cicd-architecture.md) | dev-standardsの`reusable-ci.yml`・karutaの`ci.yml`/`cd.yml`のjob依存関係（Mermaidフロー図） | [#905](https://github.com/bamiyanapp/karuta/issues/905) |
 | [api-usage.md](./api-usage.md) | `frontend/src`配下のAPI呼び出し箇所 | [#909](https://github.com/bamiyanapp/karuta/issues/909) |
 
 生成タイミングのCI組み込み（PRごとの自動再生成・ドリフト検知等）は未対応。方針は[issue #900](https://github.com/bamiyanapp/karuta/issues/900)の検討事項を参照し、別途フォローアップで対応する。

--- a/docs/generated/cicd-architecture.md
+++ b/docs/generated/cicd-architecture.md
@@ -1,0 +1,49 @@
+# CI/CD構成図（自動生成）
+
+このファイルはdev-standardsの`reusable-ci.yml`のjob定義と、karuta自身の`.github/workflows/ci.yml`/`cd.yml`から`scripts/docs/generate-cicd-architecture.js`によって自動生成される。手動で編集しないこと。再生成するには`node scripts/docs/generate-cicd-architecture.js`を実行する（[issue #905](https://github.com/bamiyanapp/karuta/issues/905)）。
+
+job間の依存（`needs:`）およびkarutaの実際の設定（`ci.yml`の`with:`）に基づく有効/無効の判定は静的解析で抽出しているが、dev-standards submoduleの参照バージョンが更新されるとjob構成自体が変わりうる点に留意する。
+
+## CIワークフロー（reusable-ci.yml、karuta設定反映）
+
+```mermaid
+graph TD
+    commitlint["commitlint"]
+    frontend-test["frontend-test"]
+    backend-test["backend-test"]
+    package-test["package-test（karutaでは無効/スキップ）"]
+    style package-test stroke-dasharray: 5 5
+    frontend-e2e-test["frontend-e2e-test"]
+    standards-check["standards-check"]
+    duplication-check["duplication-check"]
+    render-mermaid-diagrams["render-mermaid-diagrams"]
+    merge["merge"]
+
+    commitlint --> frontend-test
+    commitlint --> backend-test
+    commitlint --> package-test
+    commitlint --> frontend-e2e-test
+    commitlint --> standards-check
+    commitlint --> duplication-check
+    commitlint --> render-mermaid-diagrams
+    commitlint --> merge
+    frontend-test --> merge
+    backend-test --> merge
+    package-test --> merge
+    frontend-e2e-test --> merge
+    standards-check --> merge
+    duplication-check --> merge
+    render-mermaid-diagrams --> merge
+```
+
+## CDワークフロー（karuta cd.yml）
+
+```mermaid
+graph TD
+    release["release"]
+    build-and-deploy-frontend["build-and-deploy-frontend"]
+    deploy-backend["deploy-backend"]
+
+    release --> build-and-deploy-frontend
+    release --> deploy-backend
+```

--- a/docs/generated/dynamodb-tables.md
+++ b/docs/generated/dynamodb-tables.md
@@ -33,3 +33,27 @@ ORM（Prisma/TypeORM等）は使わずAWS SDKを直接呼び出す構成のた�
 - キースキーマ: roomId (HASH)
 - TTL: `ttl`属性（有効）
 
+## 属性一覧（ER図）
+
+```mermaid
+erDiagram
+    "karuta-comments" {
+        string id PK
+    }
+    "karuta-phrases" {
+        string category PK
+        string id SK
+    }
+    "karuta-polly-cache" {
+        string id PK
+    }
+    "karuta-quiz-room-connections" {
+        string connectionId PK
+        string roomId "GSI: roomId-index"
+    }
+    "karuta-quiz-rooms" {
+        string roomId PK
+    }
+```
+
+テーブル間に外部キー制約は無いが、アプリケーションコード上は`roomId`が`karuta-quiz-rooms`と`karuta-quiz-room-connections`（GSI `roomId-index`）をまたいで使われており、緩やかな関連を持つ（図には正式なリレーションとして描画しない）。

--- a/docs/generated/serverless-architecture.md
+++ b/docs/generated/serverless-architecture.md
@@ -1,0 +1,92 @@
+# サーバレス構成図（自動生成）
+
+このファイルは`backend/serverless.yml`のfunctions/resources定義、および各Lambda関数のコード（環境変数参照・Polly呼び出しの検出）から`scripts/docs/generate-serverless-architecture.js`によって自動生成される。手動で編集しないこと。再生成するには`node scripts/docs/generate-serverless-architecture.js`を実行する（[issue #904](https://github.com/bamiyanapp/karuta/issues/904)）。
+
+関数からリソースへの依存関係は、関数コード内の`process.env.<変数名>`参照を静的に検出して導出している（AIによる意味解釈ではなく正規表現ベース）。エクスポートされた関数が直接、または1階層のヘルパー関数（`関数名(...)`という直接呼び出し構文）経由で参照している場合のみ検出でき、`array.map(helperFn)`のような関数の参照渡しは検出できない既知の制約がある。
+
+```mermaid
+graph LR
+    Client[フロントエンド]
+    APIGW[API Gateway<br/>HTTP API]
+    WSGW[API Gateway<br/>WebSocket API]
+    Polly[(AWS Polly)]
+    getPhrase["getPhrase"]
+    getCategories["getCategories"]
+    getCongratulationAudio["getCongratulationAudio"]
+    getPhrasesList["getPhrasesList"]
+    postComment["postComment"]
+    getComments["getComments"]
+    recordTime["recordTime"]
+    generateEfudaPdf["generateEfudaPdf"]
+    renderEfudaPdfWorker["renderEfudaPdfWorker"]
+    getEfudaPdfStatus["getEfudaPdfStatus"]
+    createQuizRoom["createQuizRoom"]
+    listQuizRooms["listQuizRooms"]
+    checkQuizRoom["checkQuizRoom"]
+    connectQuizRoom["connectQuizRoom"]
+    disconnectQuizRoom["disconnectQuizRoom"]
+    syncQuizRoom["syncQuizRoom"]
+    updateQuizRoomState["updateQuizRoomState"]
+    setQuizRoomName["setQuizRoomName"]
+    buzzQuizRoom["buzzQuizRoom"]
+    judgeQuizRoomBuzz["judgeQuizRoomBuzz"]
+    resetQuizRoomPoints["resetQuizRoomPoints"]
+    closeQuizRoom["closeQuizRoom"]
+    table_karuta_phrases[(karuta-phrases<br/>(DynamoDB))]
+    table_karuta_comments[(karuta-comments<br/>(DynamoDB))]
+    table_karuta_polly_cache[(karuta-polly-cache<br/>(DynamoDB))]
+    table_karuta_quiz_rooms[(karuta-quiz-rooms<br/>(DynamoDB))]
+    table_karuta_quiz_room_connections[(karuta-quiz-room-connections<br/>(DynamoDB))]
+    bucket_karuta_efuda_pdf___aws_accountId_[(karuta-efuda-pdf-${aws:accountId}<br/>(S3))]
+
+    Client -->|HTTP| APIGW
+    Client -->|WebSocket| WSGW
+    APIGW --> getPhrase
+    APIGW --> getCategories
+    APIGW --> getCongratulationAudio
+    APIGW --> getPhrasesList
+    APIGW --> postComment
+    APIGW --> getComments
+    APIGW --> recordTime
+    APIGW --> generateEfudaPdf
+    APIGW --> getEfudaPdfStatus
+    APIGW --> createQuizRoom
+    APIGW --> listQuizRooms
+    APIGW --> checkQuizRoom
+    WSGW --> connectQuizRoom
+    WSGW --> disconnectQuizRoom
+    WSGW --> syncQuizRoom
+    WSGW --> updateQuizRoomState
+    WSGW --> setQuizRoomName
+    WSGW --> buzzQuizRoom
+    WSGW --> judgeQuizRoomBuzz
+    WSGW --> resetQuizRoomPoints
+    WSGW --> closeQuizRoom
+    getPhrase --> table_karuta_polly_cache
+    getPhrase --> table_karuta_phrases
+    getCategories --> table_karuta_phrases
+    getPhrasesList --> table_karuta_phrases
+    postComment --> table_karuta_comments
+    getComments --> table_karuta_comments
+    recordTime --> table_karuta_phrases
+    renderEfudaPdfWorker --> bucket_karuta_efuda_pdf___aws_accountId_
+    getEfudaPdfStatus --> bucket_karuta_efuda_pdf___aws_accountId_
+    createQuizRoom --> table_karuta_quiz_rooms
+    listQuizRooms --> table_karuta_quiz_rooms
+    checkQuizRoom --> table_karuta_quiz_rooms
+    connectQuizRoom --> table_karuta_quiz_rooms
+    connectQuizRoom --> table_karuta_quiz_room_connections
+    disconnectQuizRoom --> table_karuta_quiz_room_connections
+    disconnectQuizRoom --> table_karuta_quiz_rooms
+    syncQuizRoom --> table_karuta_quiz_rooms
+    updateQuizRoomState --> table_karuta_quiz_rooms
+    setQuizRoomName --> table_karuta_quiz_rooms
+    setQuizRoomName --> table_karuta_quiz_room_connections
+    buzzQuizRoom --> table_karuta_quiz_rooms
+    judgeQuizRoomBuzz --> table_karuta_quiz_rooms
+    resetQuizRoomPoints --> table_karuta_quiz_rooms
+    closeQuizRoom --> table_karuta_quiz_rooms
+    getPhrase --> Polly
+    getCongratulationAudio --> Polly
+    generateEfudaPdf -->|非同期Invoke| renderEfudaPdfWorker
+```

--- a/docs/generated/websocket-api.md
+++ b/docs/generated/websocket-api.md
@@ -4,14 +4,53 @@
 
 クイズ大会モードのリアルタイム通信（読み札・結果画面の同期、早押し判定等）に使うAPI Gateway WebSocket API（`backend/quizRoomHandler.js`）のルート一覧。
 
-| ルート | 関数名 | ハンドラー |
-| :--- | :--- | :--- |
-| `$connect` | connectQuizRoom | `quizRoomHandler.connectQuizRoom` |
-| `$disconnect` | disconnectQuizRoom | `quizRoomHandler.disconnectQuizRoom` |
-| `buzz` | buzzQuizRoom | `quizRoomHandler.buzzQuizRoom` |
-| `closeRoom` | closeQuizRoom | `quizRoomHandler.closeQuizRoom` |
-| `judgeBuzz` | judgeQuizRoomBuzz | `quizRoomHandler.judgeQuizRoomBuzz` |
-| `resetPoints` | resetQuizRoomPoints | `quizRoomHandler.resetQuizRoomPoints` |
-| `setName` | setQuizRoomName | `quizRoomHandler.setQuizRoomName` |
-| `sync` | syncQuizRoom | `quizRoomHandler.syncQuizRoom` |
-| `updateState` | updateQuizRoomState | `quizRoomHandler.updateQuizRoomState` |
+| ルート | 関数名 | ハンドラー | 実行権限 | ブロードキャスト |
+| :--- | :--- | :--- | :--- | :--- |
+| `$connect` | connectQuizRoom | `quizRoomHandler.connectQuizRoom` | 制限なし | なし（呼び出し元のみ） |
+| `$disconnect` | disconnectQuizRoom | `quizRoomHandler.disconnectQuizRoom` | 制限なし | あり（ルーム内の全接続へ） |
+| `buzz` | buzzQuizRoom | `quizRoomHandler.buzzQuizRoom` | 参加者のみ | あり（ルーム内の全接続へ） |
+| `closeRoom` | closeQuizRoom | `quizRoomHandler.closeQuizRoom` | 管理者のみ | あり（ルーム内の全接続へ） |
+| `judgeBuzz` | judgeQuizRoomBuzz | `quizRoomHandler.judgeQuizRoomBuzz` | 管理者のみ | あり（ルーム内の全接続へ） |
+| `resetPoints` | resetQuizRoomPoints | `quizRoomHandler.resetQuizRoomPoints` | 管理者のみ | あり（ルーム内の全接続へ） |
+| `setName` | setQuizRoomName | `quizRoomHandler.setQuizRoomName` | 制限なし | あり（ルーム内の全接続へ） |
+| `sync` | syncQuizRoom | `quizRoomHandler.syncQuizRoom` | 制限なし | なし（呼び出し元のみ） |
+| `updateState` | updateQuizRoomState | `quizRoomHandler.updateQuizRoomState` | 管理者のみ | あり（ルーム内の全接続へ） |
+
+## 代表的な通信フロー（シーケンス図）
+
+実行権限・ブロードキャスト有無は静的解析（`withRoleGuard`/`broadcastToRoom`呼び出しの検出）で機械的に抽出しているが、下記の呼び出し順序自体はコードの意味的な理解に基づき構成したもので、厳密な自動生成ではない点に留意する。
+
+```mermaid
+sequenceDiagram
+    participant Admin as クライアント（管理者）
+    participant Participant as クライアント（参加者）
+    participant GW as API Gateway (WebSocket)
+    participant L as Lambda（quizRoomHandler）
+    participant Room as ルーム内の全接続
+
+    Admin->>GW: $connect（roomId・adminToken）
+    GW->>L: connectQuizRoom
+    Participant->>GW: $connect（roomId）
+    GW->>L: connectQuizRoom
+    Participant->>L: sync
+    L-->>Participant: 現在の状態（sync）
+    Participant->>L: setName
+    L->>Room: participants（ブロードキャスト）
+    Admin->>L: updateState（読み札の表示等）
+    L->>Room: state（ブロードキャスト）
+    Participant->>L: buzz
+    L->>Room: buzz（ブロードキャスト）
+    Admin->>L: judgeBuzz
+    alt 正解
+        L->>Room: points（ブロードキャスト）
+    else 不正解
+        L->>Room: roundReset（ブロードキャスト）
+    end
+    Admin->>L: resetPoints
+    L->>Room: points（リセット後、ブロードキャスト）
+    Admin->>L: closeRoom
+    L->>Room: roomClosed（ブロードキャスト）
+    Participant--)GW: $disconnect
+    GW--)L: disconnectQuizRoom
+    L->>Room: participants（ブロードキャスト）
+```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "lint": "commitlint --last --verbose",
-    "docs:generate": "node scripts/docs/generate-backend-api.js && node scripts/docs/generate-websocket-api.js && node scripts/docs/generate-dynamodb-tables.js && node scripts/docs/generate-api-usage.js"
+    "docs:generate": "node scripts/docs/generate-backend-api.js && node scripts/docs/generate-websocket-api.js && node scripts/docs/generate-dynamodb-tables.js && node scripts/docs/generate-serverless-architecture.js && node scripts/docs/generate-cicd-architecture.js && node scripts/docs/generate-api-usage.js"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.0.0",

--- a/scripts/docs/generate-cicd-architecture.js
+++ b/scripts/docs/generate-cicd-architecture.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const yaml = require("js-yaml");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const reusableCiPath = path.join(repoRoot, "dev-standards", ".github", "workflows", "reusable-ci.yml");
+const karutaCiPath = path.join(repoRoot, ".github", "workflows", "ci.yml");
+const karutaCdPath = path.join(repoRoot, ".github", "workflows", "cd.yml");
+const outputPath = path.join(repoRoot, "docs", "generated", "cicd-architecture.md");
+
+function loadWorkflow(filePath) {
+  return yaml.load(fs.readFileSync(filePath, "utf-8"));
+}
+
+function normalizeNeeds(needs) {
+  if (!needs) {
+    return [];
+  }
+  return Array.isArray(needs) ? needs : [needs];
+}
+
+// job定義の`if:`文字列から、このjobの実行有無を左右する`inputs.<name>`参照を抽出する。
+// `inputs.packages == ''`のような比較演算子つきの参照は、booleanのenable_*フラグとは
+// 性質が異なる（値の比較であり単純な有効/無効ではない）ため、別枠で保持する
+function extractInputConditions(ifCondition) {
+  if (typeof ifCondition !== "string") {
+    return [];
+  }
+  const matches = [...ifCondition.matchAll(/inputs\.(\w+)(\s*(?:==|!=)\s*'[^']*')?/g)];
+  return matches.map((m) => ({ name: m[1], comparison: m[2] ? m[2].trim() : null }));
+}
+
+function extractJobs(workflow) {
+  const jobs = workflow.jobs || {};
+  return Object.entries(jobs).map(([name, def]) => ({
+    name,
+    needs: normalizeNeeds(def.needs),
+    conditions: extractInputConditions(def.if),
+  }));
+}
+
+// karutaのci.ymlの`jobs.ci.with`から、reusable-ci.ymlの各inputに実際に
+// 設定されている値を得る（未設定のinputはreusable-ci.yml側のdefaultのまま）
+function extractKarutaCiInputs(karutaWorkflow, reusableWorkflow) {
+  const configuredWith = (karutaWorkflow.jobs.ci && karutaWorkflow.jobs.ci.with) || {};
+  const inputDefs = (reusableWorkflow.on.workflow_call && reusableWorkflow.on.workflow_call.inputs) || {};
+  const resolved = {};
+  for (const [name, def] of Object.entries(inputDefs)) {
+    resolved[name] = Object.prototype.hasOwnProperty.call(configuredWith, name) ? configuredWith[name] : def.default;
+  }
+  return resolved;
+}
+
+// このjobがkaruta固有の設定のもとで実際に有効かどうかを判定する。
+// 単純な`inputs.enable_xxx`条件（真偽値フラグ）はkarutaCiInputsの値で判定できるが、
+// `inputs.packages == ''`のような値比較条件は、resolvedInputs.packagesの実際の値と
+// 比較演算子を評価して判定する
+function isJobEnabledForKaruta(job, karutaCiInputs) {
+  if (job.conditions.length === 0) {
+    return true;
+  }
+  return job.conditions.every(({ name, comparison }) => {
+    const value = karutaCiInputs[name];
+    if (!comparison) {
+      return Boolean(value);
+    }
+    const match = comparison.match(/(==|!=)\s*'([^']*)'/);
+    if (!match) {
+      return true;
+    }
+    const [, operator, expected] = match;
+    const actual = value === undefined || value === null ? "" : String(value);
+    return operator === "==" ? actual === expected : actual !== expected;
+  });
+}
+
+function renderCiGraph(jobs, karutaCiInputs) {
+  let body = "```mermaid\ngraph TD\n";
+  for (const job of jobs) {
+    const enabled = isJobEnabledForKaruta(job, karutaCiInputs);
+    const label = enabled ? job.name : `${job.name}（karutaでは無効/スキップ）`;
+    body += `    ${job.name}["${label}"]\n`;
+    if (!enabled) {
+      body += `    style ${job.name} stroke-dasharray: 5 5\n`;
+    }
+  }
+  body += "\n";
+  for (const job of jobs) {
+    for (const need of job.needs) {
+      body += `    ${need} --> ${job.name}\n`;
+    }
+  }
+  body += "```\n";
+  return body;
+}
+
+function renderCdGraph(cdWorkflow) {
+  const jobs = extractJobs(cdWorkflow);
+  let body = "```mermaid\ngraph TD\n";
+  for (const job of jobs) {
+    body += `    ${job.name}["${job.name}"]\n`;
+  }
+  body += "\n";
+  for (const job of jobs) {
+    for (const need of job.needs) {
+      body += `    ${need} --> ${job.name}\n`;
+    }
+  }
+  body += "```\n";
+  return body;
+}
+
+function main() {
+  const reusableCiWorkflow = loadWorkflow(reusableCiPath);
+  const karutaCiWorkflow = loadWorkflow(karutaCiPath);
+  const karutaCdWorkflow = loadWorkflow(karutaCdPath);
+
+  const ciJobs = extractJobs(reusableCiWorkflow);
+  const karutaCiInputs = extractKarutaCiInputs(karutaCiWorkflow, reusableCiWorkflow);
+
+  let body = "# CI/CD構成図（自動生成）\n\n";
+  body +=
+    "このファイルはdev-standardsの`reusable-ci.yml`のjob定義と、karuta自身の`.github/workflows/ci.yml`/" +
+    "`cd.yml`から`scripts/docs/generate-cicd-architecture.js`によって自動生成される。手動で編集しない" +
+    "こと。再生成するには`node scripts/docs/generate-cicd-architecture.js`を実行する" +
+    "（[issue #905](https://github.com/bamiyanapp/karuta/issues/905)）。\n\n" +
+    "job間の依存（`needs:`）およびkarutaの実際の設定（`ci.yml`の`with:`）に基づく" +
+    "有効/無効の判定は静的解析で抽出しているが、dev-standards submoduleの参照バージョンが" +
+    "更新されるとjob構成自体が変わりうる点に留意する。\n\n";
+  body += "## CIワークフロー（reusable-ci.yml、karuta設定反映）\n\n";
+  body += renderCiGraph(ciJobs, karutaCiInputs);
+  body += "\n## CDワークフロー（karuta cd.yml）\n\n";
+  body += renderCdGraph(karutaCdWorkflow);
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, body, "utf-8");
+  console.log(`Generated: ${path.relative(repoRoot, outputPath)} (${ciJobs.length} CI jobs)`);
+}
+
+main();

--- a/scripts/docs/generate-dynamodb-tables.js
+++ b/scripts/docs/generate-dynamodb-tables.js
@@ -29,6 +29,42 @@ function renderTableSection(table) {
   return section;
 }
 
+const ATTRIBUTE_TYPE_LABEL = { S: "string", N: "number", B: "binary" };
+
+// Mermaidのerディレクトリ図。DynamoDBはORMを介さずAWS SDKを直接呼び出す構成で
+// 外部キー制約も無いため、テーブル間の関連（リレーション行）は描かず、各テーブルの
+// 属性一覧（パーティションキー/ソートキー/GSIキー）のみをエンティティとして図示する。
+// アプリケーションコード上の緩やかな関連（roomId等）は図ではなく後続の文章で補足する。
+function renderErDiagram(tables) {
+  let body = "```mermaid\nerDiagram\n";
+  for (const table of tables) {
+    body += `    "${table.tableName}" {\n`;
+    const keyTypeByAttribute = new Map(table.keySchema.map((k) => [k.attribute, k.keyType]));
+    const gsiAttributeNames = new Set(
+      table.globalSecondaryIndexes.flatMap((gsi) => gsi.keySchema.map((k) => k.attribute))
+    );
+    for (const attr of table.attributeDefinitions) {
+      // メインのKeySchemaに属さず、GSIのキーとしてのみ使われる属性は、
+      // 下のGSIループ側でまとめて出力するため、ここでは重複を避けてスキップする
+      if (!keyTypeByAttribute.has(attr.attribute) && gsiAttributeNames.has(attr.attribute)) {
+        continue;
+      }
+      const type = ATTRIBUTE_TYPE_LABEL[attr.type] || "string";
+      const keyType = keyTypeByAttribute.get(attr.attribute);
+      const keyLabel = keyType === "HASH" ? "PK" : keyType === "RANGE" ? "SK" : "";
+      body += `        ${type} ${attr.attribute} ${keyLabel}\n`;
+    }
+    for (const gsi of table.globalSecondaryIndexes) {
+      for (const k of gsi.keySchema) {
+        body += `        string ${k.attribute} "GSI: ${gsi.indexName}"\n`;
+      }
+    }
+    body += "    }\n";
+  }
+  body += "```\n";
+  return body;
+}
+
 function renderMarkdown(tables) {
   let body = "# DynamoDBテーブル定義書（自動生成）\n\n";
   body +=
@@ -41,6 +77,12 @@ function renderMarkdown(tables) {
   for (const table of tables) {
     body += renderTableSection(table);
   }
+  body += "## 属性一覧（ER図）\n\n";
+  body += renderErDiagram(tables);
+  body +=
+    "\nテーブル間に外部キー制約は無いが、アプリケーションコード上は`roomId`が" +
+    "`karuta-quiz-rooms`と`karuta-quiz-room-connections`（GSI `roomId-index`）を" +
+    "またいで使われており、緩やかな関連を持つ（図には正式なリレーションとして描画しない）。\n";
   return body;
 }
 

--- a/scripts/docs/generate-serverless-architecture.js
+++ b/scripts/docs/generate-serverless-architecture.js
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const {
+  loadServerlessConfig,
+  extractHttpApiRoutes,
+  extractWebsocketRoutes,
+  extractDynamoDbTables,
+  extractS3Buckets,
+  listFunctionNames,
+  extractFunctionEnvironment,
+  extractProviderEnvironment,
+} = require("./serverless-yaml");
+const { splitExportsIntoBlocks, splitNamedFunctionsIntoBlocks } = require("./handler-blocks");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const serverlessPath = path.join(repoRoot, "backend", "serverless.yml");
+const outputPath = path.join(repoRoot, "docs", "generated", "serverless-architecture.md");
+
+function sanitizeId(label) {
+  return label.replace(/[^a-zA-Z0-9]/g, "_");
+}
+
+// !GetAtt <論理ID>.Arn形式の参照から、Serverless Frameworkの命名規則
+// （関数名の先頭を大文字にし"LambdaFunction"を付与）を逆算して関数名を復元する。
+// 対応する関数がfunctionNamesに存在しなければnullを返す
+function resolveGetAttToFunctionName(getAttRef, functionNames) {
+  if (!getAttRef || typeof getAttRef !== "object" || !getAttRef["Fn::GetAtt"]) {
+    return null;
+  }
+  const logicalId = String(getAttRef["Fn::GetAtt"]).split(".")[0];
+  for (const functionName of functionNames) {
+    const expectedLogicalId = `${functionName.charAt(0).toUpperCase()}${functionName.slice(1)}LambdaFunction`;
+    if (logicalId === expectedLogicalId) {
+      return functionName;
+    }
+  }
+  return null;
+}
+
+// exportされた関数のブロックが直接呼び出している、非exportのトップレベル
+// ヘルパー関数のブロックを1階層分だけ集める（例: handler.jsのgetPhraseが
+// findPhraseItem/synthesizePhraseAudioを呼ぶケース）。ヘルパーの呼び出しチェーンを
+// 深く辿るとAIによる意味解釈に近づいてしまうため、1階層のみを対象にする
+// （本ファイルの実際のコード構成をカバーするのに必要十分な範囲。issue #904のコメント参照）
+function collectCalledHelperBlocks(functionBlock, namedFunctionBlocks) {
+  const called = [];
+  for (const [helperName, helperBlock] of namedFunctionBlocks) {
+    if (new RegExp(`\\b${helperName}\\(`).test(functionBlock)) {
+      called.push(helperBlock);
+    }
+  }
+  return called;
+}
+
+function usesPolly(functionBlock, calledHelperBlocks) {
+  const POLLY_CALL_RE = /pollyClient\.send\(|SynthesizeSpeechCommand\(/;
+  return POLLY_CALL_RE.test(functionBlock) || calledHelperBlocks.some((block) => POLLY_CALL_RE.test(block));
+}
+
+function collectEnvVarNames(functionBlock, calledHelperBlocks) {
+  const text = [functionBlock, ...calledHelperBlocks].join("\n");
+  return [...new Set([...text.matchAll(/process\.env\.(\w+)/g)].map((m) => m[1]))];
+}
+
+function buildResourceNodesByEnvValue(tables, buckets) {
+  const map = new Map();
+  for (const table of tables) {
+    map.set(table.tableName, { id: `table_${sanitizeId(table.tableName)}`, label: `${table.tableName}<br/>(DynamoDB)` });
+  }
+  for (const bucket of buckets) {
+    map.set(bucket.bucketName, { id: `bucket_${sanitizeId(bucket.bucketName)}`, label: `${bucket.bucketName}<br/>(S3)` });
+  }
+  return map;
+}
+
+function main() {
+  const config = loadServerlessConfig(serverlessPath);
+  const httpRoutes = extractHttpApiRoutes(config);
+  const websocketRoutes = extractWebsocketRoutes(config);
+  const tables = extractDynamoDbTables(config);
+  const buckets = extractS3Buckets(config);
+  const functionNames = listFunctionNames(config);
+  const providerEnv = extractProviderEnvironment(config);
+  const resourceNodeByEnvValue = buildResourceNodesByEnvValue(tables, buckets);
+
+  const handlerBlockCache = new Map(); // ファイルベース名 -> { exportBlocks, namedBlocks }
+  function getHandlerBlocks(fileBaseName) {
+    if (!handlerBlockCache.has(fileBaseName)) {
+      const filePath = path.join(repoRoot, "backend", `${fileBaseName}.js`);
+      handlerBlockCache.set(fileBaseName, {
+        exportBlocks: splitExportsIntoBlocks(filePath),
+        namedBlocks: splitNamedFunctionsIntoBlocks(filePath),
+      });
+    }
+    return handlerBlockCache.get(fileBaseName);
+  }
+
+  const functionHandlerByName = {};
+  for (const route of [...httpRoutes, ...websocketRoutes]) {
+    functionHandlerByName[route.functionName] = route.handler;
+  }
+  // httpApi/websocketいずれのイベントも持たない関数（例: renderEfudaPdfWorker）は
+  // serverless.ymlのfunctions定義から直接handlerを引く
+  for (const functionName of functionNames) {
+    if (!functionHandlerByName[functionName]) {
+      functionHandlerByName[functionName] = config.functions[functionName].handler;
+    }
+  }
+
+  const edges = [];
+  const usesPollyByFunction = new Set();
+  const functionToFunctionInvokes = [];
+
+  for (const functionName of functionNames) {
+    const handler = functionHandlerByName[functionName];
+    const [fileBaseName, exportName] = handler.split(".");
+    const { exportBlocks, namedBlocks } = getHandlerBlocks(fileBaseName);
+    const block = exportBlocks.get(exportName);
+    if (!block) {
+      continue;
+    }
+
+    const calledHelperBlocks = collectCalledHelperBlocks(block, namedBlocks);
+
+    if (usesPolly(block, calledHelperBlocks)) {
+      usesPollyByFunction.add(functionName);
+    }
+
+    const envVarNames = collectEnvVarNames(block, calledHelperBlocks);
+    const functionEnv = extractFunctionEnvironment(config, functionName);
+    const combinedEnv = { ...providerEnv, ...functionEnv };
+    for (const envVarName of envVarNames) {
+      const value = combinedEnv[envVarName];
+      if (value === undefined) {
+        continue;
+      }
+      const invokedFunctionName = resolveGetAttToFunctionName(value, functionNames);
+      if (invokedFunctionName) {
+        functionToFunctionInvokes.push({ from: functionName, to: invokedFunctionName });
+        continue;
+      }
+      if (resourceNodeByEnvValue.has(value)) {
+        edges.push({ from: functionName, to: value });
+      }
+    }
+  }
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(
+    outputPath,
+    renderMarkdown({
+      httpRoutes,
+      websocketRoutes,
+      functionNames,
+      resourceNodeByEnvValue,
+      edges,
+      usesPollyByFunction,
+      functionToFunctionInvokes,
+    }),
+    "utf-8"
+  );
+  console.log(
+    `Generated: ${path.relative(repoRoot, outputPath)} (${functionNames.length} functions, ${edges.length} resource edges)`
+  );
+}
+
+function renderMarkdown({
+  httpRoutes,
+  websocketRoutes,
+  functionNames,
+  resourceNodeByEnvValue,
+  edges,
+  usesPollyByFunction,
+  functionToFunctionInvokes,
+}) {
+  let body = "# サーバレス構成図（自動生成）\n\n";
+  body +=
+    "このファイルは`backend/serverless.yml`のfunctions/resources定義、および各Lambda関数の" +
+    "コード（環境変数参照・Polly呼び出しの検出）から`scripts/docs/generate-serverless-architecture.js`" +
+    "によって自動生成される。手動で編集しないこと。再生成するには" +
+    "`node scripts/docs/generate-serverless-architecture.js`を実行する" +
+    "（[issue #904](https://github.com/bamiyanapp/karuta/issues/904)）。\n\n" +
+    "関数からリソースへの依存関係は、関数コード内の`process.env.<変数名>`参照を" +
+    "静的に検出して導出している（AIによる意味解釈ではなく正規表現ベース）。" +
+    "エクスポートされた関数が直接、または1階層のヘルパー関数（`関数名(...)`という" +
+    "直接呼び出し構文）経由で参照している場合のみ検出でき、`array.map(helperFn)`の" +
+    "ような関数の参照渡しは検出できない既知の制約がある。\n\n";
+  body += "```mermaid\ngraph LR\n";
+  body += "    Client[フロントエンド]\n";
+  body += "    APIGW[API Gateway<br/>HTTP API]\n";
+  body += "    WSGW[API Gateway<br/>WebSocket API]\n";
+  body += "    Polly[(AWS Polly)]\n";
+
+  const httpFunctionNames = new Set(httpRoutes.map((r) => r.functionName));
+  const websocketFunctionNames = new Set(websocketRoutes.map((r) => r.functionName));
+
+  for (const functionName of functionNames) {
+    body += `    ${functionName}["${functionName}"]\n`;
+  }
+  for (const [, node] of resourceNodeByEnvValue) {
+    body += `    ${node.id}[(${node.label})]\n`;
+  }
+
+  body += "\n";
+  if (httpFunctionNames.size > 0) {
+    body += "    Client -->|HTTP| APIGW\n";
+  }
+  if (websocketFunctionNames.size > 0) {
+    body += "    Client -->|WebSocket| WSGW\n";
+  }
+  for (const functionName of functionNames) {
+    if (httpFunctionNames.has(functionName)) {
+      body += `    APIGW --> ${functionName}\n`;
+    }
+    if (websocketFunctionNames.has(functionName)) {
+      body += `    WSGW --> ${functionName}\n`;
+    }
+  }
+  for (const edge of edges) {
+    const node = resourceNodeByEnvValue.get(edge.to);
+    body += `    ${edge.from} --> ${node.id}\n`;
+  }
+  for (const functionName of usesPollyByFunction) {
+    body += `    ${functionName} --> Polly\n`;
+  }
+  for (const invoke of functionToFunctionInvokes) {
+    body += `    ${invoke.from} -->|非同期Invoke| ${invoke.to}\n`;
+  }
+  body += "```\n";
+  return body;
+}
+
+main();

--- a/scripts/docs/generate-websocket-api.js
+++ b/scripts/docs/generate-websocket-api.js
@@ -4,12 +4,71 @@
 const fs = require("fs");
 const path = require("path");
 const { loadServerlessConfig, extractWebsocketRoutes } = require("./serverless-yaml");
+const { extractHandlerBehavior } = require("./handler-behavior");
 
 const repoRoot = path.resolve(__dirname, "..", "..");
 const serverlessPath = path.join(repoRoot, "backend", "serverless.yml");
 const outputPath = path.join(repoRoot, "docs", "generated", "websocket-api.md");
 
-function renderMarkdown(routes) {
+const ROLE_LABEL = { admin: "管理者のみ", participant: "参加者のみ" };
+
+function renderTable(routes, behavior) {
+  let body = "| ルート | 関数名 | ハンドラー | 実行権限 | ブロードキャスト |\n";
+  body += "| :--- | :--- | :--- | :--- | :--- |\n";
+  for (const route of routes) {
+    const b = behavior[route.functionName] || {};
+    const role = ROLE_LABEL[b.role] || "制限なし";
+    const broadcast = b.broadcasts ? "あり（ルーム内の全接続へ）" : "なし（呼び出し元のみ）";
+    body += `| \`${route.route}\` | ${route.functionName} | \`${route.handler}\` | ${role} | ${broadcast} |\n`;
+  }
+  return body;
+}
+
+// クイズ大会モードの代表的な1ラウンド分の通信フロー。ルート一覧・実行権限・
+// ブロードキャスト有無は静的解析（extractHandlerBehavior）で抽出できるが、
+// 「どの順序で呼ばれるか」というライフサイクル全体の流れはコードの意味的な
+// 理解が必要なため、quizRoomHandler.js・useQuizRoomSync.js（frontend側）の
+// 読解に基づき手動で構成した（issue #902のコメントで留意点として明記済み）。
+// ルート名・型自体が変わった場合はこのテンプレートも追従して更新が必要になる。
+function renderSequenceDiagram() {
+  return `\`\`\`mermaid
+sequenceDiagram
+    participant Admin as クライアント（管理者）
+    participant Participant as クライアント（参加者）
+    participant GW as API Gateway (WebSocket)
+    participant L as Lambda（quizRoomHandler）
+    participant Room as ルーム内の全接続
+
+    Admin->>GW: $connect（roomId・adminToken）
+    GW->>L: connectQuizRoom
+    Participant->>GW: $connect（roomId）
+    GW->>L: connectQuizRoom
+    Participant->>L: sync
+    L-->>Participant: 現在の状態（sync）
+    Participant->>L: setName
+    L->>Room: participants（ブロードキャスト）
+    Admin->>L: updateState（読み札の表示等）
+    L->>Room: state（ブロードキャスト）
+    Participant->>L: buzz
+    L->>Room: buzz（ブロードキャスト）
+    Admin->>L: judgeBuzz
+    alt 正解
+        L->>Room: points（ブロードキャスト）
+    else 不正解
+        L->>Room: roundReset（ブロードキャスト）
+    end
+    Admin->>L: resetPoints
+    L->>Room: points（リセット後、ブロードキャスト）
+    Admin->>L: closeRoom
+    L->>Room: roomClosed（ブロードキャスト）
+    Participant--)GW: $disconnect
+    GW--)L: disconnectQuizRoom
+    L->>Room: participants（ブロードキャスト）
+\`\`\`
+`;
+}
+
+function renderMarkdown(routes, behavior) {
   let body = "# WebSocket API仕様書（自動生成）\n\n";
   body +=
     "このファイルは`backend/serverless.yml`のwebsocketイベント定義から" +
@@ -18,11 +77,13 @@ function renderMarkdown(routes) {
     "（[issue #902](https://github.com/bamiyanapp/karuta/issues/902)）。\n\n";
   body += "クイズ大会モードのリアルタイム通信（読み札・結果画面の同期、早押し判定等）に使う" +
     "API Gateway WebSocket API（`backend/quizRoomHandler.js`）のルート一覧。\n\n";
-  body += "| ルート | 関数名 | ハンドラー |\n";
-  body += "| :--- | :--- | :--- |\n";
-  for (const route of routes) {
-    body += `| \`${route.route}\` | ${route.functionName} | \`${route.handler}\` |\n`;
-  }
+  body += renderTable(routes, behavior);
+  body += "\n## 代表的な通信フロー（シーケンス図）\n\n";
+  body +=
+    "実行権限・ブロードキャスト有無は静的解析（`withRoleGuard`/`broadcastToRoom`呼び出しの検出）で" +
+    "機械的に抽出しているが、下記の呼び出し順序自体はコードの意味的な理解に基づき構成したもので、" +
+    "厳密な自動生成ではない点に留意する。\n\n";
+  body += renderSequenceDiagram();
   return body;
 }
 
@@ -40,8 +101,24 @@ function main() {
     return a.route.localeCompare(b.route);
   });
 
+  // handlerは"quizRoomHandler.connectQuizRoom"形式（ファイル名.関数名）。
+  // ファイルごとにグルーピングし、実行権限・ブロードキャスト有無を抽出する
+  const functionNamesByFile = new Map();
+  for (const route of routes) {
+    const [fileBaseName, exportName] = route.handler.split(".");
+    if (!functionNamesByFile.has(fileBaseName)) {
+      functionNamesByFile.set(fileBaseName, []);
+    }
+    functionNamesByFile.get(fileBaseName).push(exportName);
+  }
+  const behavior = {};
+  for (const [fileBaseName, exportNames] of functionNamesByFile) {
+    const handlerSourcePath = path.join(repoRoot, "backend", `${fileBaseName}.js`);
+    Object.assign(behavior, extractHandlerBehavior(handlerSourcePath, exportNames));
+  }
+
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-  fs.writeFileSync(outputPath, renderMarkdown(routes), "utf-8");
+  fs.writeFileSync(outputPath, renderMarkdown(routes, behavior), "utf-8");
   console.log(`Generated: ${path.relative(repoRoot, outputPath)} (${routes.length} routes)`);
 }
 

--- a/scripts/docs/handler-behavior.js
+++ b/scripts/docs/handler-behavior.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const { splitExportsIntoBlocks } = require("./handler-blocks");
+
+// backend/quizRoomHandler.js等のハンドラーファイルの各関数ブロックから、
+// 振る舞い（権限ガード・ブロードキャスト有無）を正規表現で検出する。AIによる
+// コード意味解釈ではなく、withRoleGuard()・broadcastToRoom()という既存の共通
+// ヘルパー呼び出しパターンの有無を機械的に検出するだけの静的解析であり、
+// これらのヘルパー名が変わった場合は追従が必要になる（issue #902）。
+function extractHandlerBehavior(handlerSourcePath, functionNames) {
+  const blocks = splitExportsIntoBlocks(handlerSourcePath);
+  const behavior = {};
+  for (const name of functionNames) {
+    const block = blocks.get(name);
+    if (!block) {
+      continue;
+    }
+    const roleMatch = block.match(/withRoleGuard\(\s*["'](admin|participant)["']/);
+    behavior[name] = {
+      role: roleMatch ? roleMatch[1] : null,
+      broadcasts: /broadcastToRoom\s*\(/.test(block),
+    };
+  }
+  return behavior;
+}
+
+module.exports = { extractHandlerBehavior };

--- a/scripts/docs/handler-blocks.js
+++ b/scripts/docs/handler-blocks.js
@@ -1,0 +1,115 @@
+"use strict";
+
+const fs = require("fs");
+
+// 指定した開始位置（`{`の位置）から、波括弧の対応（ネスト深度カウント）で
+// ブロックの終端位置を探す。文字列・テンプレートリテラル内の波括弧は現状の
+// コードベースでは常に対応が取れている（単体の`{`や`}`を含む文字列リテラルが
+// 無いことを確認済み）ため、字句解析（トークナイズ）までは行わない素朴な
+// カウントで実用上十分と判断した。
+function findMatchingBraceEnd(content, firstBraceIndex) {
+  let depth = 0;
+  for (let i = firstBraceIndex; i < content.length; i++) {
+    if (content[i] === "{") {
+      depth++;
+    } else if (content[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        return i;
+      }
+    }
+  }
+  return -1;
+}
+
+// 開き括弧の位置から、括弧の対応（ネスト深度カウント）で引数リストの終端
+// （対応する`)`）位置を探す。分割引数（例: `function f({ a, b }) {`）のように
+// 引数リスト自体が`{`を含む場合、本体の開始位置（`{`）を引数リストの外側の
+// `{`と取り違えないようにするため、まず引数リストの終端を確定させてから
+// 関数本体の`{`を探す必要がある
+function findMatchingParenEnd(content, openParenIndex) {
+  let depth = 0;
+  for (let i = openParenIndex; i < content.length; i++) {
+    if (content[i] === "(") {
+      depth++;
+    } else if (content[i] === ")") {
+      depth--;
+      if (depth === 0) {
+        return i;
+      }
+    }
+  }
+  return -1;
+}
+
+// ハンドラーファイル（backend/handler.js等）を`exports.<name> = <関数>`の代入から
+// 関数本体の終端を特定し、トップレベルの関数ブロックへ分割する。
+// `exports.docClient = docClient;`のような単純な再エクスポート（代入直後に`{`が
+// 続かない）は関数ではないため対象外とする。
+//
+// 単純な行ベースの「次のexports.行までを1ブロックとする」実装では、
+// handler.jsのようにexportされた関数の間に非exportのヘルパー関数（例:
+// synthesizePhraseAudio）が挟まる構成で、そのヘルパー部分を直前の関数の
+// 本体だと誤認識してしまう問題があったため、波括弧の対応を実際に数える方式にした。
+function splitExportsIntoBlocks(filePath) {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const exportAssignmentRe = /^exports\.(\w+)\s*=\s*/gm;
+
+  const blocks = new Map();
+  let match;
+  while ((match = exportAssignmentRe.exec(content))) {
+    const name = match[1];
+    const assignStart = match.index;
+    const afterAssign = match.index + match[0].length;
+    const firstBraceIndex = content.indexOf("{", afterAssign);
+    // 代入値と`{`の間にセミコロンが挟まる場合（`{`が現れる前に文が終わっている）は、
+    // 関数ではなく単純な値の再エクスポート（例: exports.docClient = docClient;）と
+    // みなしスキップする
+    if (firstBraceIndex === -1 || content.slice(afterAssign, firstBraceIndex).includes(";")) {
+      continue;
+    }
+
+    const endIndex = findMatchingBraceEnd(content, firstBraceIndex);
+    if (endIndex === -1) {
+      continue;
+    }
+    blocks.set(name, content.slice(assignStart, endIndex + 1));
+  }
+  return blocks;
+}
+
+// `function <name>(...) { ... }` / `async function <name>(...) { ... }`形式の
+// 非export（ファイル内限定）のトップレベル関数を抽出する。exportされた関数から
+// 呼び出される内部ヘルパー（例: handler.jsのsynthesizePhraseAudio）を辿って
+// 間接的な外部サービス呼び出し（Polly等）を検出する用途（issue #904）で使う。
+function splitNamedFunctionsIntoBlocks(filePath) {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const functionDeclarationRe = /^(?:async\s+)?function\s+(\w+)\s*\(/gm;
+
+  const blocks = new Map();
+  let match;
+  while ((match = functionDeclarationRe.exec(content))) {
+    const name = match[1];
+    const declarationStart = match.index;
+    // マッチの末尾（引数リストの開き括弧`(`自体）から、対応する`)`を探し、
+    // 引数リストが分割引数（`{...}`）を含んでいてもその中の`{`を本体の
+    // 開始位置と誤認識しないようにする
+    const openParenIndex = match.index + match[0].length - 1;
+    const closeParenIndex = findMatchingParenEnd(content, openParenIndex);
+    if (closeParenIndex === -1) {
+      continue;
+    }
+    const firstBraceIndex = content.indexOf("{", closeParenIndex);
+    if (firstBraceIndex === -1) {
+      continue;
+    }
+    const endIndex = findMatchingBraceEnd(content, firstBraceIndex);
+    if (endIndex === -1) {
+      continue;
+    }
+    blocks.set(name, content.slice(declarationStart, endIndex + 1));
+  }
+  return blocks;
+}
+
+module.exports = { splitExportsIntoBlocks, splitNamedFunctionsIntoBlocks };

--- a/scripts/docs/serverless-yaml.js
+++ b/scripts/docs/serverless-yaml.js
@@ -128,9 +128,57 @@ function extractDynamoDbTables(config) {
   return tables;
 }
 
+function extractS3Buckets(config) {
+  const resources = (config.resources && config.resources.Resources) || {};
+  const buckets = [];
+  for (const [resourceName, def] of Object.entries(resources)) {
+    if (!def || def.Type !== "AWS::S3::Bucket") {
+      continue;
+    }
+    const props = def.Properties || {};
+    buckets.push({
+      resourceName,
+      bucketName: resolveSelfCustomVariables(props.BucketName, config),
+    });
+  }
+  return buckets;
+}
+
+function listFunctionNames(config) {
+  return Object.keys(config.functions || {});
+}
+
+// provider.environment（全関数で共有される環境変数）を、${self:custom.xxx}解決込みで返す
+function extractProviderEnvironment(config) {
+  const environment = (config.provider && config.provider.environment) || {};
+  const resolved = {};
+  for (const [key, value] of Object.entries(environment)) {
+    resolved[key] = resolveSelfCustomVariables(value, config);
+  }
+  return resolved;
+}
+
+// functions.<name>.environment（関数固有の環境変数上書き）を返す。文字列値は
+// ${self:custom.xxx}を解決し、CloudFormation組み込み関数（!GetAtt等）はそのまま
+// `{ "Fn::GetAtt": "<論理ID>.<属性>" }`形式で返す（値解決はしない）
+function extractFunctionEnvironment(config, functionName) {
+  const def = (config.functions || {})[functionName] || {};
+  const environment = def.environment || {};
+  const resolved = {};
+  for (const [key, value] of Object.entries(environment)) {
+    resolved[key] = resolveSelfCustomVariables(value, config);
+  }
+  return resolved;
+}
+
 module.exports = {
   loadServerlessConfig,
+  resolveSelfCustomVariables,
   extractHttpApiRoutes,
   extractWebsocketRoutes,
   extractDynamoDbTables,
+  extractS3Buckets,
+  listFunctionNames,
+  extractFunctionEnvironment,
+  extractProviderEnvironment,
 };

--- a/scripts/docs/serverless-yaml.js
+++ b/scripts/docs/serverless-yaml.js
@@ -1,13 +1,16 @@
 "use strict";
 
 const fs = require("fs");
-const yaml = require("js-yaml");
+const { load, CORE_SCHEMA, defineScalarTag } = require("js-yaml");
 
 // serverless.ymlはCloudFormationテンプレートのresourcesを含み、!GetAtt・!Subのような
 // CloudFormation組み込み関数の短縮タグを使う。js-yamlの既定スキーマはこれらのタグを
 // 知らずパースエラーになるため、値をそのまま`{ "Fn::<Tag>": <値> }`として保持するだけの
 // 最小限のカスタムスキーマを用意する（本パーサーは静的なルート・テーブル定義の抽出が
 // 目的で、組み込み関数の値解決自体は行わない。参照: issue #901/#902/#903）。
+// スカラー形式（例: `!GetAtt Resource.Attr`）のみ対応し、シーケンス/マッピング形式
+// （例: `!GetAtt [Resource, Attr]`）は本コードベースの実際のserverless.ymlで
+// 使われていないため未対応（必要になった場合はdefineSequenceTag/defineMappingTagで追加する）。
 const INTRINSIC_TAGS = [
   "GetAtt",
   "Sub",
@@ -25,21 +28,17 @@ const INTRINSIC_TAGS = [
   "Condition",
 ];
 
-const CLOUDFORMATION_SCHEMA = yaml.DEFAULT_SCHEMA.extend(
-  INTRINSIC_TAGS.flatMap((tag) =>
-    ["scalar", "sequence", "mapping"].map(
-      (kind) =>
-        new yaml.Type(`!${tag}`, {
-          kind,
-          construct: (data) => ({ [`Fn::${tag}`]: data }),
-        })
-    )
+const CLOUDFORMATION_SCHEMA = CORE_SCHEMA.withTags(
+  ...INTRINSIC_TAGS.map((tag) =>
+    defineScalarTag(`!${tag}`, {
+      resolve: (source) => ({ [`Fn::${tag}`]: source }),
+    })
   )
 );
 
 function loadServerlessConfig(filePath) {
   const raw = fs.readFileSync(filePath, "utf-8");
-  return yaml.load(raw, { schema: CLOUDFORMATION_SCHEMA });
+  return load(raw, { schema: CLOUDFORMATION_SCHEMA });
 }
 
 const SELF_CUSTOM_VAR_RE = /\$\{self:custom\.([\w.]+)\}/g;


### PR DESCRIPTION
## Summary
- issue #902（WebSocket API仕様書）にsequenceDiagram、#903（DynamoDBテーブル定義書）にerDiagramを追加
- #904（サーバレス構成図）・#905（CI/CD構成図）を新規実装（いずれも元々Mermaid図の生成が目的のIssue）
- 共通基盤として、ハンドラーファイルをexports/非exportのトップレベル関数ブロックへ正しく分割する`scripts/docs/handler-blocks.js`を実装
- Renovateによるjs-yaml v4→v5更新（PR #911、main反映済み）に伴う破壊的API変更（`DEFAULT_SCHEMA`/`yaml.Type`廃止）に対応

## 実装内容

### #902 WebSocket API仕様書
- 実行権限（`withRoleGuard`検出）・ブロードキャスト有無（`broadcastToRoom`検出）を表に追加
- クイズ大会モードの代表的な1ラウンド分の通信フローをMermaid `sequenceDiagram`として追加（呼び出し順序自体はコードの意味的理解に基づき手動構成、その旨を明記）

### #903 DynamoDBテーブル定義書
- 各テーブルの属性一覧をMermaid `erDiagram`として追加（外部キー制約が無いため関連は描画せず、テキストで補足）

### #904 サーバレス構成図（新規）
- `serverless.yml`のfunctions/resources定義と、各Lambda関数コードの`process.env.<変数名>`参照（1階層のヘルパー関数呼び出しを含む）を静的解析し、Lambda関数→DynamoDBテーブル/S3バケット/Polly/他Lambda関数（非同期Invoke）の依存関係をMermaid flowchartとして生成

### #905 CI/CD構成図（新規）
- dev-standardsの`reusable-ci.yml`のjob依存関係と、karuta自身の`ci.yml`/`cd.yml`の実際の設定（`with:`）を突き合わせ、karutaで有効/無効なjobを反映したMermaid flowchartを生成

### 共通基盤の改善
- `scripts/docs/handler-blocks.js`: 波括弧の対応を実際に数える方式で関数ブロックを分割する共通ロジック。従来の「次のexports.行まで」という行ベースの実装では、handler.jsのように非exportヘルパー（例: `synthesizePhraseAudio`）がexportされた関数の間に挟まる構成を誤認識する問題があったため修正した
- js-yaml v5対応: `CORE_SCHEMA` + `defineScalarTag` + `Schema#withTags()`の新APIへ移行。v4/v5どちらでも生成結果が完全に同一であることを確認済み

## Test plan
- [x] `npm run docs:generate`を実行し、6ファイル全てが正しく生成されることを確認
- [x] `getPhrase`が`synthesizePhraseAudio`ヘルパー経由でPolly・phrasesテーブル両方を使っていることが正しく検出されることを個別確認
- [x] frontend `npm run lint` エラー0件
- [x] backend `npm run lint` エラー0件
- [x] frontend/backend既存テストが全て通過（frontend 252件、backend 1543件。アプリケーションコードの変更はなし）


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_