### PR TITLE
fix(docs): 生成ドキュメントのMermaid図を画像として埋め込む

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,11 @@ jobs:
       # Architecture／Screen Transitionsの2図）のmermaid図をSVGへ事前レンダリング
       # し、PR差分ビュー・API経由でのファイル取得等でmermaidがネイティブ
       # レンダリングされない場面でも確認できるようにする
+      # docs/generated/配下の4ファイル（websocket-api.md・dynamodb-tables.md・
+      # serverless-architecture.md・cicd-architecture.md）は、issue #901-909の
+      # ドキュメント自動生成でMermaid図を追加したが、mermaid_doc_pathsに含めて
+      # いなかったためコードのままでしか見えず画像化されていなかった。対象に追加する
       enable_mermaid_render: true
-      mermaid_doc_paths: "docs/cicd-pipeline-specification.md\nREADME.md"
+      mermaid_doc_paths: "docs/cicd-pipeline-specification.md\nREADME.md\ndocs/generated/websocket-api.md\ndocs/generated/dynamodb-tables.md\ndocs/generated/serverless-architecture.md\ndocs/generated/cicd-architecture.md"
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/docs/generated/cicd-architecture.md
+++ b/docs/generated/cicd-architecture.md
@@ -6,6 +6,9 @@ job間の依存（`needs:`）およびkarutaの実際の設定（`ci.yml`の`wit
 
 ## CIワークフロー（reusable-ci.yml、karuta設定反映）
 
+<details>
+<summary>ソースを表示（mermaid記法）</summary>
+
 ```mermaid
 graph TD
     commitlint["commitlint"]
@@ -36,7 +39,16 @@ graph TD
     render-mermaid-diagrams --> merge
 ```
 
+上記の```mermaid```ブロックはPR差分ビュー・API経由でのファイル取得等ではテキストのまま表示され図として確認できない（[#824](https://github.com/bamiyanapp/karuta/issues/824)）。ソースはこのまま維持しつつ、下記は`enable_mermaid_render` job（[docs/cicd-pipeline-specification.md](../cicd-pipeline-specification.md)参照）が`main`へのマージのたびに再レンダリングし、`docs-diagrams`ブランチの`latest/`へ上書き公開している画像（常に最新版）。
+
+</details>
+
+![CIワークフロー構成図 (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/cicd-architecture-1.png)
+
 ## CDワークフロー（karuta cd.yml）
+
+<details>
+<summary>ソースを表示（mermaid記法）</summary>
 
 ```mermaid
 graph TD
