### PR TITLE
feat(frontend): 札の表示までの待ち時間を設定可能にする

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -149,6 +149,7 @@ function App() {
   const [filterDivision, setFilterDivision] = useState('');
   const [searchQuery, setSearchQuery] = useState(''); // 全札一覧テキスト検索
   const [repeatCount, setRepeatCount] = useLocalStorageState("repeatCount", 2, (v) => parseInt(v, 10));
+  const [cardRevealDelay, setCardRevealDelay] = useLocalStorageState("cardRevealDelay", 3000, (v) => parseInt(v, 10));
   const [speechRate, setSpeechRate] = useLocalStorageState("speechRate", "80%");
   const [lang, setLang] = useLocalStorageState("lang", "ja");
   const [voiceId, setVoiceId] = useLocalStorageState("voiceId", "Mizuki");
@@ -247,6 +248,7 @@ function App() {
     voiceId,
     isMultiCategorySelection,
     quizRoomActiveRef,
+    cardRevealDelay,
   });
 
   // 「取った人を記録する」参加者登録・スコア集計（issue #518）はusePlayerScoresへ
@@ -1014,6 +1016,8 @@ function App() {
           setSpeechRate={setSpeechRate}
           repeatCount={repeatCount}
           setRepeatCount={setRepeatCount}
+          cardRevealDelay={cardRevealDelay}
+          setCardRevealDelay={setCardRevealDelay}
         />
       <div className="d-flex flex-wrap gap-2 justify-content-center mb-4">
         {division === "kids" && (

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1564,7 +1564,7 @@ describe('App', () => {
     randomSpy.mockRestore();
   });
 
-  it('updates settings (lang, sort order, speech rate)', async () => {
+  it('updates settings (lang, sort order, speech rate, card reveal delay)', async () => {
     fetch.mockImplementation(async (url) => {
       if (url.includes('get-categories')) return { ok: true, json: async () => ({ categories: [{ name: 'Cat1', group: 'kids' }] }) };
       return { ok: false };
@@ -1593,6 +1593,14 @@ describe('App', () => {
 
     fireEvent.click(screen.getByText('はやい'));
     expect(localStorage.getItem('speechRate')).toBe('100%');
+
+    // 札の表示までの待ち時間（issue #471）: 既定は3秒、変更するとlocalStorageへ保存される
+    expect(screen.getByText('3秒').closest('button')).toHaveClass('btn-dark');
+    fireEvent.click(screen.getByText('1秒'));
+    expect(localStorage.getItem('cardRevealDelay')).toBe('1000');
+    // 後続テスト（実時間の経過に依存するもの）に既定値以外の待ち時間が
+    // 漏れないようクリーンアップする
+    localStorage.removeItem('cardRevealDelay');
   });
 
   it('shows the voice selector only for Japanese, updates the setting, and includes voiceId in the phrase request (issue #217)', async () => {

--- a/frontend/src/components/SettingsFooter.jsx
+++ b/frontend/src/components/SettingsFooter.jsx
@@ -49,6 +49,15 @@ const REPEAT_COUNT_OPTIONS = [
   { value: 1, label: "1回" },
   { value: 2, label: "2回" },
 ];
+// 札をめくった際、次の札の内容が確定してから表示（フェードアニメーション開始）
+// までの待ち時間（issue #471）。既定の3秒を維持しつつ、短縮・延長できるようにする
+const CARD_REVEAL_DELAY_OPTIONS = [
+  { value: 1000, label: "1秒" },
+  { value: 2000, label: "2秒" },
+  { value: 3000, label: "3秒" },
+  { value: 4000, label: "4秒" },
+  { value: 5000, label: "5秒" },
+];
 
 function SettingsFooter({
   themeSetting,
@@ -63,6 +72,8 @@ function SettingsFooter({
   setSpeechRate,
   repeatCount,
   setRepeatCount,
+  cardRevealDelay,
+  setCardRevealDelay,
 }) {
   return (
     <section className="settings-container mb-4 p-3 mx-auto shadow-sm rounded-4 bg-light border" style={{ maxWidth: "500px" }}>
@@ -84,7 +95,14 @@ function SettingsFooter({
         options={REPEAT_COUNT_OPTIONS}
         value={repeatCount}
         onChange={setRepeatCount}
-        wrapClassName="d-flex align-items-center justify-content-center gap-3"
+        wrapClassName="mb-3 d-flex align-items-center justify-content-center gap-3 border-bottom pb-2"
+      />
+      <SettingsButtonGroup
+        label="札の表示までの待ち時間"
+        options={CARD_REVEAL_DELAY_OPTIONS}
+        value={cardRevealDelay}
+        onChange={setCardRevealDelay}
+        wrapClassName="d-flex align-items-center justify-content-center gap-3 flex-wrap"
       />
     </section>
   );

--- a/frontend/src/hooks/useKarutaReading.js
+++ b/frontend/src/hooks/useKarutaReading.js
@@ -47,6 +47,7 @@ export function useKarutaReading({
   voiceId,
   isMultiCategorySelection,
   quizRoomActiveRef,
+  cardRevealDelay = 3000,
 }) {
   const [currentPhrase, setCurrentPhrase] = useState(null);
   // クイズ大会モード（issue #781）: 参加者への「次の札」ブロードキャストを、管理者自身の
@@ -202,11 +203,12 @@ export function useKarutaReading({
           animationResolveRef.current = resolve;
         });
 
-        // 3秒待機してからフェードアニメーションを開始
+        // cardRevealDelay（既定3秒、設定画面で変更可能。issue #471）待機してから
+        // フェードアニメーションを開始
         flipTimeoutRef.current = setTimeout(() => {
           nextContentRef.current = { type: "phrase", content: phraseData, playbackSettings };
           setIsFadingOut(true);
-        }, 3000); // 待機時間
+        }, cardRevealDelay);
 
         // クイズ大会モード（issue #861）: 参加者側はWebSocketブロードキャストの受信・
         // 画面反映（ネットワーク往復＋バックエンドのpostToConnection処理）に一定の
@@ -254,7 +256,7 @@ export function useKarutaReading({
     return () => {
       if (flipTimeoutRef.current) clearTimeout(flipTimeoutRef.current);
     }
-  }, [audioQueue, isReading, playAudio, playIntroSound, categoryKey, setHistoryByCategory, quizRoomActiveRef]);
+  }, [audioQueue, isReading, playAudio, playIntroSound, categoryKey, setHistoryByCategory, quizRoomActiveRef, cardRevealDelay]);
 
   // 現在の札を読み上げている間に、次に読み上げる予定の札の音声を先読みしておく
   useEffect(() => {


### PR DESCRIPTION
## 概要

Closes #471

札をめくった後、次の札の内容が確定してからフェードアニメーションが始まるまでの待ち時間（従来は3000msの固定値）を、設定画面から1〜5秒の範囲で変更できるようにしました。

## 設計

- `useKarutaReading`に`cardRevealDelay`パラメータを追加し、既定値3000msを維持しつつ外部から可変にした
- `App.jsx`で`useLocalStorageState`を使い`cardRevealDelay`設定を永続化し、`SettingsFooter`へ受け渡した
- `SettingsFooter`に新しい設定行「札の表示までの待ち時間」（1秒〜5秒の5段階）を追加
- クイズルームモード同期用の別の3000ms待機（`useKarutaReading`内の無関係な箇所）は本issueの対象外のため変更していない

## 影響範囲

- `frontend/src/hooks/useKarutaReading.js`
- `frontend/src/App.jsx`
- `frontend/src/components/SettingsFooter.jsx`

## テスト

- [x] `frontend`: `npm run lint`（0エラー）
- [x] `frontend`: `npx vitest --run`（254件全て成功）
- [x] `backend`: `npm run lint && npm test`（1543件全て成功、影響なし）


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_