### PR TITLE
feat(ci): push時CIの軽量化（skip_verification_on_push）を有効化する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,5 +75,15 @@ jobs:
       # いなかったためコードのままでしか見えず画像化されていなかった。対象に追加する
       enable_mermaid_render: true
       mermaid_doc_paths: "docs/cicd-pipeline-specification.md\nREADME.md\ndocs/generated/websocket-api.md\ndocs/generated/dynamodb-tables.md\ndocs/generated/serverless-architecture.md\ndocs/generated/cicd-architecture.md"
+      # push時CI軽量化（issue #973、dev-standards#187バックログ③）。PRの
+      # 「base_branchと同期済みでなければマージ不可」（up-to-date required）
+      # ＋Squash merge運用のもとでは、squash merge直後のpush-to-main上のツリーは
+      # 直前のpull_requestイベントで検証済みのPR head内容と完全に一致するため、
+      # push時のfrontend-test/backend-test/package-test/standards-check/
+      # duplication-checkの再実行は構造的に冗長。frontend-e2e-test（E2E
+      # スクリーンショットのlatest/ベースライン公開）・render-mermaid-diagrams
+      # （mermaid画像のlatest/公開）はpush時のみの副作用があるため対象外のまま
+      # スキップされない（reusable-ci.yml側の実装）
+      skip_verification_on_push: true
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
## 概要

Closes #973

`ci.yml`の`ci`ジョブに`skip_verification_on_push: true`を追加しました。

## 設計

`reusable-ci.yml`の`skip_verification_on_push`入力（v1.22.0で追加、bamiyanapp/dev-standards#187バックログ③）は、PRの「`base_branch`と同期済みでなければマージ不可」（up-to-date required）＋Squash merge運用のもとでは、push-to-main上のツリーが直前の`pull_request`イベントで検証済みのPR head内容と完全に一致するため、push時の`frontend-test`等の再実行が構造的に冗長であることを利用した最適化です。karutaは既に`reusable-ci.yml@v2.1.0`を参照していますが、この入力はデフォルト`false`（オプトイン）のため未設定のままでした。

## 影響範囲

- `.github/workflows/ci.yml`

push（squash merge後のmain検証）時に`frontend-test`・`backend-test`・`package-test`・`standards-check`・`duplication-check`がスキップされるようになります。`frontend-e2e-test`（E2Eスクリーンショットの`latest/`ベースライン公開）・`render-mermaid-diagrams`（mermaid画像の`latest/`公開）はpush時のみの副作用があるため、`reusable-ci.yml`側の実装により対象外のまま実行され続けます。

## テスト

- [x] `python3`の`yaml.safe_load`による`ci.yml`の構文検証成功
- [x] `frontend`: `npm run lint`（0エラー）
- [x] `backend`: `npm run lint && npm test`（0エラー、1545件成功）

## ⚠️ レビュー時にご確認いただきたい前提条件

この最適化は、以下2点が成立している場合のみ安全です（`reusable-ci.yml`のコメント参照）。

- branch protectionで「`base_branch`と同期済みでなければマージ不可」（up-to-date required）が有効
- Squash merge運用（マージ後のmainツリーがPRのheadと完全一致する）

このセッションのツールからはbranch protection設定を直接確認できなかったため、マージ前にGitHubのSettings > Branches（スマートフォンのブラウザ操作で完結します）でご確認をお願いします。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_