### PR TITLE
feat(settings): 読み上げスピード「ゆっくり」をふつうとの中間速度へ引き上げる

### DIFF
--- a/frontend/src/components/SettingsFooter.jsx
+++ b/frontend/src/components/SettingsFooter.jsx
@@ -41,7 +41,9 @@ const SORT_ORDER_OPTIONS = [
   { value: "hard", label: "難しい" },
 ];
 const SPEECH_RATE_OPTIONS = [
-  { value: "70%", label: "ゆっくり" },
+  // issue #1001: 「ゆっくり」が遅すぎるとの声を受け、「ふつう」（80%）との
+  // 中間の速度（75%）へ引き上げた
+  { value: "75%", label: "ゆっくり" },
   { value: "80%", label: "ふつう" },
   { value: "100%", label: "はやい" },
 ];


### PR DESCRIPTION
Closes #1001

## 概要

読み上げスピード設定「ゆっくり」が遅すぎるとの声を受け、「ふつう」（80%）との中間速度（75%）へ引き上げます。

## 変更内容

`frontend/src/components/SettingsFooter.jsx`の`SPEECH_RATE_OPTIONS`で、「ゆっくり」に対応する`speechRate`を`70%`から`75%`へ変更しました。「ふつう」「はやい」は変更していません。

## Test plan

- `frontend`: `npm run lint`・`npx vitest run`（フルスイート、254件）を実行し、いずれも0件のエラーで通過することを確認済みです
- `backend`: `npm run lint`・`npm test`（1545件）を実行し、影響なし・0件のエラーで通過することを確認済みです
- 定数値の変更のみのため新規テストは追加していません。既存テストは`SPEECH_RATE_OPTIONS`の値に依存していないことを確認済みです

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_