### PR TITLE
fix(pwa): プレイ中はPWA更新プロンプトを保留し、ゲーム中断を防ぐ

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import { useLocalStorageState } from "./hooks/useLocalStorageState";
 import { useSessionStorageState } from "./hooks/useSessionStorageState";
 import { useUrlQuerySync, parseCategoriesParam } from "./hooks/useUrlQuerySync";
 import { useWakeLock } from "./hooks/useWakeLock";
+import { setGameplayActive } from "./gameplayActivity";
 import { useKarutaReading } from "./hooks/useKarutaReading";
 import { usePlayerScores } from "./hooks/usePlayerScores";
 import { useQuizRoomAdmin } from "./hooks/useQuizRoomAdmin";
@@ -550,6 +551,16 @@ function App() {
   });
 
   useWakeLock(view === "game" && selectedCategories.length > 0);
+
+  // PWA更新プロンプト（issue #1000）: プレイ中に「更新する」が押されると、選択中の
+  // カテゴリ・読み上げ中の進行状態（sessionStorageに永続化されないもの）を失った
+  // まま即座にページが再読み込みされ、ゲームが中断されてしまう。useWakeLockと同じ
+  // 「実際に読み上げ画面で遊んでいる最中」の条件をPwaUpdatePromptへ伝え、その間は
+  // 更新プロンプトを保留する
+  useEffect(() => {
+    setGameplayActive(view === "game" && selectedCategories.length > 0);
+    return () => setGameplayActive(false);
+  }, [view, selectedCategories]);
 
   // クイズ大会モード（issue #470）の管理者側ロジック（ルーム作成・一覧取得・
   // WebSocket接続・早押し判定・状態ブロードキャスト）はuseQuizRoomAdminへ切り出した

--- a/frontend/src/PwaUpdatePrompt.jsx
+++ b/frontend/src/PwaUpdatePrompt.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useRegisterSW } from "virtual:pwa-register/react";
 import { useIsPrintScreenActive } from "./pdfExportStatus";
+import { useGameplayActive } from "./gameplayActivity";
 import "./PwaUpdatePrompt.css";
 
 // オフライン利用可能通知は操作を要求しない情報表示のため、この時間が経てば自動的に消す。
