### PR TITLE
feat(ci): ドキュメント重複排除とCI/CD共通化・高速化をまとめて反映

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,40 +62,23 @@ jobs:
         with:
           ref: ${{ github.sha }} # CDをトリガーしたコミットを確実にデプロイする
           fetch-depth: 0
-      - name: Set up Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 22 # backend Lambdaランタイムnodejs22.x・CI（issue #610）と統一する
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
-      # npm workspaces構成（issue #608）。個々のパッケージにlockfileが無くなった
-      # ため、リポジトリルートで一括インストールする（`.npmrc`のinstall-strategy=
-      # nestedにより、backend/node_modules配下に実行時依存が完全な形で
-      # 展開されるため、後段のserverless packagingへの影響は無い）
-      - name: Install dependencies
-        run: npm ci
       - name: 🚀 Deploy Backend (osls, Serverless Framework v3 OSS fork)
-        working-directory: backend
         # npm workspaces移行（issue #608）で`install-strategy=nested`にした結果、
         # 各Lambda関数のzip作成（package.individually: true、11関数）が同一の
         # node_modules配下を関数ごとに繰り返し走査するようになり、GitHub Actions
         # ランナーのデフォルトのファイルディスクリプタ上限（1024）を超えて
-        # `EMFILE: too many open files`でデプロイが失敗することを確認した
-        # （issue #608のPR #654マージ後の初回デプロイで実際に発生）。
-        # ソフトリミットを65536へ引き上げる対応（PR #663）を行ったが、
-        # それでも別のパッケージ（@aws-sdk/s3-request-presigner配下の
-        # @smithy/core）でEMFILEが再発した（PR #663マージ後の実際のCD実行）。
-        # 65536でも足りないほどファイル数が多いため、ソフトリミットを
-        # ハードリミットまで引き上げる（実際の上限値はランナーによって
-        # 異なるためログへ出力し、以降の障害調査で参照できるようにする）
-        run: |
-          echo "file descriptor limits: soft=$(ulimit -Sn) hard=$(ulimit -Hn)"
-          ulimit -n "$(ulimit -Hn)"
-          echo "file descriptor limit after adjustment: $(ulimit -n)"
-          npx osls deploy
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        # `EMFILE: too many open files`でデプロイが失敗する問題（issue #608のPR #654
+        # マージ後の初回デプロイで実際に発生、#663でも別パッケージで再発）への対策
+        # （ファイルディスクリプタ上限のハードリミットまでの引き上げ）を含め、
+        # dev-standardsの共通複合action化した（bamiyanapp/dev-standards#147）
+        uses: bamiyanapp/dev-standards/.github/actions/deploy-serverless@v1.15.1
+        with:
+          working-directory: backend
+          node-version: 22 # backend Lambdaランタイムnodejs22.x・CI（issue #610）と統一する
+          deploy-command: npx osls deploy
+          workspaces: true # npm workspaces構成（issue #608）。依存インストールをリポジトリルートで行う
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: 🌱 Seed Database
         working-directory: backend
         run: node seed.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ci:
-    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.20.0
+    uses: bamiyanapp/dev-standards/.github/workflows/reusable-ci.yml@v1.21.0
     with:
       frontend_dir: frontend
       backend_dir: backend

--- a/README.md
+++ b/README.md
@@ -43,35 +43,7 @@
 
 ### System Architecture
 
