### PR TITLE
fix(quiz-room): 参加者側の結果画面に難易度レベルを表示する

### DIFF
--- a/frontend/src/views/QuizRoomView.jsx
+++ b/frontend/src/views/QuizRoomView.jsx
@@ -53,6 +53,20 @@ function renderParticipantContent(roomState) {
           )}
           <div className="text-muted mb-2">所要時間</div>
           <div className="display-4 fw-bold text-dark mb-2">{r.time?.toFixed(2)}<span className="fs-4">秒</span></div>
+          {r.isFast && (
+            <div className="badge bg-warning text-dark fs-6 mb-4 px-3 py-2 rounded-pill shadow-sm">
+              🎉 平均より速い！
+            </div>
+          )}
+          {/* 難易度レベルは管理者側のResultCard（frontend/src/components/ResultCard.jsx）と
+              同じ表示形式に揃える。管理者・参加者双方に同じ結果ブロードキャストが届いている
+              にもかかわらず、参加者側にだけ表示されていなかった（issue #513） */}
+          {typeof r.difficulty === "number" && (
+            <>
+              <div className="text-muted mb-2">難易度レベル</div>
+              <div className="h3 fw-bold text-danger">{r.difficulty.toFixed(2)}</div>
+            </>
+          )}
           <AnswerAndExplanation answer={r.answer} explanation={r.explanation} />
         </div>
       </div>

--- a/frontend/src/views/QuizRoomView.test.jsx
+++ b/frontend/src/views/QuizRoomView.test.jsx
@@ -292,6 +292,33 @@ describe('QuizRoomView', () => {
     expect(document.querySelector('.confetti-container')).toBeInTheDocument();
   });
 
+  it('shows the difficulty level and the "faster than average" badge on the participant result screen, mirroring the admin result screen (issue #513)', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
+
+    emitState({ type: 'phrase', content: { category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '3' } });
+    emitState({ type: 'result', content: { time: 1.2, difficulty: 3.456, isFast: true, answer: '答え1', winner: null } });
+
+    expect(screen.getByText('難易度レベル')).toBeInTheDocument();
+    expect(screen.getByText('3.46')).toBeInTheDocument();
+    expect(screen.getByText('🎉 平均より速い！')).toBeInTheDocument();
+  });
+
+  it('omits the difficulty level and the "faster than average" badge when the broadcast result does not include them', () => {
+    window.history.pushState({}, '', '?roomId=ABC123');
+
+    render(<QuizRoomView setView={vi.fn()} wsBaseUrl={WS_BASE_URL} />);
+    confirmName();
+
+    emitState({ type: 'phrase', content: { category: 'Cat1', kana: 'あ', phrase: '読み札1', level: '3' } });
+    emitState({ type: 'result', content: { time: 1.2, answer: '答え1', winner: null } });
+
+    expect(screen.queryByText('難易度レベル')).not.toBeInTheDocument();
+    expect(screen.queryByText('🎉 平均より速い！')).not.toBeInTheDocument();
+  });
+
   it('treats an unrecognized or empty room state (e.g. right after room creation, before any card is shown) as "waiting" rather than a blank screen', () => {
     window.history.pushState({}, '', '?roomId=ABC123');
 


### PR DESCRIPTION
## Summary
- issue #513対応
- `QuizRoomView.jsx`の`renderParticipantContent`（result分岐）に、管理者側の`ResultCard.jsx`と同じ表示形式で難易度レベルを追加
- あわせて、同じく参加者側に無かった「平均より速い！」バッジ（`r.isFast`）も追加

## 背景

管理者側の結果画面（`ResultCard.jsx`）は難易度レベルを表示しているが、参加者側（`QuizRoomView.jsx`）は同じブロードキャストデータ（`useQuizRoomAdmin.js`で`difficulty`・`isFast`とも既に送信済み）を受け取っているにもかかわらず、単に描画していなかった。

## 設計メモ

`ResultCard.jsx`は`division !== "kids"`でkids区分では非表示にしているが、クイズ大会モードのブロードキャスト状態はdivisionを一切トラックしていないため、この区分制御は移植しなかった（新たにdivisionをブロードキャストへ追加する必要があり、表示漏れの修正というスコープを超えるため）。`difficulty`自体は`useKarutaReading.js`で区分によらず常に数値として算出されており、データの欠落ではなくUI側の意図的な非表示だったことを確認済み。区分による出し分けが必要であれば別issueで検討する。

## Test plan
- [x] `QuizRoomView.test.jsx`に2件追加（難易度レベル・バッジが表示されるケース／値が無い場合に表示されないケース）
- [x] frontend `npm run lint` エラー0件、`npx vitest --run` 254件通過（新規2件含む）
- [x] backend `npm run lint` エラー0件、`npm test` 1543件通過（アプリケーションコードの変更なし）

Closes #513

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_