@@ -47,3 +59,9 @@ graph TD
     release --> build-and-deploy-frontend
     release --> deploy-backend
 ```
+
+上記の```mermaid```ブロックはPR差分ビュー・API経由でのファイル取得等ではテキストのまま表示され図として確認できない（[#824](https://github.com/bamiyanapp/karuta/issues/824)）。ソースはこのまま維持しつつ、下記は`enable_mermaid_render` job（[docs/cicd-pipeline-specification.md](../cicd-pipeline-specification.md)参照）が`main`へのマージのたびに再レンダリングし、`docs-diagrams`ブランチの`latest/`へ上書き公開している画像（常に最新版）。
+
+</details>
+
+![CDワークフロー構成図 (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/cicd-architecture-2.png)

--- a/docs/generated/dynamodb-tables.md
+++ b/docs/generated/dynamodb-tables.md
@@ -35,6 +35,9 @@ ORM（Prisma/TypeORM等）は使わずAWS SDKを直接呼び出す構成のた�
 
 ## 属性一覧（ER図）
 
+<details>
+<summary>ソースを表示（mermaid記法）</summary>
+
 ```mermaid
 erDiagram
     "karuta-comments" {
@@ -55,5 +58,11 @@ erDiagram
         string roomId PK
     }
 ```
+
+上記の```mermaid```ブロックはPR差分ビュー・API経由でのファイル取得等ではテキストのまま表示され図として確認できない（[#824](https://github.com/bamiyanapp/karuta/issues/824)）。ソースはこのまま維持しつつ、下記は`enable_mermaid_render` job（[docs/cicd-pipeline-specification.md](../cicd-pipeline-specification.md)参照）が`main`へのマージのたびに再レンダリングし、`docs-diagrams`ブランチの`latest/`へ上書き公開している画像（常に最新版）。
+
+</details>
+
+![DynamoDBテーブル ER図 (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/dynamodb-tables.png)
 
 テーブル間に外部キー制約は無いが、アプリケーションコード上は`roomId`が`karuta-quiz-rooms`と`karuta-quiz-room-connections`（GSI `roomId-index`）をまたいで使われており、緩やかな関連を持つ（図には正式なリレーションとして描画しない）。

--- a/docs/generated/dynamodb-tables.md
+++ b/docs/generated/dynamodb-tables.md
@@ -45,7 +45,7 @@ erDiagram
     }
     "karuta-phrases" {
         string category PK
-        string id SK
+        string id "ソートキー"
     }
     "karuta-polly-cache" {
         string id PK

--- a/docs/generated/serverless-architecture.md
+++ b/docs/generated/serverless-architecture.md
@@ -4,6 +4,9 @@
 
 関数からリソースへの依存関係は、関数コード内の`process.env.<変数名>`参照を静的に検出して導出している（AIによる意味解釈ではなく正規表現ベース）。エクスポートされた関数が直接、または1階層のヘルパー関数（`関数名(...)`という直接呼び出し構文）経由で参照している場合のみ検出でき、`array.map(helperFn)`のような関数の参照渡しは検出できない既知の制約がある。
 
+<details>
+<summary>ソースを表示（mermaid記法）</summary>
+
 ```mermaid
 graph LR
     Client[フロントエンド]
@@ -90,3 +93,9 @@ graph LR
     getCongratulationAudio --> Polly
     generateEfudaPdf -->|非同期Invoke| renderEfudaPdfWorker
 ```
+
+上記の```mermaid```ブロックはPR差分ビュー・API経由でのファイル取得等ではテキストのまま表示され図として確認できない（[#824](https://github.com/bamiyanapp/karuta/issues/824)）。ソースはこのまま維持しつつ、下記は`enable_mermaid_render` job（[docs/cicd-pipeline-specification.md](../cicd-pipeline-specification.md)参照）が`main`へのマージのたびに再レンダリングし、`docs-diagrams`ブランチの`latest/`へ上書き公開している画像（常に最新版）。
+
+</details>
+
+![サーバレス構成図 (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/serverless-architecture.png)

--- a/docs/generated/serverless-architecture.md
+++ b/docs/generated/serverless-architecture.md
@@ -35,12 +35,12 @@ graph LR
     judgeQuizRoomBuzz["judgeQuizRoomBuzz"]
     resetQuizRoomPoints["resetQuizRoomPoints"]
     closeQuizRoom["closeQuizRoom"]
-    table_karuta_phrases[(karuta-phrases<br/>(DynamoDB))]
-    table_karuta_comments[(karuta-comments<br/>(DynamoDB))]
-    table_karuta_polly_cache[(karuta-polly-cache<br/>(DynamoDB))]
-    table_karuta_quiz_rooms[(karuta-quiz-rooms<br/>(DynamoDB))]
-    table_karuta_quiz_room_connections[(karuta-quiz-room-connections<br/>(DynamoDB))]
-    bucket_karuta_efuda_pdf___aws_accountId_[(karuta-efuda-pdf-${aws:accountId}<br/>(S3))]
+    table_karuta_phrases[(karuta-phrases<br/>DynamoDB)]
+    table_karuta_comments[(karuta-comments<br/>DynamoDB)]
+    table_karuta_polly_cache[(karuta-polly-cache<br/>DynamoDB)]
+    table_karuta_quiz_rooms[(karuta-quiz-rooms<br/>DynamoDB)]
+    table_karuta_quiz_room_connections[(karuta-quiz-room-connections<br/>DynamoDB)]
+    bucket_karuta_efuda_pdf___aws_accountId_[(karuta-efuda-pdf-ACCOUNTID<br/>S3)]
 
     Client -->|HTTP| APIGW
     Client -->|WebSocket| WSGW

--- a/docs/generated/websocket-api.md
+++ b/docs/generated/websocket-api.md
@@ -20,6 +20,9 @@
 
 実行権限・ブロードキャスト有無は静的解析（`withRoleGuard`/`broadcastToRoom`呼び出しの検出）で機械的に抽出しているが、下記の呼び出し順序自体はコードの意味的な理解に基づき構成したもので、厳密な自動生成ではない点に留意する。
 
+<details>
+<summary>ソースを表示（mermaid記法）</summary>
+
 ```mermaid
 sequenceDiagram
     participant Admin as クライアント（管理者）