@@ -32,6 +33,11 @@ function PwaUpdatePrompt() {
   // 動作しないため、この画面を開いている間に「オフラインで利用可能になりました」を
   // 出すと誤解を招く（issue #473）
   const isPrintScreenActive = useIsPrintScreenActive();
+  // issue #1000: プレイ中に「更新する」を押すと、選択中のカテゴリ・読み上げ中の
+  // 進行状態を失ったまま即座にページが再読み込みされ、ゲームが中断されてしまう。
+  // プレイ中は更新ボタン自体を出さず、プレイを終えて安全なタイミングになってから
+  // 更新できるようにする
+  const isGameplayActive = useGameplayActive();
 
   const close = () => {
     setOfflineReady(false);
@@ -45,6 +51,21 @@ function PwaUpdatePrompt() {
     const timer = setTimeout(() => setOfflineReady(false), OFFLINE_READY_AUTO_DISMISS_MS);
     return () => clearTimeout(timer);
   }, [offlineReady, setOfflineReady]);
+
+  if (needRefresh && isGameplayActive) {
+    return (
+      <div className="pwa-update-prompt" role="status">
+        <span>新しいバージョンがあります（プレイ終了後に更新できます）</span>
+        <button
+          type="button"
+          className="pwa-update-prompt-button close-button"
+          onClick={close}
+        >
+          閉じる
+        </button>
+      </div>
+    );
+  }
 
   if (needRefresh) {
     return (

--- a/frontend/src/PwaUpdatePrompt.test.jsx
+++ b/frontend/src/PwaUpdatePrompt.test.jsx
@@ -9,6 +9,7 @@ vi.mock("virtual:pwa-register/react", () => ({
 
 import PwaUpdatePrompt from "./PwaUpdatePrompt.jsx";
 import { setPrintScreenActive } from "./pdfExportStatus";
+import { setGameplayActive } from "./gameplayActivity";
 
 describe("PwaUpdatePrompt", () => {
   beforeEach(() => {
@@ -17,8 +18,10 @@ describe("PwaUpdatePrompt", () => {
 
   afterEach(() => {
     vi.useRealTimers();
-    // pdfExportStatusはモジュール単位で状態を共有するため、他テストへ漏れないよう戻す
+    // pdfExportStatus・gameplayActivityはモジュール単位で状態を共有するため、
+    // 他テストへ漏れないよう戻す
     setPrintScreenActive(false);
+    setGameplayActive(false);
   });
 
   it("更新が不要な場合は何も表示しない", () => {
@@ -70,6 +73,37 @@ describe("PwaUpdatePrompt", () => {
     fireEvent.click(screen.getByRole("button", { name: "閉じる" }));
 
     expect(setNeedRefresh).toHaveBeenCalledWith(false);
+  });
+
+  it("プレイ中は更新ボタンを表示せず、プレイ終了後まで更新を保留する（issue #1000）", () => {
+    setGameplayActive(true);
+    const updateServiceWorker = vi.fn();
+    useRegisterSWMock.mockReturnValue({
+      needRefresh: [true, vi.fn()],
+      offlineReady: [false, vi.fn()],
+      updateServiceWorker,
+    });
+
+    render(<PwaUpdatePrompt />);
+
+    expect(screen.getByText("新しいバージョンがあります（プレイ終了後に更新できます）")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "更新する" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "閉じる" })).toBeInTheDocument();
+    expect(updateServiceWorker).not.toHaveBeenCalled();
+  });
+
+  it("プレイ中でなければ通常どおり更新ボタンが表示される（issue #1000）", () => {
+    setGameplayActive(false);
+    useRegisterSWMock.mockReturnValue({
+      needRefresh: [true, vi.fn()],
+      offlineReady: [false, vi.fn()],
+      updateServiceWorker: vi.fn(),
+    });
+
+    render(<PwaUpdatePrompt />);
+
+    expect(screen.getByText("新しいバージョンがあります")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "更新する" })).toBeInTheDocument();
   });
 
   it("オフライン利用可能な場合はメッセージを表示し、「閉じる」をクリックで消える", () => {

--- a/frontend/src/gameplayActivity.js
+++ b/frontend/src/gameplayActivity.js
@@ -1,0 +1,26 @@
+import { useSyncExternalStore } from "react";
+
+// PwaUpdatePrompt（main.jsxでAppの兄弟としてグローバルにマウントされておりpropsで
+// 直接つなげない）に、「かるたを遊んでいる最中かどうか」を伝えるための最小限のstore
+// （issue #1000、pdfExportStatus.jsと同じパターン）。プレイ中にPWAの更新プロンプトで
+// 「更新する」を押すと即座にページが再読み込みされ、選択中のカテゴリ・読み上げ中の
+// 進行状態（audioQueue・isReading等、sessionStorageに永続化されないもの）が失われ、
+// ゲームが中断されてしまっていた。プレイ中は「更新する」ボタン自体を出さず、
+// プレイを終えて安全なタイミングになってから更新できるようにする
+let isGameplayActive = false;
+const listeners = new Set();
+
+export function setGameplayActive(value) {
+  isGameplayActive = value;
+  listeners.forEach((listener) => listener());
+}
+
+export function useGameplayActive() {
+  return useSyncExternalStore(
+    (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    () => isGameplayActive
+  );
+}


### PR DESCRIPTION
Closes #1000

## 概要

かるたを遊んでいる最中にPWA更新プロンプトで「更新する」を押すと、選択中のカテゴリ・読み上げ中の進行状態（`sessionStorage`に永続化されないもの）を失ったまま即座にページが再読み込みされ、ゲームが中断されてしまう問題を修正します。

## 変更内容

- `frontend/src/gameplayActivity.js`（新規）: 既存の`pdfExportStatus.js`と同じ`useSyncExternalStore`ベースの最小限store。`PwaUpdatePrompt`は`main.jsx`で`App`の兄弟としてグローバルにマウントされておりpropsで直接つなげないため、この方式で「プレイ中かどうか」を伝える
- `App.jsx`: `useWakeLock`と同じ条件（`view === "game" && selectedCategories.length > 0`）で`setGameplayActive`を呼ぶ`useEffect`を追加
- `PwaUpdatePrompt.jsx`: プレイ中は「更新する」ボタンを出さず、「新しいバージョンがあります（プレイ終了後に更新できます）」というメッセージ＋「閉じる」ボタンのみを表示するようにした。プレイ中でなければ従来どおり

## Test plan

- `frontend`: `npm run lint`・`npx vitest run`（フルスイート、260件）・`npm run build`を実行し、いずれも0件のエラーで通過することを確認済みです
- `PwaUpdatePrompt.test.jsx`に、プレイ中は更新ボタンが表示されず`updateServiceWorker`が呼ばれないこと・プレイ中でなければ従来どおり表示されることを確認する回帰テストを追加しました
- `backend`: `npm run lint`・`npm test`（1545件）を実行し、影響なし・0件のエラーで通過することを確認済みです
- 実機PWAでの目視確認は本セッションの環境制約上できていません。マージ後、実際にプレイ中に更新が検知された際の表示をスマートフォンのブラウザから確認いただけると確実です

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub4mHTcNX1tEvrR1fXXgdX)_