### PR TITLE
test(backend): phrases.csvのgroup値の妥当性・カテゴリ内一貫性を検証する

### DIFF
--- a/backend/phrases.test.js
+++ b/backend/phrases.test.js
@@ -91,6 +91,30 @@ describe('データ整合性', () => {
     }
     expect(duplicates, '重複している読み札').toHaveLength(0);
   });
+
+  // handler.jsのgetCategoriesは group を "engineer" 以外すべて "kids" 扱いに丸める
+  // （`item.group === "engineer" ? "engineer" : "kids"`）ため、"kids"/"engineer"
+  // 以外の値やタイポはエラーにならず黙って"kids"化されてしまう。ここで明示的に検証する。
+  const ALLOWED_GROUPS = new Set(['kids', 'engineer']);
+  it('groupが"kids"または"engineer"のいずれかであること', () => {
+    for (const r of records) {
+      expect(ALLOWED_GROUPS.has(r.group), `id=${r.id}: group="${r.group}" が許容値でない`).toBe(true);
+    }
+  });
+
+  // handler.jsのgetCategoriesはカテゴリごとに最初に出現した行のgroupのみを採用し、
+  // 同一カテゴリ内でgroupが割れていても検知せず黙って握りつぶす。分類選択画面
+  // （division）が破綻しないよう、カテゴリ内でgroupが一貫していることを保証する。
+  it('同一カテゴリ内でgroupが一貫していること', () => {
+    const byCategory = {};
+    for (const r of records) {
+      byCategory[r.category] ??= new Set();
+      byCategory[r.category].add(r.group);
+    }
+    for (const [category, groups] of Object.entries(byCategory)) {
+      expect([...groups], `カテゴリ"${category}"でgroupが複数存在する`).toHaveLength(1);
+    }
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 概要

Closes #949

`backend/phrases.csv`のデータ品質を検証する自動テスト（`backend/phrases.test.js`）には、既にID重複・必須項目・制御文字・kana整合性・レベルユニーク性等の検証が実装済みでした。issue #949のチェックリストのうち、未カバーだった以下2点を追加しました。

## 設計

- `handler.js`の`getCategories`は`group`値を`item.group === "engineer" ? "engineer" : "kids"`で丸めており、`"kids"`/`"engineer"`以外の値やタイポがあってもエラーにならず黙って`"kids"`扱いになります。この前提を明示的にテストで検証します
- 同じく`getCategories`はカテゴリごとに最初に出現した行の`group`のみを採用するため、同一カテゴリ内で`group`値が割れていても検知されません。division別のカテゴリ選択画面が破綻しないよう、カテゴリ内で`group`が一貫していることを保証するテストを追加しました
- 「決まり字（読み上げプレフィックス）の衝突」チェックは、調査の結果、既存827件中1件のみ該当（国旗王カテゴリの意図的な類似設問ペア「排他的経済水域」/「排他的経済水域が最小」）で、実際の読み上げ・判定ロジック上の問題かどうか確証が持てなかったため、誤検知の多いテストを追加するリスクを避けて対象外としました

## 影響範囲

- `backend/phrases.test.js`（テスト2件追加、既存827件のデータは全て通過）

## テスト

- [x] `backend`: `npm run lint`（0エラー）
- [x] `backend`: `npm test`（1545件全て成功、既存1543件+新規2件）
- [x] `frontend`: `npm run lint`（0エラー、変更なし影響確認のみ）


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_