-<details>
-<summary>ソースを表示（mermaid記法）</summary>
-
-```mermaid
-graph TD
-    subgraph "Frontend (GitHub Pages)"
-        I[React + Vite]
-    end
-
-    subgraph "Backend (AWS)"
-        J[API Gateway REST] --> K[AWS Lambda];
-        K --> L[DynamoDB];
-        K --> M[Polly];
-        K --> N[S3<br/>絵札PDF];
-        N --> O[renderEfudaPdfWorker<br/>Headless Chromium];
-
-        P[API Gateway WebSocket] --> Q[quizRoomHandler];
-        Q --> R[DynamoDB<br/>ルーム・接続];
-    end
-
-    I --> J;
-    I -->|クイズ大会モード| P;
-```
-
-上記の```mermaid```ブロックはPR差分ビュー・API経由でのファイル取得等ではテキストのまま表示され図として確認できない（[#824](https://github.com/bamiyanapp/karuta/issues/824)）。ソースはこのまま維持しつつ、下記は`enable_mermaid_render` job（[docs/cicd-pipeline-specification.md](./docs/cicd-pipeline-specification.md)参照）が`main`へのマージのたびに再レンダリングし、`docs-diagrams`ブランチの`latest/`へ上書き公開している画像（常に最新版）。
-
-</details>
-
-![System Architecture (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/README-1.png)
+`backend/serverless.yml`の実際の定義から自動生成されるサーバレス構成図（関数単位のリソース依存関係、issue #919）を参照: [docs/generated/serverless-architecture.md](docs/generated/serverless-architecture.md)
 
 ### Screen Transitions
 
@@ -128,104 +100,19 @@ graph TD
 
 </details>
 
-![Screen Transitions (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/README-2.png)
+![Screen Transitions (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/README.png)
 
 ### Backend API (AWS Lambda)
 
-| 関数名 | パス | メソッド | 説明 |
-| :--- | :--- | :--- | :--- |
-| getCategories | `/get-categories` | GET | 登録されているカテゴリの一覧を取得する。 |
-| getPhrasesList | `/get-phrases-list` | GET | 指定したカテゴリ（または全カテゴリ）のフレーズ一覧を取得する。 |
-| getPhrase | `/get-phrase` | GET | 指定したIDまたはランダムなフレーズを取得し、Pollyで音声を生成（またはキャッシュから取得）して返す。 |
-| getCongratulationAudio | `/get-congratulation-audio` | GET | 全フレーズ終了時のお祝いメッセージ音声を生成して返す。 |
-| recordTime | `/record-time` | POST | 読み上げに対する回答時間と難易度を記録し、統計情報を更新する。 |
-| postComment | `/post-comment` | POST | フレーズに対して新しいコメントを投稿する。 |
-| getComments | `/get-comments` | GET | 全てのコメントを取得し、新着順にソートして返す。 |
-| generateEfudaPdf | `/generate-efuda-pdf` | POST | 絵札印刷用PDFの生成ジョブを非同期で開始する（`renderEfudaPdfWorker`がヘッドレスChromiumでレンダリングし、S3へ保存）。 |
-| getEfudaPdfStatus | `/generate-efuda-pdf-status` | GET | PDF生成ジョブの完了状況をS3上のオブジェクトの有無から確認する。 |
-| createQuizRoom | `/quiz-room` | POST | クイズ大会モードの管理者用ルームを新規作成し、ルームコードと管理者トークンを返す。 |
-| checkQuizRoom | `/quiz-room` | GET | 参加者がWebSocket接続を試みる前に、ルームコードの存在を軽量に確認する。 |
-| listQuizRooms | `/quiz-rooms` | GET | 開設中（失効しておらず管理者接続が存在する）のクイズ大会ルームを一覧で返す。 |
+`backend/serverless.yml`のhttpApiイベント定義から自動生成されるBackend API仕様書（issue #919）を参照: [docs/generated/backend-api.md](docs/generated/backend-api.md)
 
 ### WebSocket API（クイズ大会モード）
 
-読み札・結果画面の同期や早押し判定など、クイズ大会モードのリアルタイム通信はAPI Gateway WebSocket API（`quizRoomHandler.js`）で行う。
-
-| ルート | 関数名 | 説明 |
-| :--- | :--- | :--- |
-| `$connect` | connectQuizRoom | ルームコード・管理者トークンをもとに管理者/参加者としての接続を確立する。 |
-| `$disconnect` | disconnectQuizRoom | 切断を記録し、残りの参加者へ更新後の参加者一覧をブロードキャストする。 |
-| `sync` | syncQuizRoom | 接続直後・再接続時に、現在のルーム状態（札・早押し・ポイント・参加者一覧）を呼び出し元へ返す。 |
-| `updateState` | updateQuizRoomState | 管理者のみ実行可能。表示中の札・結果をルーム内の全接続へブロードキャストする。 |
-| `setName` | setQuizRoomName | 参加者が表示名を登録する（同一ルーム内での名前重複は拒否する）。 |
-| `buzz` | buzzQuizRoom | 参加者の早押しを受け付ける（同一ラウンドで最初の1件のみ確定）。 |
-| `judgeBuzz` | judgeQuizRoomBuzz | 管理者のみ実行可能。早押しの正誤を判定し、正解ならポイントを加算する。 |
+読み札・結果画面の同期や早押し判定など、クイズ大会モードのリアルタイム通信はAPI Gateway WebSocket API（`quizRoomHandler.js`）で行う。ルート一覧・代表的な通信フローは自動生成されるWebSocket API仕様書（issue #919）を参照: [docs/generated/websocket-api.md](docs/generated/websocket-api.md)
 
 ### Database (DynamoDB)
 
-#### 1. karuta-phrases
-読み上げ用フレーズを格納するテーブル。
-
-| 属性名 | 型 | キー | 説明 |
-| :--- | :--- | :--- | :--- |
-| category | String | Partition Key | カテゴリ名 |
-| id | String | Sort Key | フレーズの一意識別子 |
-| group | String | - | 対象区分（`kids`: こども向け / `engineer`: エンジニア向け） |
-| phrase | String | - | 読み上げテキスト（日本語） |
-| phrase_en | String | - | 読み上げテキスト（英語） |
-| answer | String | - | 答え（取り札）のテキスト |
-| kana | String | - | フレーズの読み（かな） |
-| level | String/Number | - | 難易度レベル |
-| readCount | Number | - | 読み上げられた回数 |
-| averageTime | Number | - | 平均回答時間（秒） |
-| averageDifficulty | Number | - | ユーザーが選択した平均難易度 |
-
-#### 2. karuta-comments
-各フレーズに対するユーザーコメントを格納するテーブル。
-
-| 属性名 | 型 | キー | 説明 |
-| :--- | :--- | :--- | :--- |
-| id | String | Partition Key | コメントID (UUID) |
-| phraseId | String | - | 対象フレーズのID |
-| category | String | - | 対象フレーズのカテゴリ |
-| phrase | String | - | 対象フレーズのテキスト |
-| comment | String | - | コメント内容 |
-| createdAt | String | - | 作成日時 (ISO8601) |
-
-#### 3. karuta-polly-cache
-Amazon Polly で生成した音声データのキャッシュ。
-
-| 属性名 | 型 | キー | 説明 |
-| :--- | :--- | :--- | :--- |
-| id | String | Partition Key | キャッシュID (ハッシュ値) |
-| audioData | String | - | Base64形式の音声データ |
-| createdAt | String | - | 作成日時 (ISO8601) |
-
-#### 4. karuta-quiz-rooms
-クイズ大会モードのルーム情報を格納するテーブル。無人ルームが残り続けないよう、TTLによる自動削除の対象。
-
-| 属性名 | 型 | キー | 説明 |
-| :--- | :--- | :--- | :--- |
-| roomId | String | Partition Key | ルームコード（6文字） |
-| adminTokenHash | String | - | 管理者トークンのハッシュ値（平文はDBに保存しない） |
-| state | Map | - | 現在ブロードキャストされている札・結果等の状態 |
-| buzz | Map | - | 現在のラウンドで最初に早押しした参加者（未判定の間のみ存在） |
-| excludedNames | StringSet | - | 現在のラウンドで不正解と判定され、再度の早押しから除外された参加者名 |
-| points | Map | - | 参加者名 → 累計ポイントのマップ |
-| createdAt | Number | - | 作成日時（UNIXタイムスタンプ） |
-| ttl | Number | - | 有効期限（作成から24時間、TTLで自動削除） |
-
-#### 5. karuta-quiz-room-connections
-クイズ大会モードのWebSocket接続情報を格納するテーブル。`$disconnect`が確実に呼ばれない異常切断時の保険として、こちらもTTLによる自動削除の対象。
-
-| 属性名 | 型 | キー | 説明 |
-| :--- | :--- | :--- | :--- |
-| connectionId | String | Partition Key | WebSocket接続ID |
-| roomId | String | GSI（`roomId-index`） | 接続先のルームコード（ルーム内の全接続へのブロードキャストに使用） |
-| role | String | - | 接続の役割（`admin` / `participant`） |
-| name | String | - | 参加者の表示名（早押し機能で入室時に登録） |
-| connectedAt | Number | - | 接続日時（UNIXタイムスタンプ） |
-| ttl | Number | - | 有効期限（接続から24時間、TTLで自動削除） |
+`backend/serverless.yml`の`AWS::DynamoDB::Table`リソース定義から自動生成されるDynamoDBテーブル定義書（issue #919）を参照: [docs/generated/dynamodb-tables.md](docs/generated/dynamodb-tables.md)
 
 ## CI/CD Pipeline Specification
 

--- a/docs/cicd-pipeline-specification.md
+++ b/docs/cicd-pipeline-specification.md
@@ -60,8 +60,8 @@ E2Eテスト実行中に読み込まれたJS（フロントエンドのビルド
 
 `release` ジョブ（共通、dev-standards の `reusable-cd.yml`）の成功後、`needs.release.outputs.new_release_published == 'true'` の場合のみ以下を実行する。ジョブ構成・依存関係は[docs/generated/cicd-architecture.md](generated/cicd-architecture.md)の「CDワークフロー」を参照。
 
-- `build-and-deploy-frontend`: frontend をビルドし、GitHub Pages へデプロイ
-- `deploy-backend`: backend を Serverless Framework（CLIはSaaSサインイン不要なOSSフォーク[osls](https://github.com/oss-serverless/serverless)、issue #611）を使用して AWS Lambda へデプロイし、`seed.js` でシードを実行する
+- `build-and-deploy-frontend`: frontend をビルドし、GitHub Pages へデプロイ（dev-standardsの`deploy-github-pages`複合actionを利用）
+- `deploy-backend`: backend を Serverless Framework（CLIはSaaSサインイン不要なOSSフォーク[osls](https://github.com/oss-serverless/serverless)、issue #611）を使用して AWS Lambda へデプロイし、`seed.js` でシードを実行する。デプロイ本体（EMFILE対策のファイルディスクリプタ上限引き上げを含む）はdev-standardsの`deploy-serverless`複合action（[bamiyanapp/dev-standards#147](https://github.com/bamiyanapp/dev-standards/issues/147)）に共通化されている
 
 ## 環境変数（karuta固有）
 

--- a/docs/cicd-pipeline-specification.md
+++ b/docs/cicd-pipeline-specification.md
@@ -6,26 +6,7 @@
 
 ## Architecture
 
-<details>
-<summary>ソースを表示（mermaid記法）</summary>
-
-```mermaid
-graph TD
-    A[PR] --> B[CI Workflow];
-    B --> C[frontend-test / backend-test];
-    C -->|Success| D[merge job: mainへSquash merge];
-    D --> E[CD Workflow on main push];
-    E --> F[release job: main上でSemantic Release実行];
-    F --> G{新バージョンが発行されたか};
-    G --> H[Deploy Frontend to GitHub Pages];
-    G --> I[Deploy Backend to AWS];
-```
-
-上記の```mermaid```ブロックはPR差分ビュー・API経由でのファイル取得等ではテキストのまま表示され図として確認できない（[bamiyanapp/karuta#824](https://github.com/bamiyanapp/karuta/issues/824)）。ソース（mermaid記法）はこのまま維持しつつ、下記は`enable_mermaid_render` job（[dev-standards側ドキュメント](../dev-standards/docs/cicd-pipeline-specification.md#1-ci-ワークフロー-reusable-ciyml)参照）が`main`へのマージのたびに再レンダリングし、`docs-diagrams`ブランチの`latest/`へ上書き公開している画像（常に最新版）。
-
-</details>
-
-![Architecture (rendered)](https://raw.githubusercontent.com/bamiyanapp/karuta/docs-diagrams/latest/cicd-pipeline-specification.png)
+`reusable-ci.yml`/`cd.yml`のjob構成・依存関係は、実際のワークフロー定義から自動生成されるCI/CD構成図（issue #919）を参照: [docs/generated/cicd-architecture.md](generated/cicd-architecture.md)
 
 semantic-releaseの実行は`main`へのpush後（CD側の`release`ジョブ）で行われる。以前はPRの作業ブランチ上でマージ前に実行する方式だったが、GitHub Actionsの`pull_request`イベントで自動設定される`GITHUB_REF`（ワークフローYAMLの`env:`では上書き不可）により常にリリースが発行されない不具合があったため、`main`への実pushイベント上で実行する方式に修正した（[dev-standards#43](https://github.com/bamiyanapp/dev-standards/pull/43)）。
 
@@ -77,7 +58,7 @@ E2Eテスト実行中に読み込まれたJS（フロントエンドのビルド
 
 ## デプロイジョブ（`cd.yml` 固有）
 
-`release` ジョブ（共通、dev-standards の `reusable-cd.yml`）の成功後、`needs.release.outputs.new_release_published == 'true'` の場合のみ以下を実行する。
+`release` ジョブ（共通、dev-standards の `reusable-cd.yml`）の成功後、`needs.release.outputs.new_release_published == 'true'` の場合のみ以下を実行する。ジョブ構成・依存関係は[docs/generated/cicd-architecture.md](generated/cicd-architecture.md)の「CDワークフロー」を参照。
 
 - `build-and-deploy-frontend`: frontend をビルドし、GitHub Pages へデプロイ
 - `deploy-backend`: backend を Serverless Framework（CLIはSaaSサインイン不要なOSSフォーク[osls](https://github.com/oss-serverless/serverless)、issue #611）を使用して AWS Lambda へデプロイし、`seed.js` でシードを実行する


### PR DESCRIPTION
## Summary
- `README.md`の「System Architecture」「Backend API (AWS Lambda)」「WebSocket API（クイズ大会モード）」「Database (DynamoDB)」の手動Mermaid図・テーブルを、対応する`docs/generated/*.md`（自動生成、issue #901-#905）への参照リンクに置き換え
- `README.md`のMermaidブロックが「Screen Transitions」1つのみになったため、埋め込み画像リンクを`README-2.png`→`README.png`に修正
- `docs/cicd-pipeline-specification.md`の「Architecture」節の手動Mermaid図を`docs/generated/cicd-architecture.md`への参照に置き換え、「デプロイジョブ」節にも同ファイルのCDグラフへの参照を追記
- `deploy-backend`ジョブを、dev-standardsの共通複合action`deploy-serverless`（[bamiyanapp/dev-standards#147](https://github.com/bamiyanapp/dev-standards/issues/147)、v1.15.1でリリース済み）を使うよう切り替え（karuta#921対応）
- `ci.yml`が参照する`reusable-ci.yml`のpinned tagをv1.20.0→v1.21.0へ更新。CI全体のconcurrency設定（同一ref・同一PRで連続pushした場合に古いCI実行を自動キャンセルする、[bamiyanapp/dev-standards#187](https://github.com/bamiyanapp/dev-standards/issues/187)/[#188](https://github.com/bamiyanapp/dev-standards/pull/188)）が有効になる

## ⚠️ 自動マージについて

このPRは`.github/workflows/cd.yml`・`ci.yml`を変更するため、`ci / merge`ジョブがBOT_TOKENの`workflow`スコープ不足により403エラーで失敗し、**自動マージされない**（bamiyanapp/dev-standards#189で詳細記録）。品質チェック（frontend-test/backend-test/e2e/duplication-check/standards-check/render-mermaid-diagrams）が全てgreenであることを確認した上で、GitHubのWeb/モバイルアプリから手動でマージしてください。

## 背景

issue #900「ドキュメント自動生成の導入検討」のフォローアップ（issue #919、#921）。`docs/generated/`配下の自動生成ドキュメント導入後も、元々あった手動記載がREADME.md/cicd-pipeline-specification.mdにそのまま残っており、二重管理・追従漏れのリスクがあった。また、GitHub Pagesデプロイは既に`deploy-github-pages`共通actionを使っているのに対し、Serverless Frameworkデプロイ側は未共通化のままだったため、dev-standards側に切り出した複合actionへ切り替えた。

`docs/quiz-room-operations.md`は運用手順（実際の挙動・異常系対応）の記載であり、生成済みドキュメントと重複する構造的事実を含まないため、確認のうえ対象外とした。

## 残存部分の自動化検討（issue #919より）

`cicd-pipeline-specification.md`に残る内容（semantic-releaseフォールバックの経緯、E2Eテスト設計意図、`.gitignore`同期の注意点等）はほとんどが設計判断の背景説明であり、静的解析による自動生成には適さない。「有効化・無効化しているジョブ」テーブルの設定値と「環境変数」テーブルの変数名は静的解析で抽出可能だが、各テーブルの価値の大部分を占める「理由」列は人手が前提のため、値のみの自動生成は本PRのスコープ外とし、issue #919にフォローアップ候補として記録した。

## Test plan
- [x] 参照先の全`docs/generated/*.md`ファイルが実在することを確認
- [x] frontend `npm run lint` エラー0件、`npx vitest --run` 252件通過
- [x] backend `npm run lint` エラー0件、`npm test` 1543件通過（アプリケーションコードの変更なし）
- [ ] マージ後、README.mdの画像埋め込み（`README.png`）が実際に再レンダリング・公開されることをスマートフォンから確認する
- [ ] マージ後、次回のCD実行（`main`への次リリース時）で`deploy-serverless`経由のデプロイが従来通り成功することを確認する
- [ ] マージ後、連続push時に古いCI実行がキャンセルされる挙動を確認する

Closes #919, Closes #921

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_