@@ -54,3 +57,9 @@ sequenceDiagram
     GW--)L: disconnectQuizRoom
     L->>Room: participants（ブロードキャスト）
 ```
+
+上記の```mermaid```ブロックはPR差分ビュー・API経由でのファイル取得等ではテキストのまま表示され図として確認できない（[#824](https://github.com/bamiyanapp/karuta/issues/824)）。ソースはこのまま維持しつつ、下記は`enable_mermaid_render` job（[docs/cicd-pipeline-specification.md](../cicd-pipeline-specification.md)参照）が`main`へのマージのたびに再レンダリングし、`docs-diagrams`ブランチの`latest/`へ上書き公開している画像（常に最新版）。
+
+</details>
+
+![WebSocket API 通信フロー (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/websocket-api.png)

--- a/docs/generated/websocket-api.md
+++ b/docs/generated/websocket-api.md
@@ -26,22 +26,22 @@
 ```mermaid
 sequenceDiagram
     participant Admin as クライアント（管理者）
-    participant Participant as クライアント（参加者）
+    participant Player as クライアント（参加者）
     participant GW as API Gateway (WebSocket)
     participant L as Lambda（quizRoomHandler）
     participant Room as ルーム内の全接続
 
     Admin->>GW: $connect（roomId・adminToken）
     GW->>L: connectQuizRoom
-    Participant->>GW: $connect（roomId）
+    Player->>GW: $connect（roomId）
     GW->>L: connectQuizRoom
-    Participant->>L: sync
-    L-->>Participant: 現在の状態（sync）
-    Participant->>L: setName
+    Player->>L: sync
+    L-->>Player: 現在の状態（sync）
+    Player->>L: setName
     L->>Room: participants（ブロードキャスト）
     Admin->>L: updateState（読み札の表示等）
     L->>Room: state（ブロードキャスト）
-    Participant->>L: buzz
+    Player->>L: buzz
     L->>Room: buzz（ブロードキャスト）
     Admin->>L: judgeBuzz
     alt 正解
@@ -53,7 +53,7 @@ sequenceDiagram
     L->>Room: points（リセット後、ブロードキャスト）
     Admin->>L: closeRoom
     L->>Room: roomClosed（ブロードキャスト）
-    Participant--)GW: $disconnect
+    Player--)GW: $disconnect
     GW--)L: disconnectQuizRoom
     L->>Room: participants（ブロードキャスト）
 ```

--- a/scripts/docs/generate-cicd-architecture.js
+++ b/scripts/docs/generate-cicd-architecture.js
@@ -4,6 +4,7 @@
 const fs = require("fs");
 const path = require("path");
 const yaml = require("js-yaml");
+const { renderMermaidWithEmbed } = require("./mermaid-embed");
 
 const repoRoot = path.resolve(__dirname, "..", "..");
 const reusableCiPath = path.join(repoRoot, "dev-standards", ".github", "workflows", "reusable-ci.yml");
@@ -77,40 +78,50 @@ function isJobEnabledForKaruta(job, karutaCiInputs) {
   });
 }
 
+// このファイルにはCI/CD 2つのMermaidブロックが含まれる。render-mermaid.jsの命名規則
+// （1ファイル内に複数ブロックがある場合`<basename>-<出現順の連番>.png`になる）に
+// 合わせ、このCIグラフが1番目（cicd-architecture-1.png）になる
 function renderCiGraph(jobs, karutaCiInputs) {
-  let body = "```mermaid\ngraph TD\n";
+  let mermaidSource = "graph TD\n";
   for (const job of jobs) {
     const enabled = isJobEnabledForKaruta(job, karutaCiInputs);
     const label = enabled ? job.name : `${job.name}（karutaでは無効/スキップ）`;
-    body += `    ${job.name}["${label}"]\n`;
+    mermaidSource += `    ${job.name}["${label}"]\n`;
     if (!enabled) {
-      body += `    style ${job.name} stroke-dasharray: 5 5\n`;
+      mermaidSource += `    style ${job.name} stroke-dasharray: 5 5\n`;
     }
   }
