### PR TITLE
fix(skills): dev-standards新規Skill（planning-and-task-breakdown）のsymlinkを追加

### DIFF
--- a/.claude/skills/planning-and-task-breakdown
+++ b/.claude/skills/planning-and-task-breakdown
@@ -1,0 +1,1 @@
+../../dev-standards/.claude/skills/planning-and-task-breakdown


### PR DESCRIPTION
## 概要

Closes #992

PR #988（Renovateによるdev-standards submodule参照更新）のCIで`ci / standards-check`が失敗していました。原因はdev-standards側の新規Skill（`planning-and-task-breakdown`、PR #208）のsymlinkがkaruta側に未反映だったためです。

## 設計

- `node dev-standards/scripts/bootstrap.js`を実行し、`.claude/skills/planning-and-task-breakdown`のsymlinkを生成・コミット
- karutaのdev-standards submodule参照コミット自体は本PRでは更新しない（Renovateの更新PR #988が別途担当するため、本PRのスコープをsymlink追加のみに限定）

## 影響範囲

- `.claude/skills/planning-and-task-breakdown`（新規symlink）

## テスト

- [x] `node dev-standards/scripts/bootstrap.js --check`（PR #988が対象とするdev-standardsコミットへ一時的に切り替えて）成功を確認
- [x] `frontend`: `npm run lint`（0エラー）
- [x] `backend`: `npm run lint && npm test`（0エラー、1545件成功）

本PRがマージされmainに反映されれば、PR #988の次回CI実行（Renovateのrebaseにより新しい`pull_request`イベントが発生した際）で`ci / standards-check`が成功する見込みです。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_