### PR TITLE
chore(release): v1.68.1 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.68.1](https://github.com/bamiyanapp/karuta/compare/v1.68.0...v1.68.1) (2026-08-16)
+
+
+### Bug Fixes
+
+* **quiz-room:** 管理者の本編読み上げが太鼓の音だけで無音になる不具合を修正 ([#999](https://github.com/bamiyanapp/karuta/issues/999)) ([785798c](https://github.com/bamiyanapp/karuta/commit/785798cf5ec2b983847c1b44711c3e067419ed50))
+
 # [1.68.0](https://github.com/bamiyanapp/karuta/compare/v1.67.0...v1.68.0) (2026-08-16)
 
 

--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,7 +1,12 @@
 [
   {
-    "version": "1.68.0",
+    "version": "1.68.1",
     "date": "2026/08/16",
+    "body": "### Bug Fixes\n\n* **quiz-room:** 管理者の本編読み上げが太鼓の音だけで無音になる不具合を修正 ([#999](https://github.com/bamiyanapp/karuta/issues/999)) ([785798c](https://github.com/bamiyanapp/karuta/commit/785798cf5ec2b983847c1b44711c3e067419ed50))"
+  },
+  {
+    "version": "1.68.0",
+    "date": "2026/08/16 06:02",
     "body": "### Features\n\n* **theme:** 共有Bootstrapテーマ（bootstrap-theme.css）へ切り替える ([#1006](https://github.com/bamiyanapp/karuta/issues/1006)) ([9060e66](https://github.com/bamiyanapp/karuta/commit/9060e66d379bbb81316be0debc70a1f653507c07)), closes [bamiyanapp/dev-standards#232](https://github.com/bamiyanapp/dev-standards/issues/232)"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karuta-root",
-  "version": "1.68.0",
+  "version": "1.68.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karuta-root",
-      "version": "1.68.0",
+      "version": "1.68.1",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "js-yaml": "^5.0.0",
     "semantic-release": "^25.0.2"
   },
-  "version": "1.68.0"
+  "version": "1.68.1"
 }


### PR DESCRIPTION
semantic-releaseによる自動バージョン更新PRです。