-  body += "\n";
+  mermaidSource += "\n";
   for (const job of jobs) {
     for (const need of job.needs) {
-      body += `    ${need} --> ${job.name}\n`;
+      mermaidSource += `    ${need} --> ${job.name}\n`;
     }
   }
-  body += "```\n";
-  return body;
+  return renderMermaidWithEmbed({
+    mermaidSource,
+    imageFileName: "cicd-architecture-1.png",
+    altText: "CIワークフロー構成図 (rendered)",
+  });
 }
 
+// CDグラフはファイル内2番目のMermaidブロック（cicd-architecture-2.png）になる
 function renderCdGraph(cdWorkflow) {
   const jobs = extractJobs(cdWorkflow);
-  let body = "```mermaid\ngraph TD\n";
+  let mermaidSource = "graph TD\n";
   for (const job of jobs) {
-    body += `    ${job.name}["${job.name}"]\n`;
+    mermaidSource += `    ${job.name}["${job.name}"]\n`;
   }
-  body += "\n";
+  mermaidSource += "\n";
   for (const job of jobs) {
     for (const need of job.needs) {
-      body += `    ${need} --> ${job.name}\n`;
+      mermaidSource += `    ${need} --> ${job.name}\n`;
     }
   }
-  body += "```\n";
-  return body;
+  return renderMermaidWithEmbed({
+    mermaidSource,
+    imageFileName: "cicd-architecture-2.png",
+    altText: "CDワークフロー構成図 (rendered)",
+  });
 }
 
 function main() {

--- a/scripts/docs/generate-dynamodb-tables.js
+++ b/scripts/docs/generate-dynamodb-tables.js
@@ -52,8 +52,17 @@ function renderErDiagram(tables) {
       }
       const type = ATTRIBUTE_TYPE_LABEL[attr.type] || "string";
       const keyType = keyTypeByAttribute.get(attr.attribute);
-      const keyLabel = keyType === "HASH" ? "PK" : keyType === "RANGE" ? "SK" : "";
-      mermaidSource += `        ${type} ${attr.attribute} ${keyLabel}\n`;
+      // MermaidのerDiagramが認識するキー種別はPK/FK/UKのみで、DynamoDBの
+      // ソートキー（RANGE）に対応する"SK"は無効なトークンとしてパースエラーに
+      // なる（実際にrender-mermaid-diagrams jobで発生）。ソートキーはPK/FK/UKの
+      // いずれにも当たらないため、キー種別は付けずコメント注記のみで示す
+      const parts = [type, attr.attribute];
+      if (keyType === "HASH") {
+        parts.push("PK");
+      } else if (keyType === "RANGE") {
+        parts.push('"ソートキー"');
+      }
+      mermaidSource += `        ${parts.join(" ")}\n`;
     }
     for (const gsi of table.globalSecondaryIndexes) {
       for (const k of gsi.keySchema) {

--- a/scripts/docs/generate-dynamodb-tables.js
+++ b/scripts/docs/generate-dynamodb-tables.js
@@ -4,6 +4,7 @@
 const fs = require("fs");
 const path = require("path");
 const { loadServerlessConfig, extractDynamoDbTables } = require("./serverless-yaml");
+const { renderMermaidWithEmbed } = require("./mermaid-embed");
 
 const repoRoot = path.resolve(__dirname, "..", "..");
 const serverlessPath = path.join(repoRoot, "backend", "serverless.yml");
@@ -36,9 +37,9 @@ const ATTRIBUTE_TYPE_LABEL = { S: "string", N: "number", B: "binary" };
 // 属性一覧（パーティションキー/ソートキー/GSIキー）のみをエンティティとして図示する。
 // アプリケーションコード上の緩やかな関連（roomId等）は図ではなく後続の文章で補足する。
 function renderErDiagram(tables) {
-  let body = "```mermaid\nerDiagram\n";
+  let mermaidSource = "erDiagram\n";
   for (const table of tables) {
-    body += `    "${table.tableName}" {\n`;
+    mermaidSource += `    "${table.tableName}" {\n`;
     const keyTypeByAttribute = new Map(table.keySchema.map((k) => [k.attribute, k.keyType]));
     const gsiAttributeNames = new Set(
       table.globalSecondaryIndexes.flatMap((gsi) => gsi.keySchema.map((k) => k.attribute))
@@ -52,17 +53,20 @@ function renderErDiagram(tables) {
       const type = ATTRIBUTE_TYPE_LABEL[attr.type] || "string";
       const keyType = keyTypeByAttribute.get(attr.attribute);
       const keyLabel = keyType === "HASH" ? "PK" : keyType === "RANGE" ? "SK" : "";
-      body += `        ${type} ${attr.attribute} ${keyLabel}\n`;
+      mermaidSource += `        ${type} ${attr.attribute} ${keyLabel}\n`;
     }
     for (const gsi of table.globalSecondaryIndexes) {
       for (const k of gsi.keySchema) {
-        body += `        string ${k.attribute} "GSI: ${gsi.indexName}"\n`;
+        mermaidSource += `        string ${k.attribute} "GSI: ${gsi.indexName}"\n`;
       }
     }
-    body += "    }\n";
+    mermaidSource += "    }\n";
   }
-  body += "```\n";
-  return body;
+  return renderMermaidWithEmbed({
+    mermaidSource,
+    imageFileName: "dynamodb-tables.png",
+    altText: "DynamoDBテーブル ER図 (rendered)",
+  });
 }
 
 function renderMarkdown(tables) {

--- a/scripts/docs/generate-serverless-architecture.js
+++ b/scripts/docs/generate-serverless-architecture.js
@@ -14,6 +14,7 @@ const {
   extractProviderEnvironment,
 } = require("./serverless-yaml");
 const { splitExportsIntoBlocks, splitNamedFunctionsIntoBlocks } = require("./handler-blocks");
+const { renderMermaidWithEmbed } = require("./mermaid-embed");
 
 const repoRoot = path.resolve(__dirname, "..", "..");
 const serverlessPath = path.join(repoRoot, "backend", "serverless.yml");
@@ -188,48 +189,54 @@ function renderMarkdown({
     "エクスポートされた関数が直接、または1階層のヘルパー関数（`関数名(...)`という" +
     "直接呼び出し構文）経由で参照している場合のみ検出でき、`array.map(helperFn)`の" +
     "ような関数の参照渡しは検出できない既知の制約がある。\n\n";
-  body += "```mermaid\ngraph LR\n";
-  body += "    Client[フロントエンド]\n";
-  body += "    APIGW[API Gateway<br/>HTTP API]\n";
-  body += "    WSGW[API Gateway<br/>WebSocket API]\n";
-  body += "    Polly[(AWS Polly)]\n";
+
+  let mermaidSource = "graph LR\n";
+  mermaidSource += "    Client[フロントエンド]\n";
+  mermaidSource += "    APIGW[API Gateway<br/>HTTP API]\n";
+  mermaidSource += "    WSGW[API Gateway<br/>WebSocket API]\n";
+  mermaidSource += "    Polly[(AWS Polly)]\n";
 
   const httpFunctionNames = new Set(httpRoutes.map((r) => r.functionName));
   const websocketFunctionNames = new Set(websocketRoutes.map((r) => r.functionName));
 
   for (const functionName of functionNames) {
-    body += `    ${functionName}["${functionName}"]\n`;
+    mermaidSource += `    ${functionName}["${functionName}"]\n`;
   }
   for (const [, node] of resourceNodeByEnvValue) {
-    body += `    ${node.id}[(${node.label})]\n`;
+    mermaidSource += `    ${node.id}[(${node.label})]\n`;
   }
 
-  body += "\n";
+  mermaidSource += "\n";
   if (httpFunctionNames.size > 0) {
-    body += "    Client -->|HTTP| APIGW\n";
+    mermaidSource += "    Client -->|HTTP| APIGW\n";
   }
   if (websocketFunctionNames.size > 0) {
-    body += "    Client -->|WebSocket| WSGW\n";
+    mermaidSource += "    Client -->|WebSocket| WSGW\n";
   }
   for (const functionName of functionNames) {
     if (httpFunctionNames.has(functionName)) {
-      body += `    APIGW --> ${functionName}\n`;
+      mermaidSource += `    APIGW --> ${functionName}\n`;
     }
     if (websocketFunctionNames.has(functionName)) {
-      body += `    WSGW --> ${functionName}\n`;
+      mermaidSource += `    WSGW --> ${functionName}\n`;
     }
   }
   for (const edge of edges) {
     const node = resourceNodeByEnvValue.get(edge.to);
-    body += `    ${edge.from} --> ${node.id}\n`;
+    mermaidSource += `    ${edge.from} --> ${node.id}\n`;
   }
   for (const functionName of usesPollyByFunction) {
-    body += `    ${functionName} --> Polly\n`;
+    mermaidSource += `    ${functionName} --> Polly\n`;
   }
   for (const invoke of functionToFunctionInvokes) {
-    body += `    ${invoke.from} -->|非同期Invoke| ${invoke.to}\n`;
+    mermaidSource += `    ${invoke.from} -->|非同期Invoke| ${invoke.to}\n`;
   }
-  body += "```\n";
+
+  body += renderMermaidWithEmbed({
+    mermaidSource,
+    imageFileName: "serverless-architecture.png",
+    altText: "サーバレス構成図 (rendered)",
+  });
   return body;
 }
 

--- a/scripts/docs/generate-serverless-architecture.js
+++ b/scripts/docs/generate-serverless-architecture.js
@@ -66,13 +66,27 @@ function collectEnvVarNames(functionBlock, calledHelperBlocks) {
   return [...new Set([...text.matchAll(/process\.env\.(\w+)/g)].map((m) => m[1]))];
 }
 
+// バケット名の`${aws:accountId}`（CloudFormation/Serverless Frameworkの疑似変数、
+// デプロイ時にしか実値が決まらないため静的には解決できない）を、`$`・`{`・`}`・`:`を
+// 含まない安全な表示用プレースホルダーに置き換える。これらの記号はノードラベル内で
+// Mermaidのパースエラーを引き起こす（実際にrender-mermaid-diagrams jobで発生）
+function sanitizeLabelText(text) {
+  return text.replace(/\$\{aws:accountId\}/g, "ACCOUNTID");
+}
+
 function buildResourceNodesByEnvValue(tables, buckets) {
   const map = new Map();
+  // ノードラベル中に丸括弧を含めると、シリンダー形状`[(...)]`の開始/終了記号と
+  // 衝突してパースエラーになる（実際にrender-mermaid-diagrams jobで発生）ため、
+  // 括弧を使わずラベルを組み立てる
   for (const table of tables) {
-    map.set(table.tableName, { id: `table_${sanitizeId(table.tableName)}`, label: `${table.tableName}<br/>(DynamoDB)` });
+    map.set(table.tableName, { id: `table_${sanitizeId(table.tableName)}`, label: `${table.tableName}<br/>DynamoDB` });
   }
   for (const bucket of buckets) {
-    map.set(bucket.bucketName, { id: `bucket_${sanitizeId(bucket.bucketName)}`, label: `${bucket.bucketName}<br/>(S3)` });
+    map.set(bucket.bucketName, {
+      id: `bucket_${sanitizeId(bucket.bucketName)}`,
+      label: `${sanitizeLabelText(bucket.bucketName)}<br/>S3`,
+    });
   }
   return map;
 }

--- a/scripts/docs/generate-websocket-api.js
+++ b/scripts/docs/generate-websocket-api.js
@@ -5,6 +5,7 @@ const fs = require("fs");
 const path = require("path");
 const { loadServerlessConfig, extractWebsocketRoutes } = require("./serverless-yaml");
 const { extractHandlerBehavior } = require("./handler-behavior");
+const { renderMermaidWithEmbed } = require("./mermaid-embed");
 
 const repoRoot = path.resolve(__dirname, "..", "..");
 const serverlessPath = path.join(repoRoot, "backend", "serverless.yml");
@@ -31,8 +32,7 @@ function renderTable(routes, behavior) {
 // 読解に基づき手動で構成した（issue #902のコメントで留意点として明記済み）。
 // ルート名・型自体が変わった場合はこのテンプレートも追従して更新が必要になる。
 function renderSequenceDiagram() {
-  return `\`\`\`mermaid
-sequenceDiagram
+  const mermaidSource = `sequenceDiagram
     participant Admin as クライアント（管理者）
     participant Participant as クライアント（参加者）
     participant GW as API Gateway (WebSocket)
@@ -63,9 +63,12 @@ sequenceDiagram
     L->>Room: roomClosed（ブロードキャスト）
     Participant--)GW: $disconnect
     GW--)L: disconnectQuizRoom
-    L->>Room: participants（ブロードキャスト）
-\`\`\`
-`;
+    L->>Room: participants（ブロードキャスト）`;
+  return renderMermaidWithEmbed({
+    mermaidSource,
+    imageFileName: "websocket-api.png",
+    altText: "WebSocket API 通信フロー (rendered)",
+  });
 }
 
 function renderMarkdown(routes, behavior) {

--- a/scripts/docs/generate-websocket-api.js
+++ b/scripts/docs/generate-websocket-api.js
@@ -32,24 +32,28 @@ function renderTable(routes, behavior) {
 // 読解に基づき手動で構成した（issue #902のコメントで留意点として明記済み）。
 // ルート名・型自体が変わった場合はこのテンプレートも追従して更新が必要になる。
 function renderSequenceDiagram() {
+  // 別名"Participant"はMermaidのsequenceDiagram構文における予約語"participant"と
+  // 衝突し、`Participant->>...`のようなメッセージ行がパースエラーになるため
+  // （実際にrender-mermaid-diagrams jobで"Expecting 'ACTOR', got 'INVALID'"エラーが
+  // 発生した）、予約語と衝突しない別名"Player"を使う
   const mermaidSource = `sequenceDiagram
     participant Admin as クライアント（管理者）
-    participant Participant as クライアント（参加者）
+    participant Player as クライアント（参加者）
     participant GW as API Gateway (WebSocket)
     participant L as Lambda（quizRoomHandler）
     participant Room as ルーム内の全接続
 
     Admin->>GW: $connect（roomId・adminToken）
     GW->>L: connectQuizRoom
-    Participant->>GW: $connect（roomId）
+    Player->>GW: $connect（roomId）
     GW->>L: connectQuizRoom
-    Participant->>L: sync
-    L-->>Participant: 現在の状態（sync）
-    Participant->>L: setName
+    Player->>L: sync
+    L-->>Player: 現在の状態（sync）
+    Player->>L: setName
     L->>Room: participants（ブロードキャスト）
     Admin->>L: updateState（読み札の表示等）
     L->>Room: state（ブロードキャスト）
-    Participant->>L: buzz
+    Player->>L: buzz
     L->>Room: buzz（ブロードキャスト）
     Admin->>L: judgeBuzz
     alt 正解
@@ -61,7 +65,7 @@ function renderSequenceDiagram() {
     L->>Room: points（リセット後、ブロードキャスト）
     Admin->>L: closeRoom
     L->>Room: roomClosed（ブロードキャスト）
-    Participant--)GW: $disconnect
+    Player--)GW: $disconnect
     GW--)L: disconnectQuizRoom
     L->>Room: participants（ブロードキャスト）`;
   return renderMermaidWithEmbed({

--- a/scripts/docs/mermaid-embed.js
+++ b/scripts/docs/mermaid-embed.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const REPO = "bamiyanapp/karuta";
+
+// dev-standardsのenable_mermaid_render機構（issue #824/#837）が生成する事前レンダリング
+// 画像を埋め込む共通ヘルパー。```mermaid```ブロックはPR差分ビュー・API経由でのファイル
+// 取得等ではテキストのまま表示され図として確認できないため、<details>で折りたたんだ
+// ソースの下に、`main`へのマージのたびに再レンダリングされる画像
+// （docs-diagramsブランチのlatest/配下）を恒久的に埋め込む。README.mdの既存の
+// 埋め込みパターン（System Architecture節等）と同じ構成にする。
+//
+// imageFileNameは、対象Markdownファイル内のmermaidブロックの出現順・総数から決まる
+// （render-mermaid.jsの命名規則: `<basename>.png`。ブロックが複数ある場合のみ
+// `<basename>-<出現順の連番、1始まり>.png`になる）。呼び出し側が自分の生成する
+// ファイルに含まれるブロック数を把握しているため、ここでは名前をそのまま受け取る。
+function renderMermaidWithEmbed({ mermaidSource, imageFileName, altText }) {
+  let body = "<details>\n<summary>ソースを表示（mermaid記法）</summary>\n\n";
+  body += "```mermaid\n" + mermaidSource.trimEnd() + "\n```\n\n";
+  body +=
+    "上記の```mermaid```ブロックはPR差分ビュー・API経由でのファイル取得等ではテキストの" +
+    "まま表示され図として確認できない（[#824](https://github.com/bamiyanapp/karuta/issues/824)）。" +
+    "ソースはこのまま維持しつつ、下記は`enable_mermaid_render` job" +
+    "（[docs/cicd-pipeline-specification.md](../cicd-pipeline-specification.md)参照）が" +
+    "`main`へのマージのたびに再レンダリングし、`docs-diagrams`ブランチの`latest/`へ" +
+    "上書き公開している画像（常に最新版）。\n\n";
+  body += "</details>\n\n";
+  body += `![${altText}](https://raw.githubusercontent.com/${REPO}/docs-diagrams/latest/${imageFileName})\n`;
+  return body;
+}
+
+module.exports = { renderMermaidWithEmbed };


### PR DESCRIPTION
## Summary
- `docs/generated/`配下のMermaid図を含む4ファイル（websocket-api.md・dynamodb-tables.md・serverless-architecture.md・cicd-architecture.md）に、README.mdの既存パターン（issue #824/#837）と同じ`<details>`折りたたみ＋事前レンダリング画像の恒久埋め込みを適用
- 共通ロジックを`scripts/docs/mermaid-embed.js`に切り出し、4つの生成スクリプトから共通利用
- karutaの`ci.yml`の`mermaid_doc_paths`にこの4ファイルを追加し、`enable_mermaid_render` jobの対象にした

## 背景

生成した```mermaid```ブロックがGitHubのPR差分ビュー・API経由のファイル取得等ではテキストのまま表示され図として確認できず、既存の仕組み（`enable_mermaid_render`、mmdcによるPNG事前レンダリング）を活用できていなかった。

## 注意事項

該当4ファイルは今回初めて`mermaid_doc_paths`の対象になるため、マージ後の`main`へのpushで`render-mermaid-diagrams` jobが実行されて初めて`docs-diagrams`ブランチの`latest/`へ画像が公開される。マージ直後は埋め込んだ画像リンクが一時的に404になる（README.md等の既存ファイルと同じ運用パターン）。マージ後、実際に画像が公開・表示されることを別途確認する。

## Test plan
- [x] `npm run docs:generate`を実行し、4ファイル全てに正しいファイル名（`cicd-architecture.md`のみ2ブロックのため`-1`/`-2`連番）で画像埋め込みが生成されることを確認
- [x] frontend `npm run lint` エラー0件
- [x] backend `npm run lint` エラー0件
- [x] frontend/backend既存テストが全て通過（frontend 252件、backend 1543件。アプリケーションコードの変更はなし）


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_